### PR TITLE
Add /blockinfo command

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/BlockInfoCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/BlockInfoCommand.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.misc.commands;
+
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.internal.CommandBase;
+import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
+import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.block.trait.BlockTrait;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.util.blockray.BlockRay;
+import org.spongepowered.api.util.blockray.BlockRayHit;
+import org.spongepowered.api.world.World;
+
+import java.util.Collection;
+import java.util.Optional;
+
+@Permissions
+@RegisterCommand({ "blockinfo" })
+@RunAsync
+public class BlockInfoCommand extends CommandBase<Player> {
+
+    @Override
+    public CommandSpec createSpec() {
+        return CommandSpec.builder().executor(this).build();
+    }
+
+    @Override
+    public CommandResult executeCommand(Player player, CommandContext args) throws Exception {
+        BlockRay<World> bl = BlockRay.from(player).blockLimit(10).filter(BlockRay.continueAfterFilter(BlockRay.onlyAirFilter(), 1)).build();
+        Optional<BlockRayHit<World>> ob = bl.end();
+
+        // If the last block is not air...
+        if (ob.isPresent() && ob.get().getLocation().getBlockType() != BlockTypes.AIR) {
+            BlockRayHit<World> brh = ob.get();
+
+            // get the information.
+            BlockState b = brh.getLocation().getBlock();
+            BlockType it = b.getType();
+            player.sendMessage(Util.getTextMessageWithFormat("command.blockinfo.id", it.getId(), it.getName()));
+
+            Collection<BlockTrait<?>> cb = b.getTraits();
+            if (!cb.isEmpty()) {
+                cb.forEach(x -> b.getTraitValue(x).ifPresent(v ->
+                    player.sendMessage(Util.getTextMessageWithFormat("command.blockinfo.traits.item", x.getName(), v.toString()))
+                ));
+            }
+
+            return CommandResult.success();
+        }
+
+        player.sendMessage(Util.getTextMessageWithFormat("command.blockinfo.none"));
+        return CommandResult.empty();
+    }
+}

--- a/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
+++ b/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
@@ -480,6 +480,10 @@ command.thru.notsafe=&cUnable to find a safe place to jump to.
 command.more.success=&aStacked your {0}: you now have {1}.
 command.more.none=&cYou must be holding an item.
 
+command.blockinfo.id=&aBlock ID: &e{0}&a. Block name: &e{1}&a.
+command.blockinfo.traits.item=&aTrait: &e{0}&a. Value: &e{1}&a.
+command.blockinfo.none=&cNo block was found ahead of you.
+
 # Ban
 ban.defaultreason=The banhammer has spoken!
 


### PR DESCRIPTION
`/blockinfo` adds the ability to get a block's information when looking at it. Based on the EssentialCmds version, but heavily updated.