### PR TITLE
Add /freezeplayer

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/api/data/NucleusUser.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/data/NucleusUser.java
@@ -246,4 +246,18 @@ public interface NucleusUser {
      * @return <code>true</code> if successful.
      */
     boolean removeFromIgnoreList(UUID uuid);
+
+    /**
+     * Checks if a user is frozen
+     *
+     * @return <code>true</code> if player is frozen.
+     */
+    boolean isFrozen();
+
+    /**
+     * Set the frozen value of a user.
+     *
+     * @param frozen Sets whether or not the user is frozen.
+     */
+    void setFrozen(boolean frozen);
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/commands/admin/FreezePlayerCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/commands/admin/FreezePlayerCommand.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.commands.admin;
+
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.api.PluginModule;
+import io.github.nucleuspowered.nucleus.api.data.NucleusUser;
+import io.github.nucleuspowered.nucleus.internal.CommandBase;
+import io.github.nucleuspowered.nucleus.internal.annotations.Modules;
+import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
+import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
+import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import io.github.nucleuspowered.nucleus.internal.services.datastore.UserConfigLoader;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import org.spongepowered.api.command.CommandException;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.text.Text;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Modules(PluginModule.ADMIN)
+@Permissions
+@RegisterCommand({"freezeplayer", "freeze"})
+public class FreezePlayerCommand extends CommandBase<CommandSource> {
+
+    @Inject private UserConfigLoader userConfigLoader;
+
+    private final String player = "player";
+
+    @Override
+    public Map<String, PermissionInformation> permissionSuffixesToRegister() {
+        Map<String, PermissionInformation> m = new HashMap<>();
+        m.put("others", new PermissionInformation(Util.getMessageWithFormat("permission.others", this.getAliases()[0]), SuggestedLevel.ADMIN));
+        return m;
+    }
+
+    @Override
+    public CommandSpec createSpec() {
+        return CommandSpec.builder()
+                .arguments(GenericArguments.optional(GenericArguments.requiringPermission(
+                        GenericArguments.onlyOne(GenericArguments.player(Text.of(player))), permissions.getPermissionWithSuffix("others"))))
+                .executor(this).build();
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        Optional<Player> opl = this.getUser(Player.class, src, player, args);
+        if (!opl.isPresent()) {
+            return CommandResult.empty();
+        }
+
+        NucleusUser nu;
+
+        try {
+            nu = userConfigLoader.getUser(opl.get());
+        } catch (IOException | ObjectMappingException e) {
+            e.printStackTrace();
+            throw new CommandException(Util.getTextMessageWithFormat("command.file.load"), e);
+        }
+
+        if (nu.isFrozen()) {
+            nu.setFrozen(false);
+        } else {
+            nu.setFrozen(true);
+        }
+
+        src.sendMessage(Util.getTextMessageWithFormat("command.freezeplayer.success", opl.get().getName(), nu.isFrozen() ? "frozen" : "un-frozen"));
+        return CommandResult.success();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/config/serialisers/UserConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/config/serialisers/UserConfig.java
@@ -72,6 +72,9 @@ public class UserConfig {
     @Setting
     private List<UUID> ignoreList = Lists.newArrayList();
 
+    @Setting
+    private boolean isFrozen = false;
+
     public MuteData getMuteData() {
         return muteData;
     }
@@ -206,5 +209,13 @@ public class UserConfig {
 
     public void setIgnoreList(List<UUID> ignoreList) {
         this.ignoreList = ignoreList;
+    }
+
+    public boolean isFrozen() {
+        return isFrozen;
+    }
+
+    public void setFrozen(boolean isFrozen) {
+        this.isFrozen = isFrozen;
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/services/datastore/UserService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/services/datastore/UserService.java
@@ -497,4 +497,14 @@ public class UserService implements InternalNucleusUser {
     public boolean removeFromIgnoreList(UUID uuid) {
         return config.getIgnoreList().remove(uuid);
     }
+
+    @Override
+    public boolean isFrozen() {
+        return config.isFrozen();
+    }
+
+    @Override
+    public void setFrozen(boolean value) {
+       config.setFrozen(value);
+    }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/listeners/AdminListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/listeners/AdminListener.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.listeners;
+
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.api.PluginModule;
+import io.github.nucleuspowered.nucleus.api.data.NucleusUser;
+import io.github.nucleuspowered.nucleus.internal.ListenerBase;
+import io.github.nucleuspowered.nucleus.internal.annotations.Modules;
+import io.github.nucleuspowered.nucleus.internal.services.datastore.UserConfigLoader;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.action.InteractEvent;
+import org.spongepowered.api.event.block.InteractBlockEvent;
+import org.spongepowered.api.event.entity.DisplaceEntityEvent;
+import org.spongepowered.api.event.filter.cause.First;
+
+import java.io.IOException;
+
+@Modules(PluginModule.ADMIN)
+public class AdminListener extends ListenerBase {
+
+    @Inject private UserConfigLoader ucl;
+
+    @Listener
+    public void onPlayerMovement(DisplaceEntityEvent.Move event, @First Player player) {
+        NucleusUser nu;
+        try {
+            nu = ucl.getUser(player);
+        } catch (IOException | ObjectMappingException e) {
+            e.printStackTrace();
+            return;
+        }
+
+        if (nu.isFrozen()) {
+            player.sendMessage(Util.getTextMessageWithFormat("freeze.cancelmove"));
+            event.setCancelled(true);
+        }
+    }
+
+    @Listener
+    public void onPlayerInteractBlock(InteractEvent event, @First Player player) {
+        NucleusUser nu;
+        try {
+            nu = ucl.getUser(player);
+        } catch (IOException | ObjectMappingException e) {
+            e.printStackTrace();
+            return;
+        }
+
+        if (nu.isFrozen()) {
+            player.sendMessage(Util.getTextMessageWithFormat("freeze.cancelinteract"));
+            event.setCancelled(true);
+        }
+    }
+
+    @Listener
+    public void onPlayerInteractBlock(InteractBlockEvent event, @First Player player) {
+        NucleusUser nu;
+        try {
+            nu = ucl.getUser(player);
+        } catch (IOException | ObjectMappingException e) {
+            e.printStackTrace();
+            return;
+        }
+
+        if (nu.isFrozen()) {
+            player.sendMessage(Util.getTextMessageWithFormat("freeze.cancelinteractblock"));
+            event.setCancelled(true);
+        }
+    }
+}

--- a/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
+++ b/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
@@ -49,6 +49,10 @@ warmup.start=&aWarmup started: your command will be executed in &e{0}. &aDo not 
 warmup.end=&aCompleted warmup. Executing command.
 warmup.cancel=&cYour warmup has been cancelled.
 
+freeze.cancelmove=&cYou cannot move while frozen.
+freeze.cancelinteract=&cYou cannot interact with entities while frozen.
+freeze.cancelinteractblock=&cYou cannot interact with block while frozen.
+
 cooldown.message=&cYou can''t run this command for another &e(0)&c.
 
 cost.complete=&aYou were charged &e{0}&a to run that command.
@@ -208,6 +212,8 @@ command.kit.fullinventory=&cYour inventory is full, some items were lost.
 command.kit.list.kits=&aKits
 command.kit.cost.success=&aKit {0} cost has been set to {1}.
 command.kit.notenough=&cYou do not have enough for {0}, you require {1}.
+
+command.freezeplayer.success=&aSet player {0} {1}.
 
 command.socialspy.on=&aYou can now see others'' private messages.
 command.socialspy.off=&aYou can no longer see others'' private messages.


### PR DESCRIPTION
Related: Issue #40 

Use cases:
* [x] - Server admin wants to freeze a player, disabling them from moving, interacting with entities, or with blocks.

Changes:
* [x] - Added proper event listeners and cancellation for `frozen` players.
* [x] - Added command `/freezeplayer`.
* [x] - Added message in `message.properties`
