### PR TITLE
Add /ignore command and listeners.

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/api/PluginModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/PluginModule.java
@@ -28,7 +28,8 @@ public enum PluginModule {
     NICKNAME("nickname"),
     WORLDS("worlds"),
     KITS("kits"),
-    POWERTOOL("powertool");
+    POWERTOOL("powertool"),
+    IGNORE("ignore");
 
     String key;
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/api/data/NucleusUser.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/data/NucleusUser.java
@@ -223,4 +223,27 @@ public interface NucleusUser {
      * @param set Sets whether powertools are enabled for this user.
      */
     void setPowertoolToggle(boolean set);
+
+    /**
+     * Gets the UUID of the users that should be ignored.
+     *
+     * @return The {@link List} of {@link UUID}s that represent the users that are ignored.
+     */
+    List<UUID> getIgnoreList();
+
+    /**
+     * Adds a user to the ignore list.
+     *
+     * @param uuid The {@link UUID} of the user to ignore.
+     * @return <code>true</code> if successful.
+     */
+    boolean addToIgnoreList(UUID uuid);
+
+    /**
+     * Remove a user from the ignore list.
+     *
+     * @param uuid The {@link UUID} of the user to stop ignoring.
+     * @return <code>true</code> if successful.
+     */
+    boolean removeFromIgnoreList(UUID uuid);
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/commands/ignore/IgnoreCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/commands/ignore/IgnoreCommand.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.commands.ignore;
+
+import com.google.common.collect.Maps;
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.api.PluginModule;
+import io.github.nucleuspowered.nucleus.internal.CommandBase;
+import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.interfaces.InternalNucleusUser;
+import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
+import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import io.github.nucleuspowered.nucleus.internal.services.datastore.UserConfigLoader;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.text.Text;
+
+import java.util.Map;
+
+@Modules(PluginModule.IGNORE)
+@RunAsync
+@NoCooldown
+@NoCost
+@NoWarmup
+@RegisterCommand("ignore")
+@Permissions(suggestedLevel = SuggestedLevel.USER)
+public class IgnoreCommand extends CommandBase<Player> {
+
+    @Inject private UserConfigLoader loader;
+
+    private final String userKey = "user";
+    private final String toggleKey = "toggle";
+
+    @Override
+    protected Map<String, PermissionInformation> permissionSuffixesToRegister() {
+        Map<String, PermissionInformation> m = Maps.newHashMap();
+        m.put("exempt.chat", new PermissionInformation(Util.getMessageWithFormat("permission.ignore.chat"), SuggestedLevel.MOD));
+        return m;
+    }
+
+    @Override
+    public CommandSpec createSpec() {
+        return CommandSpec.builder().arguments(
+                GenericArguments.onlyOne(GenericArguments.user(Text.of(userKey))),
+                GenericArguments.optional(GenericArguments.onlyOne(GenericArguments.bool(Text.of(toggleKey))))
+        ).executor(this).build();
+    }
+
+    @Override
+    public CommandResult executeCommand(Player src, CommandContext args) throws Exception {
+        // Get the target
+        User target = args.<User>getOne(userKey).get();
+
+        if (target.equals(src)) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.ignore.self"));
+            return CommandResult.empty();
+        }
+
+        InternalNucleusUser inu = loader.getUser(src);
+
+        if (permissions.testSuffix(target, "exempt.chat")) {
+            // Make sure they are removed.
+            inu.removeFromIgnoreList(target.getUniqueId());
+            src.sendMessage(Util.getTextMessageWithFormat("command.ignore.exempt"));
+            return CommandResult.empty();
+        }
+
+        // Ok, we can ignore or unignore them.
+        boolean ignore = args.<Boolean>getOne(toggleKey).orElse(!inu.getIgnoreList().contains(target.getUniqueId()));
+
+        if (ignore) {
+            inu.addToIgnoreList(target.getUniqueId());
+            src.sendMessage(Util.getTextMessageWithFormat("command.ignore.added", target.getName()));
+        } else {
+            inu.removeFromIgnoreList(target.getUniqueId());
+            src.sendMessage(Util.getTextMessageWithFormat("command.ignore.remove", target.getName()));
+        }
+
+        return CommandResult.success();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/config/serialisers/UserConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/config/serialisers/UserConfig.java
@@ -14,6 +14,7 @@ import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 @ConfigSerializable
 public class UserConfig {
@@ -67,6 +68,9 @@ public class UserConfig {
 
     @Setting
     private Map<String, List<String>> powertools = Maps.newHashMap();
+
+    @Setting
+    private List<UUID> ignoreList = Lists.newArrayList();
 
     public MuteData getMuteData() {
         return muteData;
@@ -194,5 +198,13 @@ public class UserConfig {
 
     public void setPowertoolToggle(boolean set) {
         this.powertoolToggle = set;
+    }
+
+    public List<UUID> getIgnoreList() {
+        return this.ignoreList;
+    }
+
+    public void setIgnoreList(List<UUID> ignoreList) {
+        this.ignoreList = ignoreList;
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/services/datastore/UserService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/services/datastore/UserService.java
@@ -477,4 +477,24 @@ public class UserService implements InternalNucleusUser {
     public void setPowertoolToggle(boolean set) {
         config.setPowertoolToggle(set);
     }
+
+    @Override
+    public List<UUID> getIgnoreList() {
+        return ImmutableList.copyOf(config.getIgnoreList());
+    }
+
+    @Override
+    public boolean addToIgnoreList(UUID uuid) {
+        if (!config.getIgnoreList().contains(uuid)) {
+            config.getIgnoreList().add(uuid);
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean removeFromIgnoreList(UUID uuid) {
+        return config.getIgnoreList().remove(uuid);
+    }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/listeners/IgnoreListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/listeners/IgnoreListener.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.listeners;
+
+import com.google.common.collect.Lists;
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.api.PluginModule;
+import io.github.nucleuspowered.nucleus.api.events.MailEvent;
+import io.github.nucleuspowered.nucleus.api.events.MessageEvent;
+import io.github.nucleuspowered.nucleus.commands.ignore.IgnoreCommand;
+import io.github.nucleuspowered.nucleus.config.MainConfig;
+import io.github.nucleuspowered.nucleus.internal.CommandPermissionHandler;
+import io.github.nucleuspowered.nucleus.internal.ListenerBase;
+import io.github.nucleuspowered.nucleus.internal.PermissionRegistry;
+import io.github.nucleuspowered.nucleus.internal.annotations.Modules;
+import io.github.nucleuspowered.nucleus.internal.services.datastore.UserConfigLoader;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.Order;
+import org.spongepowered.api.event.filter.cause.First;
+import org.spongepowered.api.event.message.MessageChannelEvent;
+import org.spongepowered.api.text.channel.MessageChannel;
+import org.spongepowered.api.text.channel.MessageReceiver;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+@Modules(PluginModule.IGNORE)
+public class IgnoreListener extends ListenerBase {
+
+    @Inject private PermissionRegistry permissionRegistry;
+    @Inject private UserConfigLoader loader;
+    @Inject private MainConfig config;
+    private CommandPermissionHandler ignoreHandler;
+
+    @Listener(order = Order.FIRST)
+    public void onChat(MessageChannelEvent.Chat event, @First Player player) {
+        // Reset the channel - but only if we have to.
+        checkCancels(event.getChannel().orElse(event.getOriginalChannel()).getMembers(), player).ifPresent(x -> event.setChannel(MessageChannel.fixed(x)));
+    }
+
+    @Listener(order = Order.FIRST)
+    public void onMessage(MessageEvent event, @First Player player) {
+        if (event.getRecipient() instanceof User) {
+            try {
+                event.setCancelled(loader.getUser((User) event.getRecipient()).getIgnoreList().contains(player.getUniqueId()));
+            } catch (IOException | ObjectMappingException e) {
+                if (config.getDebugMode()) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+    @Listener(order = Order.FIRST)
+    public void onMail(MailEvent event, @First Player player) {
+        try {
+            event.setCancelled(loader.getUser(event.getRecipient()).getIgnoreList().contains(player.getUniqueId()));
+        } catch (IOException | ObjectMappingException e) {
+            if (config.getDebugMode()) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    /**
+     * Checks if we need to cancel messages to people.
+     *
+     * @param collection The collection to check through.
+     * @param player The player who is sending the message.
+     * @return {@link Optional} if unchanged, otherwise a {@link Collection} of {@link MessageReceiver}s
+     */
+    private Optional<Collection<MessageReceiver>> checkCancels(Collection<MessageReceiver> collection, Player player) {
+        if (ignoreHandler == null) {
+            permissionRegistry.getService(IgnoreCommand.class).ifPresent(x -> ignoreHandler = x);
+            if (ignoreHandler == null) {
+                return Optional.empty();
+            }
+        }
+
+        if (ignoreHandler.testSuffix(player, "exempt.chat")) {
+            return Optional.empty();
+        }
+
+        List<MessageReceiver> list = Lists.newArrayList(collection);
+        list.removeIf(x -> {
+            try {
+                return x instanceof Player && !x.equals(player) && loader.getUser((Player) x).getIgnoreList().contains(player.getUniqueId());
+            } catch (IOException | ObjectMappingException e) {
+                if (config.getDebugMode()) {
+                    e.printStackTrace();
+                }
+
+                return false;
+            }
+        });
+
+        // We do this so we don't have to recreate a channel if nothing changes.
+        if (list.size() == collection.size()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(list);
+    }
+}

--- a/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
+++ b/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
@@ -424,6 +424,11 @@ command.gamemode.set.other=&e{0}''s &agame mode was set to &e{1}&a.
 command.gamemode.get=&aYour game mode is currently &e{0}&a.
 command.gamemode.get.other=&e{0}''s &agame mode is currently &e{1}&a.
 
+command.ignore.exempt=&cYou cannot ignore the user {0}.
+command.ignore.self=&cYou cannot ignore yourself.
+command.ignore.added=&e{0} &awas added to your ignore list.
+command.ignore.remove=&e{0} &awas removed from your ignore list.
+
 # Ban
 ban.defaultreason=The banhammer has spoken!
 
@@ -524,3 +529,5 @@ permission.kit.exempt=Allows the user to bypass kit cooldowns.
 permission.kits=Allows the user to use all kits.
 
 permission.gamemode.other=Allows the user to change the gamemode for any user.
+
+permission.ignore.chat=Exempts the user from having their chat, messages and mail ignored.


### PR DESCRIPTION
See #36.

This adds an /ignore command that allows players to ignore chat, private messages and mails from specific players. Those with the `nucleus.ignore.exempt.chat` permission cannot be ignored.