### PR TITLE
Add /clearinventory

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/commands/admin/ClearInventoryCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/commands/admin/ClearInventoryCommand.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.commands.admin;
+
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.api.PluginModule;
+import io.github.nucleuspowered.nucleus.internal.CommandBase;
+import io.github.nucleuspowered.nucleus.internal.annotations.Modules;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoCooldown;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoCost;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoWarmup;
+import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
+import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.text.Text;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@RegisterCommand({"clear", "clearinv", "clearinventory"})
+@Modules(PluginModule.ADMIN)
+@NoCooldown
+@NoWarmup
+@NoCost
+public class ClearInventoryCommand extends CommandBase<CommandSource> {
+
+    private final String player = "player";
+
+    @Override
+    public Map<String, PermissionInformation> permissionSuffixesToRegister() {
+        Map<String, PermissionInformation> m = new HashMap<>();
+        m.put("others", new PermissionInformation(Util.getMessageWithFormat("permission.others", this.getAliases()[0]), SuggestedLevel.ADMIN));
+        return m;
+    }
+
+    @Override
+    public CommandSpec createSpec() {
+        return CommandSpec.builder().executor(this).arguments(GenericArguments.optional(GenericArguments.requiringPermission(
+                GenericArguments.onlyOne(GenericArguments.player(Text.of(player))), permissions.getPermissionWithSuffix("others")))).build();
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        Optional<Player> opl = this.getUser(Player.class, src, player, args);
+        if (!opl.isPresent()) {
+            return CommandResult.empty();
+        }
+
+        opl.get().getInventory().clear();
+        src.sendMessage(Util.getTextMessageWithFormat("command.clearinventory.success", opl.get().getName()));
+        return CommandResult.success();
+    }
+}

--- a/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
+++ b/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
@@ -378,6 +378,8 @@ command.exp.set.error=Could not set experience level.
 command.exp.set.new.other={0} now has {1} experience points (level {2}).
 command.exp.set.new=You now have {0} experience points (level {1}).
 
+command.clearinventory.success=&aCleared inventory of player {0}.
+
 command.printperms=The suggested permissions have been written to {0}
 
 command.lockweather.locked=The weather has been locked in the world {0}.


### PR DESCRIPTION
Related: Issue #37

Use cases:
* Player needs to clear inventory (overrides `/clear`)

Changes:
* [x] - Added `/clearinventory` command in `admin` module.
* [x] - Add messages in `messages.properties`