### PR TITLE
Add /repair

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/commands/item/GiveCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/commands/item/GiveCommand.java
@@ -2,7 +2,7 @@
  * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
  * at the root of this project for more details.
  */
-package io.github.nucleuspowered.nucleus.commands.items;
+package io.github.nucleuspowered.nucleus.commands.item;
 
 import io.github.nucleuspowered.nucleus.api.PluginModule;
 import io.github.nucleuspowered.nucleus.internal.CommandBase;

--- a/src/main/java/io/github/nucleuspowered/nucleus/commands/item/RepairCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/commands/item/RepairCommand.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.commands.item;
+
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.api.PluginModule;
+import io.github.nucleuspowered.nucleus.internal.CommandBase;
+import io.github.nucleuspowered.nucleus.internal.annotations.Modules;
+import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
+import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.data.manipulator.mutable.item.DurabilityData;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.text.Text;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@RegisterCommand({"repair", "mend"})
+@Modules(PluginModule.ITEMS)
+public class RepairCommand extends CommandBase<CommandSource> {
+
+    private final String player = "player";
+
+    @Override
+    public Map<String, PermissionInformation> permissionSuffixesToRegister() {
+        Map<String, PermissionInformation> m = new HashMap<>();
+        m.put("others", new PermissionInformation(Util.getMessageWithFormat("permission.others", this.getAliases()[0]), SuggestedLevel.ADMIN));
+        return m;
+    }
+
+    @Override
+    public CommandSpec createSpec() {
+        return CommandSpec.builder().executor(this).arguments(GenericArguments.optional(GenericArguments.requiringPermission(
+                GenericArguments.onlyOne(GenericArguments.player(Text.of(player))), permissions.getPermissionWithSuffix("others")))).build();
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        Optional<Player> opl = this.getUser(Player.class, src, player, args);
+        if (!opl.isPresent()) {
+            return CommandResult.empty();
+        }
+
+        if (opl.get().getItemInHand().isPresent()) {
+            ItemStack stack = opl.get().getItemInHand().get();
+
+            if (stack.get(DurabilityData.class).isPresent()) {
+                DurabilityData durabilityData = stack.get(DurabilityData.class).get();
+                DataTransactionResult transactionResult = stack.offer(Keys.ITEM_DURABILITY, durabilityData.durability().getMaxValue());
+                if (transactionResult.isSuccessful()) {
+                	opl.get().setItemInHand(stack);
+                    src.sendMessage(Util.getTextMessageWithFormat("command.repair.success", opl.get().getName()));
+                    return CommandResult.success();
+                } else {
+                    src.sendMessage(Util.getTextMessageWithFormat("command.repair.error"));
+                    return CommandResult.empty();
+                }
+            } else {
+                src.sendMessage(Util.getTextMessageWithFormat("command.repair.error.notreparable"));
+                return CommandResult.empty();
+            }
+        } else {
+            src.sendMessage(Util.getTextMessageWithFormat("command.repair.error.handempty"));
+            return CommandResult.empty();
+        }
+    }
+}

--- a/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
+++ b/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
@@ -235,6 +235,10 @@ command.fly.on=&aYou are now able to fly.
 command.fly.off=&aYou are no longer able to fly.
 command.fly.error=&cCould not set fly status.
 
+command.repair.success=&aRepaired the item in {0}''s hand.
+command.repair.error.notreparable=&cThe item in your hand is not reparable.
+command.repair.error.handempty=&cYou must be holding an item to use this command.
+
 command.mail.send=&aYour mail was sent to &e{0}.
 command.mail.send.error=&e{0} &cis unable to receive mail. Your mail was not sent.
 command.mail.none=&aYou have no mail.


### PR DESCRIPTION
Related: Issue #32 

Use cases:
* Player needs to repair the item in their hand.

Changes:
* [x] - Added the command `/repair`
* [x] - Added the messages in the `messages.properties` file.

Comments:
* `SpongeDurabilityData` doesn't seem to be working...
