### PR TITLE
Add /spawnmob command

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/ImprovedEntityParser.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/ImprovedEntityParser.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.argumentparsers;
+
+import org.spongepowered.api.CatalogTypes;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.*;
+import org.spongepowered.api.text.Text;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class ImprovedEntityParser extends CommandElement {
+
+    private final CommandElement wrapped;
+
+    public ImprovedEntityParser(@Nullable Text key) {
+        super(key);
+        wrapped = GenericArguments.catalogedElement(key, CatalogTypes.ENTITY_TYPE);
+    }
+
+    @Nullable
+    @Override
+    protected Object parseValue(CommandSource source, CommandArgs args) throws ArgumentParseException {
+        return null;
+    }
+
+    @Override
+    public void parse(CommandSource source, CommandArgs args, CommandContext context) throws ArgumentParseException {
+        String arg = args.peek();
+        if (!arg.contains(":")) {
+            args.next();
+            Object state = args.getState();
+
+            // May need to question this.
+            args.removeArgs(state, state);
+            args.insertArg("minecraft:" + arg);
+        }
+
+        wrapped.parse(source, args, context);
+    }
+
+    @Override
+    public List<String> complete(CommandSource src, CommandArgs args, CommandContext context) {
+        return wrapped.complete(src, args, context);
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/guice/QuickStartInjectorModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/guice/QuickStartInjectorModule.java
@@ -18,6 +18,7 @@ import io.github.nucleuspowered.nucleus.modules.jump.config.JumpConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.kit.handlers.KitHandler;
 import io.github.nucleuspowered.nucleus.modules.mail.handlers.MailHandler;
 import io.github.nucleuspowered.nucleus.modules.message.handlers.MessageHandler;
+import io.github.nucleuspowered.nucleus.modules.mob.config.MobConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.nickname.config.NicknameConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.teleport.handlers.TeleportHandler;
 import io.github.nucleuspowered.nucleus.modules.warp.config.WarpConfigAdapter;
@@ -45,6 +46,7 @@ public class QuickStartInjectorModule extends QuickStartModuleLoaderInjector {
         bind(AdminConfigAdapter.class).toProvider(() -> getAdapter("admin", AdminConfigAdapter.class));
         bind(JumpConfigAdapter.class).toProvider(() -> getAdapter("jump", JumpConfigAdapter.class));
         bind(ConnectionMessagesConfigAdapter.class).toProvider(() -> getAdapter("connection-messages", ConnectionMessagesConfigAdapter.class));
+        bind(MobConfigAdapter.class).toProvider(() -> getAdapter("mob", MobConfigAdapter.class));
 
         bind(AFKHandler.class).toProvider(() -> getService(AFKHandler.class));
         bind(MessageHandler.class).toProvider(() -> getService(MessageHandler.class));

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/mob/MobModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/mob/MobModule.java
@@ -1,0 +1,21 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.mob;
+
+import io.github.nucleuspowered.nucleus.internal.StandardModule;
+import io.github.nucleuspowered.nucleus.modules.mob.config.MobConfigAdapter;
+import uk.co.drnaylor.quickstart.annotations.ModuleData;
+import uk.co.drnaylor.quickstart.config.AbstractConfigAdapter;
+
+import java.util.Optional;
+
+@ModuleData(id = "mob", name = "Mob")
+public class MobModule extends StandardModule {
+
+    @Override
+    public Optional<AbstractConfigAdapter<?>> getConfigAdapter() {
+        return Optional.of(new MobConfigAdapter());
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/mob/commands/SpawnMobCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/mob/commands/SpawnMobCommand.java
@@ -1,0 +1,102 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.mob.commands;
+
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.argumentparsers.ImprovedEntityParser;
+import io.github.nucleuspowered.nucleus.argumentparsers.PositiveIntegerArgument;
+import io.github.nucleuspowered.nucleus.internal.CommandBase;
+import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
+import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
+import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import io.github.nucleuspowered.nucleus.modules.mob.config.MobConfigAdapter;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.EntityType;
+import org.spongepowered.api.entity.living.Living;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.NamedCause;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.World;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Permissions
+@RegisterCommand({"spawnmob", "spawnentity"})
+public class SpawnMobCommand extends CommandBase<CommandSource> {
+
+    private final String playerKey = "player";
+    private final String amountKey = "amount";
+    private final String mobTypeKey = "mob";
+
+    @Inject private MobConfigAdapter mobConfigAdapter;
+
+    @Override
+    public CommandSpec createSpec() {
+        return CommandSpec.builder().executor(this).arguments(
+                GenericArguments.optionalWeak(GenericArguments.requiringPermission(GenericArguments.player(Text.of(playerKey)), permissions.getPermissionWithSuffix("others"))),
+                new ImprovedEntityParser(Text.of(mobTypeKey)),
+                GenericArguments.optional(new PositiveIntegerArgument(Text.of(amountKey)), 1)
+        ).build();
+    }
+
+    @Override
+    protected Map<String, PermissionInformation> permissionSuffixesToRegister() {
+        Map<String, PermissionInformation> m = new HashMap<>();
+        m.put("others", new PermissionInformation(Util.getMessageWithFormat("permission.spawnmob.other"), SuggestedLevel.ADMIN));
+        return m;
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        Optional<Player> opl = this.getUser(Player.class, src, playerKey, args);
+        if (!opl.isPresent()) {
+            return CommandResult.empty();
+        }
+
+        // Get the amount
+        int amount = args.<Integer>getOne(amountKey).get();
+        EntityType et = args.<EntityType>getOne(mobTypeKey).get();
+
+        if (!Living.class.isAssignableFrom(et.getEntityClass())) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.spawnmob.livingonly", et.getTranslation().get()));
+            return CommandResult.empty();
+        }
+
+        Location<World> loc = opl.get().getLocation();
+        World w = loc.getExtent();
+
+        // Count the number of entities spawned.
+        int i = 0;
+        do {
+            Optional<Entity> e = w.createEntity(et, loc.getPosition());
+            if (e.isPresent() && w.spawnEntity(e.get(), Cause.of(NamedCause.source(opl.get())))) {
+                i++;
+            }
+        } while (i < Math.min(amount, mobConfigAdapter.getNodeOrDefault().getMaxMobsToSpawn()));
+
+        if (i == 0) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.spawnmob.fail", et.getTranslation().get()));
+            return CommandResult.empty();
+        }
+
+        if (i == 1) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.spawnmob.success.singular", String.valueOf(i), et.getTranslation().get()));
+        } else {
+            src.sendMessage(Util.getTextMessageWithFormat("command.spawnmob.success.plural", String.valueOf(i), et.getTranslation().get()));
+        }
+        return CommandResult.success();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/mob/config/MobConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/mob/config/MobConfig.java
@@ -1,0 +1,19 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.mob.config;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+@ConfigSerializable
+public class MobConfig {
+
+    @Setting(value = "max-mobs-to-spawn", comment = "loc:config.mobspawn.maxamt")
+    private int maxMobsToSpawn = 20;
+
+    public int getMaxMobsToSpawn() {
+        return Math.max(1, maxMobsToSpawn);
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/mob/config/MobConfigAdapter.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/mob/config/MobConfigAdapter.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.mob.config;
+
+import com.google.common.reflect.TypeToken;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.commented.SimpleCommentedConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+
+public class MobConfigAdapter extends NucleusConfigAdapter<MobConfig> {
+
+    @Override
+    protected MobConfig getDefaultObject() {
+        return new MobConfig();
+    }
+
+    @Override
+    protected MobConfig convertFromConfigurateNode(ConfigurationNode node) throws ObjectMappingException {
+        return node.getValue(TypeToken.of(MobConfig.class), new MobConfig());
+    }
+
+    @Override
+    protected ConfigurationNode insertIntoConfigurateNode(MobConfig data) throws ObjectMappingException {
+        return SimpleCommentedConfigurationNode.root().setValue(TypeToken.of(MobConfig.class), data);
+    }
+}

--- a/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
+++ b/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
@@ -107,6 +107,8 @@ config.connectionmessages.enablelogout=Enables changing the logout message.
 config.connectionmessages.enablelogin=Enables changing the login message.
 config.connectionmessages.enablefirst=Enables the first time login message.
 
+config.mobspawn.maxamt=The maximum number of mobs that can be spawned using /spawnmob.
+
 afk.toafk=&7* &r{0} &7is now AFK.
 afk.fromafk=&7* &r{0} &7is no longer AFK.
 afk.kickedafk=has been kicked for being AFK too long.
@@ -491,6 +493,11 @@ command.iteminfo.id=&aItem ID: &e{0}&a. Item name: &e{1}&a.
 command.iteminfo.key=&aData Key: &e{0}&a. Value: &e{1}&a.
 command.iteminfo.none=&cYou must be holding the item you wish to inspect.
 
+command.spawnmob.fail=&cUnable to spawn in any {0} entities.
+command.spawnmob.success.singular=&aSpawned in {0} {1} entity.
+command.spawnmob.success.plural=&aSpawned in {0} {1} entities.
+command.spawnmob.livingonly=&cUnable to spawn in {0}, the entity must be living.
+
 # Ban
 ban.defaultreason=The banhammer has spoken!
 
@@ -597,3 +604,5 @@ permission.ignore.chat=Exempts the user from having their chat, messages and mai
 
 permission.iteminfo.extended=Displays data associated with the item.
 permission.blockinfo.extended=Displays properties and traits associated with the block.
+
+permission.spawnmob.other=Allows the user to spawn a mob on another player.


### PR DESCRIPTION
Allows users to spawn entities in, by default at the player's location, optionally at someone else's position.