### PR TITLE
Update kits implementation.

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/commands/kit/KitListCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/commands/kit/KitListCommand.java
@@ -55,7 +55,7 @@ public class KitListCommand extends CommandBase<CommandSource> {
         }
 
         PaginationList.Builder paginationBuilder =
-                paginationService.builder().contents(kitText).title(Text.of(TextColors.GREEN, "Showing Kits")).padding(Text.of(TextColors.GREEN, "-"));
+                paginationService.builder().contents(kitText).title(Util.getTextMessageWithFormat("command.kit.list.kits")).padding(Text.of(TextColors.GREEN, "-"));
         paginationBuilder.sendTo(src);
 
         return CommandResult.success();

--- a/src/main/java/io/github/nucleuspowered/nucleus/commands/kit/KitSetCooldownCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/commands/kit/KitSetCooldownCommand.java
@@ -20,6 +20,7 @@ import org.spongepowered.api.command.spec.CommandSpec;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.text.Text;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -47,10 +48,10 @@ public class KitSetCooldownCommand extends CommandBase<Player> {
     @Override
     public CommandResult executeCommand(final Player player, CommandContext args) throws Exception {
         String kitName = args.<String>getOne(kit).get();
-        long interval = TimeUnit.MILLISECONDS.convert(args.<Long>getOne(duration).get(), TimeUnit.SECONDS);
-        kitConfig.setInterval(kitName, interval);
+        long seconds = args.<Long>getOne(duration).get();
+        kitConfig.setInterval(kitName, Duration.ofSeconds(seconds));
         kitConfig.save();
-        player.sendMessage(Util.getTextMessageWithFormat("command.kit.setcooldown.success", kitName));
+        player.sendMessage(Util.getTextMessageWithFormat("command.kit.setcooldown.success", kitName, Util.getTimeStringFromSeconds(seconds)));
         return CommandResult.success();
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/config/KitsConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/config/KitsConfig.java
@@ -8,7 +8,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.reflect.TypeToken;
 import com.google.inject.Inject;
-import io.github.nucleuspowered.nucleus.internal.Kit;
+import io.github.nucleuspowered.nucleus.config.serialisers.Kit;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import ninja.leaping.configurate.commented.SimpleCommentedConfigurationNode;
 import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
@@ -20,9 +20,9 @@ import org.spongepowered.api.item.inventory.ItemStack;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 public class KitsConfig extends AbstractConfig<CommentedConfigurationNode, HoconConfigurationLoader> {
@@ -93,20 +93,16 @@ public class KitsConfig extends AbstractConfig<CommentedConfigurationNode, Hocon
 
     public void saveInventoryAsKit(Player player, String kitName) {
         List<Inventory> slots = Lists.newArrayList(player.getInventory().slots());
-        List<ItemStack> stacks = Lists.newArrayList();
+        final List<ItemStack> stacks = Lists.newArrayList();
 
-        for (int i = 0; i < slots.size(); i++) {
-            Optional<ItemStack> stack = slots.get(i).peek();
-            if (stack.isPresent()) {
-                stacks.add(stack.get());
-            }
-        }
+        // Add all the stacks into the kit list.
+        slots.forEach(s -> s.peek().ifPresent(stacks::add));
 
         Kit kitInventory = new Kit(stacks);
         kitNodes.put(kitName, kitInventory);
     }
 
-    public void setInterval(String kitName, long interval) {
+    public void setInterval(String kitName, Duration interval) {
         this.kitNodes.get(kitName).setInterval(interval);
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/config/serialisers/Kit.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/config/serialisers/Kit.java
@@ -2,13 +2,14 @@
  * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
  * at the root of this project for more details.
  */
-package io.github.nucleuspowered.nucleus.internal;
+package io.github.nucleuspowered.nucleus.config.serialisers;
 
 import com.google.common.collect.Lists;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 import org.spongepowered.api.item.inventory.ItemStack;
 
+import java.time.Duration;
 import java.util.List;
 
 @ConfigSerializable
@@ -16,6 +17,9 @@ public class Kit {
 
     @Setting private List<ItemStack> stacks;
 
+    /**
+     * This is in seconds to be consistent with the rest of the plugin.
+     */
     @Setting private long interval;
 
     public Kit() {
@@ -42,12 +46,12 @@ public class Kit {
         return this;
     }
 
-    public long getInterval() {
-        return interval;
+    public Duration getInterval() {
+        return Duration.ofSeconds(interval);
     }
 
-    public Kit setInterval(long interval) {
-        this.interval = interval;
+    public Kit setInterval(Duration interval) {
+        this.interval = interval.getSeconds();
         return this;
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/config/serialisers/UserConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/config/serialisers/UserConfig.java
@@ -56,6 +56,9 @@ public class UserConfig {
     @Setting
     private String nickname;
 
+    /**
+     * In seconds
+     */
     @Setting
     private Map<String, Long> kitLastUsedTime = Maps.newHashMap();
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/interfaces/InternalNucleusUser.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/interfaces/InternalNucleusUser.java
@@ -59,11 +59,9 @@ public interface InternalNucleusUser extends NucleusUser {
 
     void setJailOnNextLogin(boolean set);
 
-    Map<String, Long> getKitLastUsedTime();
+    Map<String, Instant> getKitLastUsedTime();
 
-    void setKitLastUsedTime(Map<String, Long> kitLastUsedTime);
-
-    void addKitLastUsedTime(String kitName, long currentTimeMillis);
+    void addKitLastUsedTime(String kitName, Instant lastTime);
 
     void removeKitLastUsedTime(String kitName);
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/services/datastore/UserService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/services/datastore/UserService.java
@@ -415,19 +415,16 @@ public class UserService implements InternalNucleusUser {
     }
 
     @Override
-    public Map<String, Long> getKitLastUsedTime() {
-        return config.getKitLastUsedTime();
+    public Map<String, Instant> getKitLastUsedTime() {
+        final Map<String, Instant> r = Maps.newHashMap();
+        config.getKitLastUsedTime().forEach((k, v) -> r.put(k, Instant.ofEpochSecond(v)));
+        return r;
     }
 
     @Override
-    public void setKitLastUsedTime(Map<String, Long> kitLastUsedTime) {
-        config.setKitLastUsedTime(kitLastUsedTime);
-    }
-
-    @Override
-    public void addKitLastUsedTime(String kitName, long currentTimeMillis) {
+    public void addKitLastUsedTime(String kitName, Instant lastTime) {
         Map<String, Long> kitLastUsedTime = config.getKitLastUsedTime();
-        kitLastUsedTime.put(kitName, currentTimeMillis);
+        kitLastUsedTime.put(kitName, lastTime.getEpochSecond());
         config.setKitLastUsedTime(kitLastUsedTime);
     }
 

--- a/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
+++ b/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
@@ -182,14 +182,17 @@ command.world.setgamemode.success=Set world gamemode.
 command.world.setspawn.success=Set world spawn.
 command.world.spawn.success=Teleported to world spawn.
 
-command.kit.spawned=&aKit {0} spawned.
+command.kit.spawned=&aThe kit {0} was added to your inventory.
+command.kit.fail=&cThe kit {0} could not be added to your inventory.
 command.kit.cooldown=&cYou must wait {0} before using this Kit again.
 command.kit.add.success=&aKit {0} successfully created.
 command.kit.add.alreadyexists=&cKit {0} already exists!
 command.kit.remove.success=&aKit {0} successfully deleted.
 command.kit.set.success=&aKit {0} successfully updated.
-command.kit.setcooldown.success=&aKit {0} cooldown set.
+command.kit.setcooldown.success=&aKit {0} cooldown set to {1}.
 command.kit.list.text=&fSpawn kit &6{0}.
+command.kit.fullinventory=&cYour inventory is full, some items were lost.
+command.kit.list.kits=&aKits
 
 command.socialspy.on=You can now see others'' private messages.
 command.socialspy.off=You can no longer see others'' private messages.
@@ -485,3 +488,6 @@ permission.chat.colour=Allows user to type colours in chat.
 permission.chat.style=Allows user to use styles in chat.
 permission.chat.magic=Allows user to use magic characters in chat.
 permission.chat.urls=Allows user to type clickable URLs in chat.
+
+permission.kit.exempt=Allows the user to bypass kit cooldowns.
+permission.kits=Allows the user to use all kits.


### PR DESCRIPTION
This updates the Kits implementation - mostly code cleanup.

The changes are:

* Times are represented by seconds, not milliseconds
* Updated use of longs to use Instants and Durations - to make it clearer what the values are in the code
* Moved some messages to templates
* Tell the user if some items are lost because there isn't enough space.
* Remove duplicate code - duration time stamp method was already present in the Util class.
* Add permission `nucleus.kit.exempt.cooldown` to bypass cooldowns.