### PR TITLE
Add /gamemode command

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/ImprovedGameModeParser.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/ImprovedGameModeParser.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.argumentparsers;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import io.github.nucleuspowered.nucleus.Util;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.ArgumentParseException;
+import org.spongepowered.api.command.args.CommandArgs;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.entity.living.player.gamemode.GameMode;
+import org.spongepowered.api.entity.living.player.gamemode.GameModes;
+import org.spongepowered.api.text.Text;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ImprovedGameModeParser extends CommandElement {
+
+    private final static Map<String, GameMode> gameModeMap = Maps.newHashMap();
+
+    static {
+        gameModeMap.put("survival", GameModes.SURVIVAL);
+        gameModeMap.put("s", GameModes.SURVIVAL);
+        gameModeMap.put("su", GameModes.SURVIVAL);
+        gameModeMap.put("0", GameModes.SURVIVAL);
+        gameModeMap.put("creative", GameModes.CREATIVE);
+        gameModeMap.put("c", GameModes.CREATIVE);
+        gameModeMap.put("1", GameModes.CREATIVE);
+        gameModeMap.put("adventure", GameModes.ADVENTURE);
+        gameModeMap.put("a", GameModes.ADVENTURE);
+        gameModeMap.put("2", GameModes.ADVENTURE);
+        gameModeMap.put("spectator", GameModes.SPECTATOR);
+        gameModeMap.put("sp", GameModes.SPECTATOR);
+        gameModeMap.put("3", GameModes.SPECTATOR);
+    }
+
+    public ImprovedGameModeParser(@Nullable Text key) {
+        super(key);
+    }
+
+    @Nullable
+    @Override
+    protected Object parseValue(CommandSource source, CommandArgs args) throws ArgumentParseException {
+        String arg = args.next();
+        GameMode mode = gameModeMap.get(arg.toLowerCase());
+
+        if (mode == null) {
+            throw args.createError(Util.getTextMessageWithFormat("args.gamemode.error", arg));
+        }
+
+        return mode;
+    }
+
+    @Override
+    public List<String> complete(CommandSource src, CommandArgs args, CommandContext context) {
+        try {
+            String arg = args.peek();
+            return gameModeMap.keySet().stream().filter(x -> arg.startsWith(arg.toLowerCase())).collect(Collectors.toList());
+        } catch (ArgumentParseException e) {
+            return Lists.newArrayList(gameModeMap.keySet());
+        }
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/commands/admin/GamemodeCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/commands/admin/GamemodeCommand.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.commands.admin;
+
+import com.google.common.collect.Maps;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.api.PluginModule;
+import io.github.nucleuspowered.nucleus.argumentparsers.ImprovedGameModeParser;
+import io.github.nucleuspowered.nucleus.internal.CommandBase;
+import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
+import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.living.player.gamemode.GameMode;
+import org.spongepowered.api.entity.living.player.gamemode.GameModes;
+import org.spongepowered.api.text.Text;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Permissions
+@Modules(PluginModule.ADMIN)
+@NoCooldown
+@NoWarmup
+@NoCost
+@RegisterCommand({"gamemode", "gm"})
+public class GamemodeCommand extends CommandBase<CommandSource> {
+
+    private final String userKey = "user";
+    private final String gamemodeKey = "gamemode";
+
+    @Override
+    protected Map<String, PermissionInformation> permissionSuffixesToRegister() {
+        Map<String, PermissionInformation> mpi = Maps.newHashMap();
+        mpi.put("others", new PermissionInformation(Util.getMessageWithFormat("permission.gamemode.other"), SuggestedLevel.ADMIN));
+        return mpi;
+    }
+
+    @Override
+    public CommandSpec createSpec() {
+        return CommandSpec.builder().arguments(
+                GenericArguments.optionalWeak(GenericArguments.requiringPermission(GenericArguments.onlyOne(GenericArguments.user(Text.of(userKey))), permissions.getPermissionWithSuffix("others"))),
+                GenericArguments.optional(GenericArguments.onlyOne(new ImprovedGameModeParser(Text.of(gamemodeKey))))
+        ).executor(this).build();
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        Optional<Player> ou = this.getUser(Player.class, src, userKey, args);
+        if (!ou.isPresent()) {
+            return CommandResult.empty();
+        }
+
+        Player user = ou.get();
+        Optional<GameMode> ogm = args.<GameMode>getOne(gamemodeKey);
+        if (!ogm.isPresent()) {
+            String mode = user.get(Keys.GAME_MODE).orElse(GameModes.SURVIVAL).getName();
+            if (src.equals(user)) {
+                src.sendMessage(Util.getTextMessageWithFormat("command.gamemode.get", mode));
+            } else {
+                src.sendMessage(Util.getTextMessageWithFormat("command.gamemode.get.other", user.getName(), mode));
+            }
+
+            return CommandResult.success();
+        }
+
+        GameMode gm = ogm.get();
+        DataTransactionResult dtr = user.offer(Keys.GAME_MODE, gm);
+        if (dtr.isSuccessful()) {
+            if (!src.equals(user)) {
+                src.sendMessage(Util.getTextMessageWithFormat("command.gamemode.set.other", user.getName(), gm.getName()));
+            }
+
+            user.sendMessage(Util.getTextMessageWithFormat("command.gamemode.set", gm.getName()));
+            return CommandResult.success();
+        }
+
+        src.sendMessage(Util.getTextMessageWithFormat("command.gamemode.error", user.getName()));
+        return CommandResult.empty();
+    }
+}

--- a/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
+++ b/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
@@ -135,6 +135,8 @@ args.explevel.error=&cThe argument must be a number prefixed with "l" or "lv".
 
 args.worldproperties.default=&eNo world was specified - the default was used.
 
+args.gamemode.error=&e"{0}" is not a valid gamemode.
+
 commandlog={0} ran the command: /{1} {2}
 
 # Commands
@@ -412,6 +414,12 @@ command.powertool.list.none=&aYou do not have any powertools.
 command.powertool.list.header=&ePowertools ({0}&e)
 command.powertool.ind.header=&aPowertool commands for &e{0}
 
+command.gamemode.error=&cUnable to set the game mode for {0}.
+command.gamemode.set=&aYour game mode was set to &e{0}&a.
+command.gamemode.set.other=&e{0}''s &agame mode was set to &e{1}&a.
+command.gamemode.get=&aYour game mode is currently &e{0}&a.
+command.gamemode.get.other=&e{0}''s &agame mode is currently &e{1}&a.
+
 # Ban
 ban.defaultreason=The banhammer has spoken!
 
@@ -510,3 +518,5 @@ permission.chat.urls=Allows user to type clickable URLs in chat.
 
 permission.kit.exempt=Allows the user to bypass kit cooldowns.
 permission.kits=Allows the user to use all kits.
+
+permission.gamemode.other=Allows the user to change the gamemode for any user.


### PR DESCRIPTION
This adds a /gamemode (or /gm) command that does the following:

* Allows use of short form /gm [0|1|2|3|s|c|a|su|sp|survival|creative|adventure|spectator]
* Allows use of /gm to see current game mode
* Allows use of /gm [user] to see other's game modes, optionally setting them.