### PR TITLE
Refactor the CommandBase slightly to use a common CommandSpec root.

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -63,17 +63,17 @@ If you think there is a bug with the module loader itself (package, `uk.co.drnay
 
 If you are developing a command, please keep the following in mind:
 
-* ALWAYS use the `CommandBase<>` class. It contains a lot of scaffolding that the plugin loader requires.
-
-* The `@Permissions` (unless the command should not have any permission checks at all, in which case, use `@NoPermissions`, but please be ready to justify this!) and `@RegisterCommand` annotations are mandatory on this class - tests enforce this.
-
-* If you require one of the Nucleus handlers/services - check to see if it can be injected. using the `@Inject`
-annotation. The plugin object is always injected and does not need to be done again.
+* ALWAYS use the `CommandBase<>` class. It contains a lot of scaffolding that the plugin loader requires. Do not use the `AbstractCommand<>` class.
+* If your command requires arguments, override the `CommandElement[] getArguemnts()` method, and return an array of arguments.
+* Please add a description for your command - add it to the `messages.properties` file with the key
+`description.[parentcommand alias].[primary command alias].desc`.
+    * The parent command alias is only required if the command is a subcommand - it is a period separated path to the sub command.
+* If you require one of the Nucleus handlers/services - check to see if it can be injected. using the `@Inject` annotation.
+The plugin object is always injected into a protected variable and does not need to be done again.
 
 Listeners and Runnable Tasks extend the `ListenerBase` and `TaskBase` classes, respectively. They will have the Nucleus plugin instance injected automatically, but you are able to use other injections on these classes too.
 
-The key rule here is - if you are unsure as to how something works, **please** ask us! We are more than willing to help you
-as much as possible!
+The key rule here is - if you are unsure as to how something works, **please** ask us! We are more than willing to help you as much as possible!
 
 ### Code Style
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/PermissionRegistry.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/PermissionRegistry.java
@@ -6,6 +6,7 @@ package io.github.nucleuspowered.nucleus.internal;
 
 import com.google.common.collect.Maps;
 import io.github.nucleuspowered.nucleus.PluginInfo;
+import io.github.nucleuspowered.nucleus.internal.command.AbstractCommand;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 
@@ -16,14 +17,14 @@ import java.util.Optional;
 public class PermissionRegistry {
 
     public final static String PERMISSIONS_PREFIX = PluginInfo.ID + ".";
-    private final Map<Class<? extends CommandBase>, CommandPermissionHandler> serviceRegistry = Maps.newHashMap();
+    private final Map<Class<? extends AbstractCommand>, CommandPermissionHandler> serviceRegistry = Maps.newHashMap();
     private final Map<String, PermissionInformation> otherPermissions = Maps.newHashMap();
 
-    public Optional<CommandPermissionHandler> getService(Class<? extends CommandBase> command) {
+    public Optional<CommandPermissionHandler> getService(Class<? extends AbstractCommand> command) {
         return Optional.ofNullable(serviceRegistry.get(command));
     }
 
-    public void addHandler(Class<? extends CommandBase> cb, CommandPermissionHandler cph) {
+    public void addHandler(Class<? extends AbstractCommand> cb, CommandPermissionHandler cph) {
         if (serviceRegistry.containsKey(cb)) {
             // Silently discard.
             return;

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/annotations/ModuleCommandSet.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/annotations/ModuleCommandSet.java
@@ -1,0 +1,19 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.internal.annotations;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@BindingAnnotation
+@Target(FIELD)
+@Retention(RUNTIME)
+public @interface ModuleCommandSet {
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/annotations/RegisterCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/annotations/RegisterCommand.java
@@ -4,7 +4,7 @@
  */
 package io.github.nucleuspowered.nucleus.internal.annotations;
 
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
+import io.github.nucleuspowered.nucleus.internal.command.AbstractCommand;
 
 import java.lang.annotation.*;
 
@@ -17,11 +17,11 @@ import java.lang.annotation.*;
 public @interface RegisterCommand {
 
     /**
-     * The subcommand that this represents. Defaults to the {@link CommandBase} class.
+     * The subcommand that this represents. Defaults to the {@link AbstractCommand} class.
      *
      * @return The subcommand.
      */
-    Class<? extends CommandBase> subcommandOf() default CommandBase.class;
+    Class<? extends AbstractCommand> subcommandOf() default AbstractCommand.class;
 
     /**
      * The aliases for this command.

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/annotations/RunAsync.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/annotations/RunAsync.java
@@ -4,12 +4,10 @@
  */
 package io.github.nucleuspowered.nucleus.internal.annotations;
 
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
-
 import java.lang.annotation.*;
 
 /**
- * Any {@link CommandBase} that is decorated with this annotation will be
+ * Any {@link io.github.nucleuspowered.nucleus.internal.command.CommandBase} that is decorated with this annotation will be
  * run on an async thread. This should only be used for thread-safe operations.
  */
 @Target(ElementType.TYPE)

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/command/CommandBase.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/command/CommandBase.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.internal.command;
+
+import com.google.common.base.Preconditions;
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.modules.core.config.CoreConfigAdapter;
+import org.spongepowered.api.command.CommandCallable;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.text.Text;
+
+import java.util.List;
+import java.util.Map;
+
+public abstract class CommandBase<T extends CommandSource> extends AbstractCommand<T> {
+
+    @Inject protected CoreConfigAdapter cca;
+
+    /**
+     * Gets the arguments of the command.
+     *
+     * @return The arguments of the command.
+     */
+    public CommandElement[] getArguments() {
+        return new CommandElement[]{};
+    }
+
+    /**
+     * Gets the description for the command.
+     *
+     * @return The description.
+     */
+    public String getDescription() {
+        String key = String.format("description.%sdesc", this.commandPath);
+        try {
+            return Util.getMessageWithFormat(key);
+        } catch (Exception e) {
+            if (cca.getNodeOrDefault().isDebugmode()) {
+                return key;
+            }
+
+            return "";
+        }
+    }
+
+    @Override
+    public final CommandSpec createSpec() {
+        Preconditions.checkState(permissions != null);
+        CommandSpec.Builder cb = CommandSpec.builder().executor(this).arguments(getArguments());
+
+        if (!permissions.isPassthrough()) {
+            cb.permission(permissions.getBase());
+        }
+
+        String description = getDescription();
+        if (!description.isEmpty()) {
+            cb.description(Text.of(getDescription()));
+        }
+
+        Map<List<String>, CommandCallable> m = createChildCommands();
+        if (!m.isEmpty()) {
+            cb.children(m);
+        }
+
+        return cb.build();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/command/OldCommandBase.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/command/OldCommandBase.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.internal.command;
+
+import com.google.common.base.Preconditions;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.spec.CommandSpec;
+
+/**
+ * @deprecated Deprecated in favour of {@link CommandBase}
+ */
+@Deprecated
+public abstract class OldCommandBase<T extends CommandSource> extends AbstractCommand<T> {
+
+     /**
+     * Builds the common base for the CommandSpec.
+     *
+     * @return The uncompleted {@link org.spongepowered.api.command.spec.CommandSpec.Builder}
+     */
+    protected final CommandSpec.Builder getSpecBuilderBase() {
+        Preconditions.checkState(permissions != null);
+        CommandSpec.Builder cb = CommandSpec.builder().executor(this);
+
+        if (!permissions.isPassthrough()) {
+            cb.permission(permissions.getBase());
+        }
+
+        return cb;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/BroadcastCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/BroadcastCommand.java
@@ -5,12 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.admin.commands;
 
 import com.google.inject.Inject;
-import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.config.CommandsConfig;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.modules.admin.config.AdminConfigAdapter;
-import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
@@ -26,13 +23,13 @@ import org.spongepowered.api.text.serializer.TextSerializers;
 @NoWarmup
 @Permissions
 @RegisterCommand({ "broadcast", "bcast", "bc" })
-public class BroadcastCommand extends CommandBase<CommandSource> {
+public class BroadcastCommand extends OldCommandBase<CommandSource> {
     private final String message = "message";
     @Inject private AdminConfigAdapter adminConfigAdapter;
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(GenericArguments.onlyOne(GenericArguments.remainingJoinedStrings(Text.of(message)))).executor(this).build();
+        return getSpecBuilderBase().arguments(GenericArguments.onlyOne(GenericArguments.remainingJoinedStrings(Text.of(message)))).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/ClearInventoryCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/ClearInventoryCommand.java
@@ -5,8 +5,8 @@
 package io.github.nucleuspowered.nucleus.modules.admin.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.command.CommandResult;
@@ -26,7 +26,7 @@ import java.util.Optional;
 @NoWarmup
 @NoCost
 @Permissions
-public class ClearInventoryCommand extends CommandBase<CommandSource> {
+public class ClearInventoryCommand extends OldCommandBase<CommandSource> {
 
     private final String player = "player";
 
@@ -39,7 +39,7 @@ public class ClearInventoryCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).arguments(GenericArguments.optional(GenericArguments.requiringPermission(
+        return getSpecBuilderBase().arguments(GenericArguments.optional(GenericArguments.requiringPermission(
                 GenericArguments.onlyOne(GenericArguments.player(Text.of(player))), permissions.getPermissionWithSuffix("others")))).build();
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/ExperienceCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/ExperienceCommand.java
@@ -5,8 +5,8 @@
 package io.github.nucleuspowered.nucleus.modules.admin.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
@@ -22,15 +22,15 @@ import org.spongepowered.api.text.Text;
 @NoCooldown
 @NoWarmup
 @NoCost
-public class ExperienceCommand extends CommandBase<CommandSource> {
+public class ExperienceCommand extends OldCommandBase<CommandSource> {
 
     public static final String playerKey = "player";
     public static final String experienceKey = "experience";
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().children(this.createChildCommands())
-                .arguments(GenericArguments.onlyOne(GenericArguments.playerOrSource(Text.of(playerKey)))).executor(this).build();
+        return getSpecBuilderBase().children(this.createChildCommands())
+                .arguments(GenericArguments.onlyOne(GenericArguments.playerOrSource(Text.of(playerKey)))).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/FreezePlayerCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/FreezePlayerCommand.java
@@ -8,9 +8,9 @@ import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.NucleusUser;
 import io.github.nucleuspowered.nucleus.config.loaders.UserConfigLoader;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.command.CommandException;
@@ -28,7 +28,7 @@ import java.util.Optional;
 
 @Permissions
 @RegisterCommand({"freezeplayer", "freeze"})
-public class FreezePlayerCommand extends CommandBase<CommandSource> {
+public class FreezePlayerCommand extends OldCommandBase<CommandSource> {
 
     @Inject private UserConfigLoader userConfigLoader;
 
@@ -43,10 +43,10 @@ public class FreezePlayerCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder()
+        return getSpecBuilderBase()
                 .arguments(GenericArguments.optional(GenericArguments.requiringPermission(
                         GenericArguments.onlyOne(GenericArguments.player(Text.of(player))), permissions.getPermissionWithSuffix("others"))))
-                .executor(this).build();
+                .build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/GamemodeCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/GamemodeCommand.java
@@ -7,8 +7,8 @@ package io.github.nucleuspowered.nucleus.modules.admin.commands;
 import com.google.common.collect.Maps;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.ImprovedGameModeParser;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.command.CommandResult;
@@ -31,7 +31,7 @@ import java.util.Optional;
 @NoWarmup
 @NoCost
 @RegisterCommand({"gamemode", "gm"})
-public class GamemodeCommand extends CommandBase<CommandSource> {
+public class GamemodeCommand extends OldCommandBase<CommandSource> {
 
     private final String userKey = "user";
     private final String gamemodeKey = "gamemode";
@@ -45,10 +45,10 @@ public class GamemodeCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(
+        return getSpecBuilderBase().arguments(
                 GenericArguments.optionalWeak(GenericArguments.requiringPermission(GenericArguments.onlyOne(GenericArguments.user(Text.of(userKey))), permissions.getPermissionWithSuffix("others"))),
                 GenericArguments.optional(GenericArguments.onlyOne(new ImprovedGameModeParser(Text.of(gamemodeKey))))
-        ).executor(this).build();
+        ).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/SudoCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/SudoCommand.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.admin.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.Sponge;
@@ -26,15 +26,15 @@ import java.util.Map;
 
 @Permissions
 @RegisterCommand("sudo")
-public class SudoCommand extends CommandBase<CommandSource> {
+public class SudoCommand extends OldCommandBase<CommandSource> {
 
     private final String playerKey = "player";
     private final String commandKey = "command";
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(GenericArguments.onlyOne(GenericArguments.player(Text.of(playerKey))),
-                GenericArguments.onlyOne(GenericArguments.remainingJoinedStrings(Text.of(commandKey)))).executor(this).build();
+        return getSpecBuilderBase().arguments(GenericArguments.onlyOne(GenericArguments.player(Text.of(playerKey))),
+                GenericArguments.onlyOne(GenericArguments.remainingJoinedStrings(Text.of(commandKey)))).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/exp/GiveExperience.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/exp/GiveExperience.java
@@ -5,8 +5,8 @@
 package io.github.nucleuspowered.nucleus.modules.admin.commands.exp;
 
 import io.github.nucleuspowered.nucleus.argumentparsers.PositiveIntegerArgument;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.modules.admin.commands.ExperienceCommand;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
@@ -24,14 +24,14 @@ import java.util.Optional;
 @NoCost
 @Permissions(root = "exp")
 @RegisterCommand(value = "give", subcommandOf = ExperienceCommand.class)
-public class GiveExperience extends CommandBase<CommandSource> {
+public class GiveExperience extends OldCommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(
+        return getSpecBuilderBase().arguments(
                 GenericArguments.optionalWeak(GenericArguments.onlyOne(GenericArguments.player(Text.of(ExperienceCommand.playerKey)))),
                 GenericArguments.onlyOne(new PositiveIntegerArgument(Text.of(ExperienceCommand.experienceKey)))
-        ).executor(this).build();
+        ).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/exp/SetExperience.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/exp/SetExperience.java
@@ -6,8 +6,8 @@ package io.github.nucleuspowered.nucleus.modules.admin.commands.exp;
 
 import io.github.nucleuspowered.nucleus.argumentparsers.ExperienceLevelArgument;
 import io.github.nucleuspowered.nucleus.argumentparsers.PositiveIntegerArgument;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.modules.admin.commands.ExperienceCommand;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
@@ -26,19 +26,19 @@ import java.util.Optional;
 @NoCost
 @Permissions(root = "exp")
 @RegisterCommand(value = "set", subcommandOf = ExperienceCommand.class)
-public class SetExperience extends CommandBase<CommandSource> {
+public class SetExperience extends OldCommandBase<CommandSource> {
 
     private final String levelKey = "level";
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(
+        return getSpecBuilderBase().arguments(
                 GenericArguments.optionalWeak(GenericArguments.onlyOne(GenericArguments.player(Text.of(ExperienceCommand.playerKey)))),
                 GenericArguments.firstParsing(
                     GenericArguments.onlyOne(new ExperienceLevelArgument(Text.of(levelKey))),
                     GenericArguments.onlyOne(new PositiveIntegerArgument(Text.of(ExperienceCommand.experienceKey)))
                 )
-        ).executor(this).build();
+        ).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/exp/TakeExperience.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/exp/TakeExperience.java
@@ -5,8 +5,8 @@
 package io.github.nucleuspowered.nucleus.modules.admin.commands.exp;
 
 import io.github.nucleuspowered.nucleus.argumentparsers.PositiveIntegerArgument;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.modules.admin.commands.ExperienceCommand;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
@@ -24,14 +24,14 @@ import java.util.Optional;
 @NoCost
 @Permissions(root = "exp")
 @RegisterCommand(value = "take", subcommandOf = ExperienceCommand.class)
-public class TakeExperience extends CommandBase<CommandSource> {
+public class TakeExperience extends OldCommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(
+        return getSpecBuilderBase().arguments(
                 GenericArguments.optionalWeak(GenericArguments.onlyOne(GenericArguments.player(Text.of(ExperienceCommand.playerKey)))),
                 GenericArguments.onlyOne(new PositiveIntegerArgument(Text.of(ExperienceCommand.experienceKey)))
-        ).executor(this).build();
+        ).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/afk/commands/AFKCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/afk/commands/AFKCommand.java
@@ -7,8 +7,8 @@ package io.github.nucleuspowered.nucleus.modules.afk.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.NameUtil;
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.afk.handlers.AFKHandler;
 import org.spongepowered.api.command.CommandResult;
@@ -23,13 +23,13 @@ import org.spongepowered.api.text.channel.MessageChannel;
 @NoWarmup
 @NoCost
 @RunAsync
-public class AFKCommand extends CommandBase<Player> {
+public class AFKCommand extends OldCommandBase<Player> {
 
     @Inject private AFKHandler afkHandler;
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).build();
+        return getSpecBuilderBase().build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/afk/listeners/AFKListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/afk/listeners/AFKListener.java
@@ -36,7 +36,7 @@ public class AFKListener extends ListenerBase {
 
     private CommandPermissionHandler getPermissionUtil() {
         if (s == null) {
-            s = permissionRegistry.getService(AFKCommand.class).orElseGet(() -> new CommandPermissionHandler(new AFKCommand()));
+            s = permissionRegistry.getService(AFKCommand.class).orElseGet(() -> new CommandPermissionHandler(new AFKCommand(), plugin));
         }
 
         return s;

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/BanCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/BanCommand.java
@@ -6,9 +6,9 @@ package io.github.nucleuspowered.nucleus.modules.ban.commands;
 
 import com.google.common.collect.Maps;
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.PermissionRegistry;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.Sponge;
@@ -32,7 +32,7 @@ import java.util.Map;
 @NoWarmup
 @NoCooldown
 @NoCost
-public class BanCommand extends CommandBase<CommandSource> {
+public class BanCommand extends OldCommandBase<CommandSource> {
 
     public static final String notifyPermission = PermissionRegistry.PERMISSIONS_PREFIX + "ban.notify";
     private final String user = "user";
@@ -47,8 +47,8 @@ public class BanCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(GenericArguments.onlyOne(GenericArguments.user(Text.of(user))),
-                GenericArguments.optionalWeak(GenericArguments.remainingJoinedStrings(Text.of(reason)))).executor(this).build();
+        return getSpecBuilderBase().arguments(GenericArguments.onlyOne(GenericArguments.user(Text.of(user))),
+                GenericArguments.optionalWeak(GenericArguments.remainingJoinedStrings(Text.of(reason)))).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/CheckBanCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/CheckBanCommand.java
@@ -5,8 +5,8 @@
 package io.github.nucleuspowered.nucleus.modules.ban.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
@@ -27,13 +27,13 @@ import java.util.Optional;
 @NoCooldown
 @NoCost
 @RunAsync
-public class CheckBanCommand extends CommandBase<CommandSource> {
+public class CheckBanCommand extends OldCommandBase<CommandSource> {
 
     private final String key = "player";
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(GenericArguments.onlyOne(GenericArguments.user(Text.of(key)))).executor(this).build();
+        return getSpecBuilderBase().arguments(GenericArguments.onlyOne(GenericArguments.user(Text.of(key)))).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/TempBanCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/TempBanCommand.java
@@ -6,8 +6,8 @@ package io.github.nucleuspowered.nucleus.modules.ban.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.TimespanParser;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
@@ -31,7 +31,7 @@ import java.time.temporal.ChronoUnit;
 @NoWarmup
 @NoCooldown
 @NoCost
-public class TempBanCommand extends CommandBase<CommandSource> {
+public class TempBanCommand extends OldCommandBase<CommandSource> {
 
     private final String user = "user";
     private final String reason = "reason";
@@ -39,10 +39,10 @@ public class TempBanCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder()
+        return getSpecBuilderBase()
                 .arguments(GenericArguments.onlyOne(GenericArguments.user(Text.of(user))), GenericArguments.onlyOne(new TimespanParser(Text.of(duration))),
                         GenericArguments.optionalWeak(GenericArguments.remainingJoinedStrings(Text.of(reason))))
-                .executor(this).build();
+                .build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/UnbanCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/UnbanCommand.java
@@ -5,8 +5,8 @@
 package io.github.nucleuspowered.nucleus.modules.ban.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
@@ -28,13 +28,13 @@ import java.util.Optional;
 @NoWarmup
 @NoCooldown
 @NoCost
-public class UnbanCommand extends CommandBase<CommandSource> {
+public class UnbanCommand extends OldCommandBase<CommandSource> {
 
     private final String key = "player";
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(GenericArguments.onlyOne(GenericArguments.user(Text.of(key)))).executor(this).build();
+        return getSpecBuilderBase().arguments(GenericArguments.onlyOne(GenericArguments.user(Text.of(key)))).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/NucleusCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/NucleusCommand.java
@@ -5,10 +5,8 @@
 package io.github.nucleuspowered.nucleus.modules.core.commands;
 
 import com.google.inject.Inject;
-import io.github.nucleuspowered.nucleus.api.service.NucleusModuleService;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
-import org.spongepowered.api.Sponge;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
@@ -33,7 +31,7 @@ import static io.github.nucleuspowered.nucleus.PluginInfo.*;
 @NoCooldown
 @NoCost
 @RegisterCommand({ "nucleus" })
-public class NucleusCommand extends CommandBase<CommandSource> {
+public class NucleusCommand extends OldCommandBase<CommandSource> {
 
     @Inject private ModuleContainer container;
 
@@ -42,7 +40,7 @@ public class NucleusCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().children(this.createChildCommands()).executor(this).build();
+        return getSpecBuilderBase().children(this.createChildCommands()).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/ReloadCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/ReloadCommand.java
@@ -5,8 +5,8 @@
 package io.github.nucleuspowered.nucleus.modules.core.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
@@ -18,11 +18,11 @@ import org.spongepowered.api.command.spec.CommandSpec;
 @NoWarmup
 @RunAsync
 @RegisterCommand(value = "reload", subcommandOf = NucleusCommand.class)
-public class ReloadCommand extends CommandBase<CommandSource> {
+public class ReloadCommand extends OldCommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).build();
+        return getSpecBuilderBase().build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/ResetUserCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/ResetUserCommand.java
@@ -7,8 +7,8 @@ package io.github.nucleuspowered.nucleus.modules.core.commands;
 import io.github.nucleuspowered.nucleus.Nucleus;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.config.loaders.UserConfigLoader;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
@@ -39,13 +39,13 @@ import java.util.function.Consumer;
 @NoCooldown
 @NoCost
 @RegisterCommand(value = "resetuser", subcommandOf = NucleusCommand.class)
-public class ResetUserCommand extends CommandBase<CommandSource> {
+public class ResetUserCommand extends OldCommandBase<CommandSource> {
 
     private final String userKey = "user";
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(GenericArguments.user(Text.of(userKey))).executor(this).build();
+        return getSpecBuilderBase().arguments(GenericArguments.user(Text.of(userKey))).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/SaveCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/SaveCommand.java
@@ -5,8 +5,8 @@
 package io.github.nucleuspowered.nucleus.modules.core.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
@@ -23,11 +23,11 @@ import org.spongepowered.api.command.spec.CommandSpec;
 @NoWarmup
 @Permissions(root = "nucleus")
 @RegisterCommand(value = "save", subcommandOf = NucleusCommand.class)
-public class SaveCommand extends CommandBase<CommandSource> {
+public class SaveCommand extends OldCommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).build();
+        return getSpecBuilderBase().build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/SuggestedPermissionsCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/SuggestedPermissionsCommand.java
@@ -5,10 +5,10 @@
 package io.github.nucleuspowered.nucleus.modules.core.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.command.CommandResult;
@@ -27,13 +27,13 @@ import java.util.stream.Collectors;
 @RunAsync
 @Permissions(root = "nucleus")
 @RegisterCommand(value = "printperms", subcommandOf = NucleusCommand.class)
-public class SuggestedPermissionsCommand extends CommandBase<CommandSource> {
+public class SuggestedPermissionsCommand extends OldCommandBase<CommandSource> {
 
     private final String file = "nucleus-perms.txt";
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).build();
+        return getSpecBuilderBase().build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/environment/commands/LockWeatherCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/environment/commands/LockWeatherCommand.java
@@ -8,8 +8,8 @@ import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.NucleusWorld;
 import io.github.nucleuspowered.nucleus.config.loaders.WorldConfigLoader;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
@@ -31,7 +31,7 @@ import java.util.Optional;
 @NoWarmup
 @NoCooldown
 @NoCost
-public class LockWeatherCommand extends CommandBase<CommandSource> {
+public class LockWeatherCommand extends OldCommandBase<CommandSource> {
 
     @Inject private WorldConfigLoader loader;
 
@@ -40,10 +40,10 @@ public class LockWeatherCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(
+        return getSpecBuilderBase().arguments(
                 GenericArguments.onlyOne(GenericArguments.optionalWeak(GenericArguments.world(Text.of(worldKey)))),
                 GenericArguments.onlyOne(GenericArguments.optional(GenericArguments.bool(Text.of(toggleKey))))
-        ).executor(this).build();
+        ).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/environment/commands/SetTimeCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/environment/commands/SetTimeCommand.java
@@ -6,9 +6,9 @@ package io.github.nucleuspowered.nucleus.modules.environment.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.WorldTimeParser;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
@@ -19,13 +19,13 @@ import org.spongepowered.api.world.storage.WorldProperties;
 
 @Permissions(root = "time")
 @RegisterCommand(value = "set", subcommandOf = TimeCommand.class)
-public class SetTimeCommand extends CommandBase<CommandSource> {
+public class SetTimeCommand extends OldCommandBase<CommandSource> {
     private final String time = "time";
     private final String world = "world";
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).description(Text.of("Sets the time")).arguments(
+        return getSpecBuilderBase().description(Text.of("Sets the time")).arguments(
                 GenericArguments.optionalWeak(GenericArguments.onlyOne(GenericArguments.world(Text.of(world)))),
                 GenericArguments.onlyOne(new WorldTimeParser(Text.of(time)))
         ).build();

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/environment/commands/SetTimeCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/environment/commands/SetTimeCommand.java
@@ -8,27 +8,27 @@ import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.WorldTimeParser;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
-import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
+import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
 import org.spongepowered.api.command.args.GenericArguments;
-import org.spongepowered.api.command.spec.CommandSpec;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.world.storage.WorldProperties;
 
 @Permissions(root = "time")
 @RegisterCommand(value = "set", subcommandOf = TimeCommand.class)
-public class SetTimeCommand extends OldCommandBase<CommandSource> {
+public class SetTimeCommand extends CommandBase<CommandSource> {
     private final String time = "time";
     private final String world = "world";
 
     @Override
-    public CommandSpec createSpec() {
-        return getSpecBuilderBase().description(Text.of("Sets the time")).arguments(
-                GenericArguments.optionalWeak(GenericArguments.onlyOne(GenericArguments.world(Text.of(world)))),
-                GenericArguments.onlyOne(new WorldTimeParser(Text.of(time)))
-        ).build();
+    public CommandElement[] getArguments() {
+        return new CommandElement[] {
+            GenericArguments.optionalWeak(GenericArguments.onlyOne(GenericArguments.world(Text.of(world)))),
+            GenericArguments.onlyOne(new WorldTimeParser(Text.of(time)))
+        };
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/environment/commands/TimeCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/environment/commands/TimeCommand.java
@@ -5,21 +5,17 @@
 package io.github.nucleuspowered.nucleus.modules.environment.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
-import org.spongepowered.api.command.CommandCallable;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
 import org.spongepowered.api.command.args.GenericArguments;
-import org.spongepowered.api.command.spec.CommandSpec;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.world.storage.WorldProperties;
-
-import java.util.List;
-import java.util.Map;
 
 @Permissions(suggestedLevel = SuggestedLevel.USER)
 @RegisterCommand("time")
@@ -28,10 +24,8 @@ public class TimeCommand extends CommandBase<CommandSource> {
     private final String world = "world";
 
     @Override
-    public CommandSpec createSpec() {
-        Map<List<String>, CommandCallable> ms = this.createChildCommands(SetTimeCommand.class);
-        return CommandSpec.builder().executor(this)
-                .arguments(GenericArguments.optionalWeak(GenericArguments.onlyOne(GenericArguments.world(Text.of(world))))).children(ms).build();
+    public CommandElement[] getArguments() {
+        return new CommandElement[] { GenericArguments.optionalWeak(GenericArguments.onlyOne(GenericArguments.world(Text.of(world)))) };
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/environment/commands/WeatherCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/environment/commands/WeatherCommand.java
@@ -10,9 +10,9 @@ import io.github.nucleuspowered.nucleus.api.data.NucleusWorld;
 import io.github.nucleuspowered.nucleus.argumentparsers.TimespanParser;
 import io.github.nucleuspowered.nucleus.argumentparsers.WeatherParser;
 import io.github.nucleuspowered.nucleus.config.loaders.WorldConfigLoader;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
@@ -29,7 +29,7 @@ import java.util.Optional;
 
 @Permissions
 @RegisterCommand("weather")
-public class WeatherCommand extends CommandBase<CommandSource> {
+public class WeatherCommand extends OldCommandBase<CommandSource> {
     private final String world = "world";
     private final String weather = "weather";
     private final String duration = "duration";
@@ -39,7 +39,7 @@ public class WeatherCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).arguments(
+        return getSpecBuilderBase().arguments(
                 GenericArguments.optionalWeak(GenericArguments.onlyOne(GenericArguments.world(Text.of(world)))),
                 GenericArguments.onlyOne(new WeatherParser(Text.of(weather))), // More flexible with the arguments we can use.
                 GenericArguments.firstParsing(

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/fun/commands/HatCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/fun/commands/HatCommand.java
@@ -5,8 +5,8 @@
 package io.github.nucleuspowered.nucleus.modules.fun.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.command.CommandResult;
@@ -28,7 +28,7 @@ import java.util.Optional;
 @NoWarmup
 @NoCost
 @Permissions
-public class HatCommand extends CommandBase<Player> {
+public class HatCommand extends OldCommandBase<Player> {
 
     private final String player = "player";
 
@@ -41,7 +41,7 @@ public class HatCommand extends CommandBase<Player> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).arguments(GenericArguments.optional(GenericArguments.requiringPermission(
+        return getSpecBuilderBase().arguments(GenericArguments.optional(GenericArguments.requiringPermission(
                 GenericArguments.onlyOne(GenericArguments.player(Text.of(player))), permissions.getPermissionWithSuffix("others")))).build();
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/fun/commands/IgniteCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/fun/commands/IgniteCommand.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.fun.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.command.CommandResult;
@@ -24,7 +24,7 @@ import java.util.Optional;
 
 @Permissions
 @RegisterCommand({"ignite", "burn"})
-public class IgniteCommand extends CommandBase<Player> {
+public class IgniteCommand extends OldCommandBase<Player> {
 
     private final String player = "player";
     private final String ticks = "ticks";
@@ -38,7 +38,7 @@ public class IgniteCommand extends CommandBase<Player> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this)
+        return getSpecBuilderBase()
                 .arguments(GenericArguments.seq(
                         GenericArguments.optionalWeak(GenericArguments.requiringPermission(
                                 GenericArguments.onlyOne(GenericArguments.player(Text.of(player))), permissions.getPermissionWithSuffix("others"))),

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/fun/commands/LightningCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/fun/commands/LightningCommand.java
@@ -5,12 +5,11 @@
 package io.github.nucleuspowered.nucleus.modules.fun.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
-import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
@@ -33,7 +32,7 @@ import java.util.Optional;
 
 @Permissions
 @RegisterCommand({"lightning", "smite", "thor"})
-public class LightningCommand extends CommandBase<CommandSource> {
+public class LightningCommand extends OldCommandBase<CommandSource> {
 
     private final String player = "player";
 
@@ -46,7 +45,7 @@ public class LightningCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).arguments(GenericArguments.optional(GenericArguments.requiringPermission(
+        return getSpecBuilderBase().arguments(GenericArguments.optional(GenericArguments.requiringPermission(
                 GenericArguments.onlyOne(GenericArguments.player(Text.of(player))), permissions.getPermissionWithSuffix("others")))).build();
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/home/commands/DeleteHomeCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/home/commands/DeleteHomeCommand.java
@@ -8,8 +8,8 @@ import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.WarpLocation;
 import io.github.nucleuspowered.nucleus.argumentparsers.HomeParser;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.core.config.CoreConfigAdapter;
 import org.spongepowered.api.command.CommandResult;
@@ -25,7 +25,7 @@ import org.spongepowered.api.text.Text;
 @NoCost
 @NoWarmup
 @RegisterCommand({"deletehome", "delhome"})
-public class DeleteHomeCommand extends CommandBase<Player> {
+public class DeleteHomeCommand extends OldCommandBase<Player> {
 
     private final String homeKey = "home";
 
@@ -33,7 +33,7 @@ public class DeleteHomeCommand extends CommandBase<Player> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(GenericArguments.onlyOne(new HomeParser(Text.of(homeKey), plugin, cca))).executor(this).build();
+        return getSpecBuilderBase().arguments(GenericArguments.onlyOne(new HomeParser(Text.of(homeKey), plugin, cca))).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/home/commands/DeleteOtherHomeCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/home/commands/DeleteOtherHomeCommand.java
@@ -7,8 +7,8 @@ package io.github.nucleuspowered.nucleus.modules.home.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.HomeOtherParser;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.modules.core.config.CoreConfigAdapter;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
@@ -23,7 +23,7 @@ import org.spongepowered.api.text.Text;
 @NoCost
 @NoWarmup
 @RegisterCommand({"deletehomeother", "delhomeother"})
-public class DeleteOtherHomeCommand extends CommandBase<CommandSource> {
+public class DeleteOtherHomeCommand extends OldCommandBase<CommandSource> {
 
     private final String homeKey = "home";
 
@@ -31,7 +31,7 @@ public class DeleteOtherHomeCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(GenericArguments.onlyOne(new HomeOtherParser(Text.of(homeKey), plugin, cca))).executor(this).build();
+        return getSpecBuilderBase().arguments(GenericArguments.onlyOne(new HomeOtherParser(Text.of(homeKey), plugin, cca))).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/home/commands/HomeCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/home/commands/HomeCommand.java
@@ -8,9 +8,9 @@ import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.WarpLocation;
 import io.github.nucleuspowered.nucleus.argumentparsers.HomeParser;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.core.config.CoreConfigAdapter;
 import org.spongepowered.api.command.CommandResult;
@@ -24,7 +24,7 @@ import java.util.Optional;
 
 @Permissions(suggestedLevel = SuggestedLevel.USER)
 @RegisterCommand("home")
-public class HomeCommand extends CommandBase<Player> {
+public class HomeCommand extends OldCommandBase<Player> {
 
     private final String home = "home";
 
@@ -32,7 +32,7 @@ public class HomeCommand extends CommandBase<Player> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this)
+        return getSpecBuilderBase()
                 .arguments(GenericArguments.onlyOne(GenericArguments.optional(new HomeParser(Text.of(home), plugin, cca)))).build();
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/home/commands/HomeOtherCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/home/commands/HomeOtherCommand.java
@@ -7,9 +7,9 @@ package io.github.nucleuspowered.nucleus.modules.home.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.HomeOtherParser;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.core.config.CoreConfigAdapter;
 import org.spongepowered.api.command.CommandResult;
@@ -21,7 +21,7 @@ import org.spongepowered.api.text.Text;
 
 @Permissions(root = "home", alias = "other", suggestedLevel = SuggestedLevel.MOD)
 @RegisterCommand("homeother")
-public class HomeOtherCommand extends CommandBase<Player> {
+public class HomeOtherCommand extends OldCommandBase<Player> {
 
     private final String home = "home";
 
@@ -29,7 +29,7 @@ public class HomeOtherCommand extends CommandBase<Player> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).arguments(GenericArguments.onlyOne(new HomeOtherParser(Text.of(home), plugin, cca))).build();
+        return getSpecBuilderBase().arguments(GenericArguments.onlyOne(new HomeOtherParser(Text.of(home), plugin, cca))).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/home/commands/ListHomeCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/home/commands/ListHomeCommand.java
@@ -6,8 +6,8 @@ package io.github.nucleuspowered.nucleus.modules.home.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.WarpLocation;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.Sponge;
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 @NoWarmup
 @NoCost
 @RegisterCommand({"listhomes", "homes"})
-public class ListHomeCommand extends CommandBase<CommandSource> {
+public class ListHomeCommand extends OldCommandBase<CommandSource> {
 
     private final String player = "player";
 
@@ -51,10 +51,10 @@ public class ListHomeCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder()
+        return getSpecBuilderBase()
                 .arguments(GenericArguments.optional(GenericArguments.onlyOne(
                         GenericArguments.requiringPermission(GenericArguments.user(Text.of(player)), permissions.getPermissionWithSuffix("others")))))
-                .executor(this).build();
+                .build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/home/commands/SetHomeCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/home/commands/SetHomeCommand.java
@@ -6,10 +6,10 @@ package io.github.nucleuspowered.nucleus.modules.home.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.WarpLocation;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.interfaces.InternalNucleusUser;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
@@ -28,15 +28,15 @@ import java.util.regex.Pattern;
 @Permissions(root = "home", alias = "set", suggestedLevel = SuggestedLevel.USER)
 @RunAsync
 @RegisterCommand({"homeset", "sethome"})
-public class SetHomeCommand extends CommandBase<Player> {
+public class SetHomeCommand extends OldCommandBase<Player> {
 
     private final String homeKey = "home";
     private final Pattern warpName = Pattern.compile("^[a-zA-Z][a-zA-Z0-9]{1,15}$");
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(GenericArguments.onlyOne(GenericArguments.optional(GenericArguments.string(Text.of(homeKey)))))
-                .executor(this).build();
+        return getSpecBuilderBase().arguments(GenericArguments.onlyOne(GenericArguments.optional(GenericArguments.string(Text.of(homeKey)))))
+                .build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/ignore/commands/IgnoreCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/ignore/commands/IgnoreCommand.java
@@ -8,8 +8,8 @@ import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.config.loaders.UserConfigLoader;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.interfaces.InternalNucleusUser;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
@@ -29,7 +29,7 @@ import java.util.Map;
 @NoWarmup
 @RegisterCommand("ignore")
 @Permissions(suggestedLevel = SuggestedLevel.USER)
-public class IgnoreCommand extends CommandBase<Player> {
+public class IgnoreCommand extends OldCommandBase<Player> {
 
     @Inject private UserConfigLoader loader;
 
@@ -45,10 +45,10 @@ public class IgnoreCommand extends CommandBase<Player> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(
+        return getSpecBuilderBase().arguments(
                 GenericArguments.onlyOne(GenericArguments.user(Text.of(userKey))),
                 GenericArguments.optional(GenericArguments.onlyOne(GenericArguments.bool(Text.of(toggleKey))))
-        ).executor(this).build();
+        ).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/item/commands/GiveCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/item/commands/GiveCommand.java
@@ -4,9 +4,9 @@
  */
 package io.github.nucleuspowered.nucleus.modules.item.commands;
 
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
@@ -14,7 +14,7 @@ import org.spongepowered.api.command.spec.CommandSpec;
 
 @Permissions
 @RegisterCommand({"give"})
-public class GiveCommand extends CommandBase<CommandSource> {
+public class GiveCommand extends OldCommandBase<CommandSource> {
     @Override
     public CommandSpec createSpec() {
         return null;

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/item/commands/MoreCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/item/commands/MoreCommand.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.item.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.spec.CommandSpec;
@@ -16,11 +16,11 @@ import org.spongepowered.api.item.inventory.ItemStack;
 
 @Permissions
 @RegisterCommand({"more", "stack"})
-public class MoreCommand extends CommandBase<Player> {
+public class MoreCommand extends OldCommandBase<Player> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).build();
+        return getSpecBuilderBase().build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/item/commands/RepairCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/item/commands/RepairCommand.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.item.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.command.CommandResult;
@@ -28,7 +28,7 @@ import java.util.Optional;
 
 @Permissions
 @RegisterCommand({"repair", "mend"})
-public class RepairCommand extends CommandBase<CommandSource> {
+public class RepairCommand extends OldCommandBase<CommandSource> {
 
     private final String player = "player";
 
@@ -41,7 +41,7 @@ public class RepairCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).arguments(GenericArguments.optional(GenericArguments.requiringPermission(
+        return getSpecBuilderBase().arguments(GenericArguments.optional(GenericArguments.requiringPermission(
                 GenericArguments.onlyOne(GenericArguments.player(Text.of(player))), permissions.getPermissionWithSuffix("others")))).build();
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/commands/CheckJailCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/commands/CheckJailCommand.java
@@ -7,8 +7,8 @@ package io.github.nucleuspowered.nucleus.modules.jail.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.JailData;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.jail.handlers.JailHandler;
 import org.spongepowered.api.Sponge;
@@ -33,14 +33,14 @@ import java.util.Optional;
 @NoCooldown
 @NoCost
 @RegisterCommand({"checkjail"})
-public class CheckJailCommand extends CommandBase<CommandSource> {
+public class CheckJailCommand extends OldCommandBase<CommandSource> {
 
     private final String playerKey = "playerKey";
     @Inject private JailHandler handler;
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).arguments(GenericArguments.onlyOne(GenericArguments.user(Text.of(playerKey)))).build();
+        return getSpecBuilderBase().arguments(GenericArguments.onlyOne(GenericArguments.user(Text.of(playerKey)))).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/commands/DeleteJailCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/commands/DeleteJailCommand.java
@@ -8,8 +8,8 @@ import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.WarpLocation;
 import io.github.nucleuspowered.nucleus.argumentparsers.JailParser;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.modules.jail.handlers.JailHandler;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
@@ -24,14 +24,14 @@ import org.spongepowered.api.text.Text;
 @NoCooldown
 @NoCost
 @RegisterCommand(value = {"delete", "del", "remove"}, subcommandOf = JailsCommand.class)
-public class DeleteJailCommand extends CommandBase<CommandSource> {
+public class DeleteJailCommand extends OldCommandBase<CommandSource> {
 
     @Inject private JailHandler handler;
     private final String jailKey = "jail";
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).arguments(GenericArguments.onlyOne(new JailParser(Text.of(jailKey), handler))).build();
+        return getSpecBuilderBase().arguments(GenericArguments.onlyOne(new JailParser(Text.of(jailKey), handler))).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/commands/JailCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/commands/JailCommand.java
@@ -10,9 +10,9 @@ import io.github.nucleuspowered.nucleus.api.data.JailData;
 import io.github.nucleuspowered.nucleus.api.data.WarpLocation;
 import io.github.nucleuspowered.nucleus.argumentparsers.JailParser;
 import io.github.nucleuspowered.nucleus.argumentparsers.TimespanParser;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.PermissionRegistry;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.jail.handlers.JailHandler;
@@ -39,7 +39,7 @@ import java.util.Optional;
 @NoCooldown
 @NoCost
 @RegisterCommand({"jail", "unjail", "togglejail"})
-public class JailCommand extends CommandBase<CommandSource> {
+public class JailCommand extends OldCommandBase<CommandSource> {
 
     public static final String notifyPermission = PermissionRegistry.PERMISSIONS_PREFIX + "jail.notify";
 
@@ -58,7 +58,7 @@ public class JailCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this)
+        return getSpecBuilderBase()
                 .arguments(GenericArguments.onlyOne(GenericArguments.user(Text.of(playerKey))),
                         GenericArguments.optional(GenericArguments.onlyOne(new JailParser(Text.of(jailKey), handler))),
                         GenericArguments.optionalWeak(GenericArguments.onlyOne(new TimespanParser(Text.of(durationKey)))),

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/commands/JailInfoCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/commands/JailInfoCommand.java
@@ -8,8 +8,8 @@ import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.WarpLocation;
 import io.github.nucleuspowered.nucleus.argumentparsers.JailParser;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.jail.handlers.JailHandler;
 import org.spongepowered.api.command.CommandResult;
@@ -26,14 +26,14 @@ import org.spongepowered.api.text.format.TextColors;
 @Permissions(root = "jail", suggestedLevel = SuggestedLevel.MOD)
 @RunAsync
 @RegisterCommand(value = "jails", subcommandOf = JailsCommand.class)
-public class JailInfoCommand extends CommandBase<CommandSource> {
+public class JailInfoCommand extends OldCommandBase<CommandSource> {
 
     private final String jailKey = "jail";
     @Inject private JailHandler handler;
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(GenericArguments.onlyOne(new JailParser(Text.of(jailKey), handler))).executor(this).build();
+        return getSpecBuilderBase().arguments(GenericArguments.onlyOne(new JailParser(Text.of(jailKey), handler))).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/commands/JailsCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/commands/JailsCommand.java
@@ -7,8 +7,8 @@ package io.github.nucleuspowered.nucleus.modules.jail.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.WarpLocation;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.jail.handlers.JailHandler;
 import org.spongepowered.api.Sponge;
@@ -32,13 +32,13 @@ import java.util.stream.Collectors;
 @RunAsync
 @RegisterCommand("jails")
 @Permissions(root = "jail", alias = "list", suggestedLevel = SuggestedLevel.MOD)
-public class JailsCommand extends CommandBase<CommandSource> {
+public class JailsCommand extends OldCommandBase<CommandSource> {
 
     @Inject private JailHandler handler;
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).children(this.createChildCommands()).build();
+        return getSpecBuilderBase().children(this.createChildCommands()).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/commands/SetJailCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/commands/SetJailCommand.java
@@ -6,8 +6,8 @@ package io.github.nucleuspowered.nucleus.modules.jail.commands;
 
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.modules.jail.handlers.JailHandler;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
@@ -22,14 +22,14 @@ import org.spongepowered.api.text.Text;
 @NoCooldown
 @NoCost
 @RegisterCommand(value = "set", subcommandOf = JailsCommand.class)
-public class SetJailCommand extends CommandBase<Player> {
+public class SetJailCommand extends OldCommandBase<Player> {
 
     private final String jailName = "jail";
     @Inject private JailHandler handler;
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(GenericArguments.onlyOne(GenericArguments.string(Text.of(jailName)))).executor(this).build();
+        return getSpecBuilderBase().arguments(GenericArguments.onlyOne(GenericArguments.string(Text.of(jailName)))).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/jump/commands/JumpCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/jump/commands/JumpCommand.java
@@ -6,9 +6,9 @@ package io.github.nucleuspowered.nucleus.modules.jump.commands;
 
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.modules.jump.config.JumpConfigAdapter;
 import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.command.CommandResult;
@@ -24,13 +24,13 @@ import org.spongepowered.api.world.World;
 
 @Permissions
 @RegisterCommand({"jump", "j", "jmp"})
-public class JumpCommand extends CommandBase<Player> {
+public class JumpCommand extends OldCommandBase<Player> {
 
     @Inject private JumpConfigAdapter jca;
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).build();
+        return getSpecBuilderBase().build();
     }
 
     // Original code taken from EssentialCmds. With thanks to 12AwsomeMan34 for the initial contribution.

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/jump/commands/ThruCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/jump/commands/ThruCommand.java
@@ -6,9 +6,9 @@ package io.github.nucleuspowered.nucleus.modules.jump.commands;
 
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.modules.jump.config.JumpConfigAdapter;
 import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.command.CommandResult;
@@ -21,13 +21,13 @@ import org.spongepowered.api.world.World;
 
 @Permissions
 @RegisterCommand({"thru", "through"})
-public class ThruCommand extends CommandBase<Player> {
+public class ThruCommand extends OldCommandBase<Player> {
 
     @Inject private JumpConfigAdapter jca;
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).build();
+        return getSpecBuilderBase().build();
     }
 
     // Original code taken from EssentialCmds. With thanks to 12AwsomeMan34 for the initial contribution.

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/kick/commands/KickAllCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/kick/commands/KickAllCommand.java
@@ -5,8 +5,8 @@
 package io.github.nucleuspowered.nucleus.modules.kick.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.Sponge;
@@ -33,13 +33,13 @@ import java.util.Map;
 @NoCooldown
 @NoCost
 @RegisterCommand("kickall")
-public class KickAllCommand extends CommandBase<CommandSource> {
+public class KickAllCommand extends OldCommandBase<CommandSource> {
 
     private final String reason = "reason";
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().description(Text.of("Kicks all players.")).executor(this)
+        return getSpecBuilderBase().description(Text.of("Kicks all players."))
                 .arguments(
                         GenericArguments.requiringPermission(GenericArguments.flags().flag("f").buildWith(GenericArguments.none()),
                                 permissions.getPermissionWithSuffix("whitelist")),

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/kick/commands/KickCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/kick/commands/KickCommand.java
@@ -5,8 +5,8 @@
 package io.github.nucleuspowered.nucleus.modules.kick.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.command.CommandResult;
@@ -31,14 +31,14 @@ import java.util.Map;
 @NoCooldown
 @NoCost
 @RegisterCommand("kick")
-public class KickCommand extends CommandBase<CommandSource> {
+public class KickCommand extends OldCommandBase<CommandSource> {
 
     private final String player = "player";
     private final String reason = "reason";
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().description(Text.of("Kicks a player.")).executor(this)
+        return getSpecBuilderBase().description(Text.of("Kicks a player."))
                 .arguments(GenericArguments.onlyOne(GenericArguments.player(Text.of(player))),
                         GenericArguments.optional(GenericArguments.onlyOne(GenericArguments.remainingJoinedStrings(Text.of(reason)))))
                 .build();

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/kit/commands/KitAddCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/kit/commands/KitAddCommand.java
@@ -6,8 +6,8 @@ package io.github.nucleuspowered.nucleus.modules.kit.commands;
 
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.kit.handlers.KitHandler;
 import org.spongepowered.api.command.CommandResult;
@@ -27,7 +27,7 @@ import org.spongepowered.api.text.Text;
 @NoWarmup
 @NoCooldown
 @NoCost
-public class KitAddCommand extends CommandBase<Player> {
+public class KitAddCommand extends OldCommandBase<Player> {
 
     @Inject private KitHandler kitConfig;
 
@@ -35,7 +35,7 @@ public class KitAddCommand extends CommandBase<Player> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).description(Text.of("Adds kit."))
+        return getSpecBuilderBase().description(Text.of("Adds kit."))
                 .arguments(GenericArguments.onlyOne(GenericArguments.string(Text.of(name)))).build();
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/kit/commands/KitCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/kit/commands/KitCommand.java
@@ -10,12 +10,12 @@ import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.Kit;
 import io.github.nucleuspowered.nucleus.argumentparsers.KitParser;
 import io.github.nucleuspowered.nucleus.config.loaders.UserConfigLoader;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.EconHelper;
 import io.github.nucleuspowered.nucleus.internal.PermissionRegistry;
 import io.github.nucleuspowered.nucleus.internal.annotations.NoCost;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.interfaces.InternalNucleusUser;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
@@ -42,7 +42,7 @@ import java.util.Map;
 @Permissions(suggestedLevel = SuggestedLevel.ADMIN)
 @RegisterCommand("kit")
 @NoCost // This is determined by the kit itself.
-public class KitCommand extends CommandBase<Player> {
+public class KitCommand extends OldCommandBase<Player> {
 
     private final String kit = "kit";
 
@@ -53,7 +53,7 @@ public class KitCommand extends CommandBase<Player> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).children(this.createChildCommands())
+        return getSpecBuilderBase().children(this.createChildCommands())
                 .arguments(GenericArguments.onlyOne(new KitParser(Text.of(kit), kca, kitConfig, true))).build();
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/kit/commands/KitCostCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/kit/commands/KitCostCommand.java
@@ -8,8 +8,8 @@ import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.KitParser;
 import io.github.nucleuspowered.nucleus.config.loaders.UserConfigLoader;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.kit.config.KitConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.kit.handlers.KitHandler;
@@ -32,7 +32,7 @@ import org.spongepowered.api.text.Text;
 @NoWarmup
 @NoCooldown
 @NoCost
-public class KitCostCommand extends CommandBase<CommandSource> {
+public class KitCostCommand extends OldCommandBase<CommandSource> {
 
     @Inject private KitHandler kitConfig;
     @Inject private UserConfigLoader userConfigLoader;
@@ -43,10 +43,10 @@ public class KitCostCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(
+        return getSpecBuilderBase().arguments(
                 GenericArguments.onlyOne(new KitParser(Text.of(kitKey), kca, kitConfig, false)),
                 GenericArguments.onlyOne(GenericArguments.doubleNum(Text.of(costKey)))
-        ).executor(this).build();
+        ).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/kit/commands/KitListCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/kit/commands/KitListCommand.java
@@ -7,8 +7,8 @@ package io.github.nucleuspowered.nucleus.modules.kit.commands;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.kit.handlers.KitHandler;
 import org.spongepowered.api.Sponge;
@@ -36,13 +36,13 @@ import java.util.ArrayList;
 @NoWarmup
 @NoCooldown
 @NoCost
-public class KitListCommand extends CommandBase<CommandSource> {
+public class KitListCommand extends OldCommandBase<CommandSource> {
 
     @Inject private KitHandler kitConfig;
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).description(Text.of("Lists kits.")).build();
+        return getSpecBuilderBase().description(Text.of("Lists kits.")).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/kit/commands/KitRemoveCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/kit/commands/KitRemoveCommand.java
@@ -7,8 +7,8 @@ package io.github.nucleuspowered.nucleus.modules.kit.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.KitParser;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.kit.config.KitConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.kit.handlers.KitHandler;
@@ -30,7 +30,7 @@ import org.spongepowered.api.text.Text;
 @NoWarmup
 @NoCooldown
 @NoCost
-public class KitRemoveCommand extends CommandBase<CommandSource> {
+public class KitRemoveCommand extends OldCommandBase<CommandSource> {
 
     @Inject private KitHandler kitConfig;
     @Inject private KitConfigAdapter kca;
@@ -39,7 +39,7 @@ public class KitRemoveCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).description(Text.of("Removes kit."))
+        return getSpecBuilderBase().description(Text.of("Removes kit."))
                 .arguments(GenericArguments.onlyOne(new KitParser(Text.of(kit), kca, kitConfig, true))).build();
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/kit/commands/KitSetCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/kit/commands/KitSetCommand.java
@@ -7,8 +7,8 @@ package io.github.nucleuspowered.nucleus.modules.kit.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.KitParser;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.kit.config.KitConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.kit.handlers.KitHandler;
@@ -29,7 +29,7 @@ import org.spongepowered.api.text.Text;
 @NoWarmup
 @NoCooldown
 @NoCost
-public class KitSetCommand extends CommandBase<Player> {
+public class KitSetCommand extends OldCommandBase<Player> {
 
     @Inject private KitHandler kitConfig;
     @Inject private KitConfigAdapter kca;
@@ -38,7 +38,7 @@ public class KitSetCommand extends CommandBase<Player> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).description(Text.of("Sets kit items."))
+        return getSpecBuilderBase().description(Text.of("Sets kit items."))
                 .arguments(GenericArguments.onlyOne(new KitParser(Text.of(kit), kca, kitConfig, true))).build();
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/kit/commands/KitSetCooldownCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/kit/commands/KitSetCooldownCommand.java
@@ -8,8 +8,8 @@ import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.KitParser;
 import io.github.nucleuspowered.nucleus.argumentparsers.TimespanParser;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.kit.config.KitConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.kit.handlers.KitHandler;
@@ -33,7 +33,7 @@ import java.time.Duration;
 @NoWarmup
 @NoCooldown
 @NoCost
-public class KitSetCooldownCommand extends CommandBase<CommandSource> {
+public class KitSetCooldownCommand extends OldCommandBase<CommandSource> {
 
     @Inject private KitHandler kitConfig;
     @Inject private KitConfigAdapter kca;
@@ -43,7 +43,7 @@ public class KitSetCooldownCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).description(Text.of("Sets kit cooldown."))
+        return getSpecBuilderBase().description(Text.of("Sets kit cooldown."))
                 .arguments(GenericArguments.seq(GenericArguments.onlyOne(new KitParser(Text.of(kit), kca, kitConfig, true)),
                         GenericArguments.onlyOne(new TimespanParser(Text.of(duration)))))
                 .build();

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/mail/commands/ClearMailCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/mail/commands/ClearMailCommand.java
@@ -6,13 +6,12 @@ package io.github.nucleuspowered.nucleus.modules.mail.commands;
 
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.mail.handlers.MailHandler;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
-import org.spongepowered.api.command.spec.CommandSpec;
 import org.spongepowered.api.entity.living.player.Player;
 
 /**
@@ -28,11 +27,6 @@ import org.spongepowered.api.entity.living.player.Player;
 public class ClearMailCommand extends CommandBase<Player> {
 
     @Inject private MailHandler handler;
-
-    @Override
-    public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).build();
-    }
 
     @Override
     public CommandResult executeCommand(Player src, CommandContext args) throws Exception {

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/mail/commands/MailCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/mail/commands/MailCommand.java
@@ -10,15 +10,15 @@ import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.mail.MailData;
 import io.github.nucleuspowered.nucleus.api.data.mail.MailFilter;
 import io.github.nucleuspowered.nucleus.argumentparsers.MailFilterParser;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.mail.handlers.MailHandler;
 import org.spongepowered.api.Game;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
 import org.spongepowered.api.command.args.GenericArguments;
-import org.spongepowered.api.command.spec.CommandSpec;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.service.pagination.PaginationService;
 import org.spongepowered.api.text.Text;
@@ -41,13 +41,12 @@ import java.util.stream.Collectors;
 public class MailCommand extends CommandBase<Player> {
 
     @Inject private MailHandler handler;
-    private final String filters = "filters";
     @Inject private Game game;
+    private final String filters = "filters";
 
     @Override
-    public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).children(this.createChildCommands(ClearMailCommand.class, SendMailCommand.class))
-                .arguments(GenericArguments.optional(GenericArguments.allOf(new MailFilterParser(Text.of(filters), handler)))).build();
+    public CommandElement[] getArguments() {
+        return new CommandElement[] { GenericArguments.optional(GenericArguments.allOf(new MailFilterParser(Text.of(filters), handler))) };
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/mail/commands/SendMailCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/mail/commands/SendMailCommand.java
@@ -6,28 +6,25 @@ package io.github.nucleuspowered.nucleus.modules.mail.commands;
 
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.CommandPermissionHandler;
 import io.github.nucleuspowered.nucleus.internal.PermissionRegistry;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.mail.handlers.MailHandler;
 import org.spongepowered.api.command.CommandException;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
 import org.spongepowered.api.command.args.GenericArguments;
-import org.spongepowered.api.command.spec.CommandSpec;
 import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.text.Text;
 
 import java.util.Optional;
 
-/**
- * Permission - "quickstart.mail.send.use"
- */
 @Permissions(root = "mail", suggestedLevel = SuggestedLevel.USER)
 @RunAsync
 @RegisterCommand(value = {"send", "s"}, subcommandOf = MailCommand.class)
@@ -40,9 +37,11 @@ public class SendMailCommand extends CommandBase<CommandSource> {
     private final String message = "message";
 
     @Override
-    public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).arguments(GenericArguments.onlyOne(GenericArguments.user(Text.of(player))),
-                GenericArguments.onlyOne(GenericArguments.remainingJoinedStrings(Text.of(message)))).build();
+    public CommandElement[] getArguments() {
+        return new CommandElement[] {
+            GenericArguments.onlyOne(GenericArguments.user(Text.of(player))),
+            GenericArguments.onlyOne(GenericArguments.remainingJoinedStrings(Text.of(message)))
+        };
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/message/commands/HelpOpCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/message/commands/HelpOpCommand.java
@@ -7,10 +7,10 @@ package io.github.nucleuspowered.nucleus.modules.message.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.ChatUtil;
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.message.config.MessageConfigAdapter;
@@ -30,7 +30,7 @@ import java.util.Map;
 @RunAsync
 @Permissions(suggestedLevel = SuggestedLevel.USER)
 @RegisterCommand({"helpop"})
-public class HelpOpCommand extends CommandBase<Player> {
+public class HelpOpCommand extends OldCommandBase<Player> {
 
     private final String messageKey = "message";
 
@@ -39,7 +39,7 @@ public class HelpOpCommand extends CommandBase<Player> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(GenericArguments.remainingJoinedStrings(Text.of(messageKey))).executor(this).build();
+        return getSpecBuilderBase().arguments(GenericArguments.remainingJoinedStrings(Text.of(messageKey))).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/message/commands/MessageCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/message/commands/MessageCommand.java
@@ -6,10 +6,10 @@ package io.github.nucleuspowered.nucleus.modules.message.commands;
 
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.argumentparsers.PlayerConsoleArgument;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.message.handlers.MessageHandler;
 import org.spongepowered.api.command.CommandResult;
@@ -27,7 +27,7 @@ import org.spongepowered.api.text.Text;
 @Permissions(suggestedLevel = SuggestedLevel.USER)
 @RunAsync
 @RegisterCommand({ "message", "m", "msg", "whisper", "w", "tell", "t" })
-public class MessageCommand extends CommandBase<CommandSource> {
+public class MessageCommand extends OldCommandBase<CommandSource> {
     private final String to = "to";
     private final String message = "message";
 
@@ -35,7 +35,7 @@ public class MessageCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this)
+        return getSpecBuilderBase()
             .arguments(
                 new PlayerConsoleArgument(Text.of(to)),
                 GenericArguments.onlyOne(GenericArguments.remainingJoinedStrings(Text.of(message)))

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/message/commands/ReplyCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/message/commands/ReplyCommand.java
@@ -5,8 +5,11 @@
 package io.github.nucleuspowered.nucleus.modules.message.commands;
 
 import com.google.inject.Inject;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
-import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.annotations.ConfigCommandAlias;
+import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
+import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.message.handlers.MessageHandler;
 import org.spongepowered.api.command.CommandResult;
@@ -25,14 +28,14 @@ import org.spongepowered.api.text.Text;
 @RunAsync
 @ConfigCommandAlias(value = "message", generate = false)
 @RegisterCommand({"reply", "r"})
-public class ReplyCommand extends CommandBase<CommandSource> {
+public class ReplyCommand extends OldCommandBase<CommandSource> {
     private final String message = "message";
 
     @Inject private MessageHandler handler;
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this)
+        return getSpecBuilderBase()
             .arguments(
                     GenericArguments.onlyOne(GenericArguments.remainingJoinedStrings(Text.of(message)))
             ).description(Text.of("Send a message to the player you just sent a message to.")).build();

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/message/commands/SocialSpyCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/message/commands/SocialSpyCommand.java
@@ -8,8 +8,8 @@ import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.NucleusUser;
 import io.github.nucleuspowered.nucleus.config.loaders.UserConfigLoader;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
@@ -24,15 +24,15 @@ import org.spongepowered.api.text.Text;
 @NoCooldown
 @NoCost
 @RegisterCommand("socialspy")
-public class SocialSpyCommand extends CommandBase<Player> {
+public class SocialSpyCommand extends OldCommandBase<Player> {
 
     private final String arg = "Social Spy";
     @Inject private UserConfigLoader userConfigLoader;
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().description(Text.of("Sets whether the player can spy on messages."))
-                .arguments(GenericArguments.optional(GenericArguments.onlyOne(GenericArguments.bool(Text.of(arg))))).executor(this).build();
+        return getSpecBuilderBase().description(Text.of("Sets whether the player can spy on messages."))
+                .arguments(GenericArguments.optional(GenericArguments.onlyOne(GenericArguments.bool(Text.of(arg))))).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/BlockInfoCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/BlockInfoCommand.java
@@ -5,11 +5,11 @@
 package io.github.nucleuspowered.nucleus.modules.misc.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.DataScanner;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.Sponge;
@@ -35,13 +35,13 @@ import java.util.*;
 @Permissions
 @RegisterCommand({ "blockinfo" })
 @RunAsync
-public class BlockInfoCommand extends CommandBase<Player> {
+public class BlockInfoCommand extends OldCommandBase<Player> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(
+        return getSpecBuilderBase().arguments(
                 GenericArguments.flags().permissionFlag(permissions.getPermissionWithSuffix("extended"), "e", "-extended").buildWith(GenericArguments.none())
-        ).executor(this).build();
+        ).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/FeedCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/FeedCommand.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.misc.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.command.CommandResult;
@@ -15,7 +15,6 @@ import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.args.GenericArguments;
 import org.spongepowered.api.command.spec.CommandSpec;
-import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.mutable.entity.FoodData;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.entity.living.player.Player;
@@ -27,7 +26,7 @@ import java.util.Optional;
 
 @Permissions
 @RegisterCommand("feed")
-public class FeedCommand extends CommandBase<CommandSource> {
+public class FeedCommand extends OldCommandBase<CommandSource> {
 
     private static final String player = "player";
 
@@ -40,7 +39,7 @@ public class FeedCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).arguments(GenericArguments.optionalWeak(GenericArguments.onlyOne(
+        return getSpecBuilderBase().arguments(GenericArguments.optionalWeak(GenericArguments.onlyOne(
                 GenericArguments.requiringPermission(GenericArguments.player(Text.of(player)), permissions.getPermissionWithSuffix("others")))))
                 .build();
     }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/FlyCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/FlyCommand.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.misc.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.interfaces.InternalNucleusUser;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
@@ -25,7 +25,7 @@ import java.util.Optional;
 
 @Permissions
 @RegisterCommand("fly")
-public class FlyCommand extends CommandBase<CommandSource> {
+public class FlyCommand extends OldCommandBase<CommandSource> {
 
     private static final String player = "player";
     private static final String toggle = "toggle";
@@ -39,7 +39,7 @@ public class FlyCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this)
+        return getSpecBuilderBase()
                 .arguments(
                         GenericArguments.optionalWeak(GenericArguments.onlyOne(GenericArguments
                                 .requiringPermission(GenericArguments.player(Text.of(player)), permissions.getPermissionWithSuffix("others")))),

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/GodCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/GodCommand.java
@@ -5,8 +5,8 @@
 package io.github.nucleuspowered.nucleus.modules.misc.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.interfaces.InternalNucleusUser;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
@@ -27,7 +27,7 @@ import java.util.Optional;
 @NoWarmup
 @NoCost
 @RegisterCommand({"god", "invuln", "invulnerability"})
-public class GodCommand extends CommandBase<CommandSource> {
+public class GodCommand extends OldCommandBase<CommandSource> {
 
     private final String playerKey = "player";
     private final String invulnKey = "invuln";
@@ -41,7 +41,7 @@ public class GodCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this)
+        return getSpecBuilderBase()
                 .arguments(
                         GenericArguments.optionalWeak(GenericArguments.onlyOne(GenericArguments
                                 .requiringPermission(GenericArguments.player(Text.of(playerKey)), permissions.getPermissionWithSuffix("others")))),

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/HealCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/HealCommand.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.misc.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.command.CommandResult;
@@ -25,7 +25,7 @@ import java.util.Optional;
 
 @Permissions
 @RegisterCommand("heal")
-public class HealCommand extends CommandBase<CommandSource> {
+public class HealCommand extends OldCommandBase<CommandSource> {
 
     private static final String player = "player";
 
@@ -38,7 +38,7 @@ public class HealCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).arguments(GenericArguments.optional(GenericArguments.requiringPermission(
+        return getSpecBuilderBase().arguments(GenericArguments.optional(GenericArguments.requiringPermission(
                 GenericArguments.onlyOne(GenericArguments.player(Text.of(player))), permissions.getPermissionWithSuffix("others")))).build();
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/InfoCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/InfoCommand.java
@@ -4,10 +4,10 @@
  */
 package io.github.nucleuspowered.nucleus.modules.misc.commands;
 
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
@@ -17,7 +17,7 @@ import org.spongepowered.api.command.spec.CommandSpec;
 @Permissions(suggestedLevel = SuggestedLevel.MOD)
 @RunAsync
 @RegisterCommand("info")
-public class InfoCommand extends CommandBase<CommandSource> {
+public class InfoCommand extends OldCommandBase<CommandSource> {
     @Override
     public CommandSpec createSpec() {
         return null;

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/ItemInfoCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/ItemInfoCommand.java
@@ -5,10 +5,10 @@
 package io.github.nucleuspowered.nucleus.modules.misc.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.DataScanner;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.Sponge;
@@ -31,13 +31,13 @@ import java.util.Map;
 
 @Permissions
 @RegisterCommand({"iteminfo", "itemdb"})
-public class ItemInfoCommand extends CommandBase<Player> {
+public class ItemInfoCommand extends OldCommandBase<Player> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(
+        return getSpecBuilderBase().arguments(
                 GenericArguments.flags().permissionFlag(permissions.getPermissionWithSuffix("extended"), "e", "-extended").buildWith(GenericArguments.none())
-        ).executor(this).build();
+        ).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/KillCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/KillCommand.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.misc.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
@@ -21,13 +21,13 @@ import org.spongepowered.api.text.Text;
 
 @Permissions
 @RegisterCommand("kill")
-public class KillCommand extends CommandBase<CommandSource> {
+public class KillCommand extends OldCommandBase<CommandSource> {
 
     private final String key = "player";
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(GenericArguments.player(Text.of(key))).executor(this).build();
+        return getSpecBuilderBase().arguments(GenericArguments.player(Text.of(key))).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/MotdCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/MotdCommand.java
@@ -4,10 +4,10 @@
  */
 package io.github.nucleuspowered.nucleus.modules.misc.commands;
 
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
@@ -17,7 +17,7 @@ import org.spongepowered.api.command.spec.CommandSpec;
 @Permissions(suggestedLevel = SuggestedLevel.USER)
 @RunAsync
 @RegisterCommand("motd")
-public class MotdCommand extends CommandBase<CommandSource> {
+public class MotdCommand extends OldCommandBase<CommandSource> {
     @Override
     public CommandSpec createSpec() {
         return null;

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/RulesCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/RulesCommand.java
@@ -4,8 +4,8 @@
  */
 package io.github.nucleuspowered.nucleus.modules.misc.commands;
 
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
@@ -18,7 +18,7 @@ import org.spongepowered.api.command.spec.CommandSpec;
 @NoWarmup
 @NoCooldown
 @NoCost
-public class RulesCommand extends CommandBase<CommandSource> {
+public class RulesCommand extends OldCommandBase<CommandSource> {
     @Override
     public CommandSpec createSpec() {
         return null;

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/SpeedCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/SpeedCommand.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.misc.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
@@ -27,7 +27,7 @@ import java.util.Optional;
 
 @RegisterCommand("speed")
 @Permissions
-public class SpeedCommand extends CommandBase<CommandSource> {
+public class SpeedCommand extends OldCommandBase<CommandSource> {
 
     private final String speedKey = "speed";
     private final String typeKey = "type";
@@ -50,12 +50,12 @@ public class SpeedCommand extends CommandBase<CommandSource> {
         keysMap.put("walk", SpeedType.WALKING);
         keysMap.put("w", SpeedType.WALKING);
 
-        return CommandSpec.builder()
+        return getSpecBuilderBase()
                 .arguments(GenericArguments.optional(GenericArguments.seq(
                         GenericArguments.optionalWeak(GenericArguments.onlyOne(GenericArguments
                                 .requiringPermission(GenericArguments.player(Text.of(playerKey)), permissions.getPermissionWithSuffix("others")))),
                 GenericArguments.optionalWeak(GenericArguments.onlyOne(GenericArguments.choices(Text.of(typeKey), keysMap, true))),
-                GenericArguments.integer(Text.of(speedKey))))).executor(this).build();
+                GenericArguments.integer(Text.of(speedKey))))).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/SuicideCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/SuicideCommand.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.misc.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
@@ -19,11 +19,11 @@ import org.spongepowered.api.entity.living.player.gamemode.GameModes;
 
 @Permissions(suggestedLevel = SuggestedLevel.USER)
 @RegisterCommand("suicide")
-public class SuicideCommand extends CommandBase<Player> {
+public class SuicideCommand extends OldCommandBase<Player> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).build();
+        return getSpecBuilderBase().build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/mob/commands/SpawnMobCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/mob/commands/SpawnMobCommand.java
@@ -8,9 +8,9 @@ import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.ImprovedEntityParser;
 import io.github.nucleuspowered.nucleus.argumentparsers.PositiveIntegerArgument;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.mob.config.MobConfigAdapter;
@@ -35,7 +35,7 @@ import java.util.Optional;
 
 @Permissions
 @RegisterCommand({"spawnmob", "spawnentity"})
-public class SpawnMobCommand extends CommandBase<CommandSource> {
+public class SpawnMobCommand extends OldCommandBase<CommandSource> {
 
     private final String playerKey = "player";
     private final String amountKey = "amount";
@@ -45,7 +45,7 @@ public class SpawnMobCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).arguments(
+        return getSpecBuilderBase().arguments(
                 GenericArguments.optionalWeak(GenericArguments.requiringPermission(GenericArguments.player(Text.of(playerKey)), permissions.getPermissionWithSuffix("others"))),
                 new ImprovedEntityParser(Text.of(mobTypeKey)),
                 GenericArguments.optional(new PositiveIntegerArgument(Text.of(amountKey)), 1)

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/mute/commands/CheckMuteCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/mute/commands/CheckMuteCommand.java
@@ -7,15 +7,12 @@ package io.github.nucleuspowered.nucleus.modules.mute.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.MuteData;
-import io.github.nucleuspowered.nucleus.api.data.NucleusUser;
 import io.github.nucleuspowered.nucleus.config.loaders.UserConfigLoader;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.mute.handler.MuteHandler;
-import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import org.spongepowered.api.Sponge;
-import org.spongepowered.api.command.CommandException;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
@@ -25,7 +22,6 @@ import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.service.user.UserStorageService;
 import org.spongepowered.api.text.Text;
 
-import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
@@ -41,7 +37,7 @@ import java.util.Optional;
 @NoCooldown
 @NoCost
 @RegisterCommand("checkmute")
-public class CheckMuteCommand extends CommandBase<CommandSource> {
+public class CheckMuteCommand extends OldCommandBase<CommandSource> {
 
     @Inject private UserConfigLoader userConfigLoader;
     @Inject private MuteHandler handler;
@@ -49,7 +45,7 @@ public class CheckMuteCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().description(Text.of("Checks the mute status of that player")).executor(this)
+        return getSpecBuilderBase().description(Text.of("Checks the mute status of that player"))
                 .arguments(GenericArguments.onlyOne(GenericArguments.user(Text.of(playerArgument)))).build();
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/mute/commands/MuteCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/mute/commands/MuteCommand.java
@@ -10,9 +10,9 @@ import io.github.nucleuspowered.nucleus.api.data.MuteData;
 import io.github.nucleuspowered.nucleus.api.data.NucleusUser;
 import io.github.nucleuspowered.nucleus.argumentparsers.TimespanParser;
 import io.github.nucleuspowered.nucleus.config.loaders.UserConfigLoader;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.PermissionRegistry;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.mute.handler.MuteHandler;
@@ -31,8 +31,6 @@ import org.spongepowered.api.text.channel.MutableMessageChannel;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -50,7 +48,7 @@ import java.util.UUID;
 @NoCooldown
 @NoCost
 @RegisterCommand({"mute", "unmute"})
-public class MuteCommand extends CommandBase<CommandSource> {
+public class MuteCommand extends OldCommandBase<CommandSource> {
 
     @Inject private UserConfigLoader userConfigLoader;
     @Inject private MuteHandler handler;
@@ -70,7 +68,7 @@ public class MuteCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().description(Text.of("Mutes or unmutes a player")).executor(this)
+        return getSpecBuilderBase().description(Text.of("Mutes or unmutes a player"))
                 .arguments(GenericArguments.onlyOne(GenericArguments.user(Text.of(playerArgument))),
                         GenericArguments.onlyOne(GenericArguments.optionalWeak(new TimespanParser(Text.of(timespanArgument)))),
                         GenericArguments.optional(GenericArguments.onlyOne(GenericArguments.remainingJoinedStrings(Text.of(reason)))))

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/nickname/commands/DelNickCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/nickname/commands/DelNickCommand.java
@@ -7,9 +7,9 @@ package io.github.nucleuspowered.nucleus.modules.nickname.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.config.loaders.UserConfigLoader;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.interfaces.InternalNucleusUser;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
@@ -23,7 +23,7 @@ import java.util.Optional;
 
 @RegisterCommand({"delnick", "delnickname", "deletenick"})
 @Permissions(alias = "nick")
-public class DelNickCommand extends CommandBase<CommandSource> {
+public class DelNickCommand extends OldCommandBase<CommandSource> {
 
     @Inject private UserConfigLoader loader;
 
@@ -31,11 +31,11 @@ public class DelNickCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder()
+        return getSpecBuilderBase()
                 .arguments(
                         GenericArguments.optional(GenericArguments.requiringPermission(GenericArguments.onlyOne(GenericArguments.user(Text.of(playerKey))),
                                 permissions.getPermissionWithSuffix("others"))))
-                .executor(this).build();
+                .build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/nickname/commands/NicknameCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/nickname/commands/NicknameCommand.java
@@ -7,9 +7,9 @@ package io.github.nucleuspowered.nucleus.modules.nickname.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.config.loaders.UserConfigLoader;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.interfaces.InternalNucleusUser;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 
 @RegisterCommand({"nick", "nickname"})
 @Permissions
-public class NicknameCommand extends CommandBase<CommandSource> {
+public class NicknameCommand extends OldCommandBase<CommandSource> {
 
     @Inject private UserConfigLoader loader;
     @Inject private NicknameConfigAdapter nicknameConfigAdapter;
@@ -55,11 +55,11 @@ public class NicknameCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder()
+        return getSpecBuilderBase()
                 .arguments(
                         GenericArguments.optionalWeak(GenericArguments.requiringPermission(
                                 GenericArguments.onlyOne(GenericArguments.user(Text.of(playerKey))), permissions.getPermissionWithSuffix("others"))),
-                GenericArguments.onlyOne(GenericArguments.string(Text.of(nickName)))).executor(this).build();
+                GenericArguments.onlyOne(GenericArguments.string(Text.of(nickName)))).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/nickname/commands/RealnameCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/nickname/commands/RealnameCommand.java
@@ -4,10 +4,10 @@
  */
 package io.github.nucleuspowered.nucleus.modules.nickname.commands;
 
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
@@ -16,7 +16,7 @@ import org.spongepowered.api.command.spec.CommandSpec;
 @RegisterCommand({"realname"})
 @Permissions
 @RunAsync
-public class RealnameCommand extends CommandBase<CommandSource> {
+public class RealnameCommand extends OldCommandBase<CommandSource> {
     @Override
     public CommandSpec createSpec() {
         return null;

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/playerinfo/commands/ListPlayerCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/playerinfo/commands/ListPlayerCommand.java
@@ -10,10 +10,10 @@ import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.NameUtil;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.config.loaders.UserConfigLoader;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.afk.handlers.AFKHandler;
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 @RunAsync
 @Permissions(suggestedLevel = SuggestedLevel.USER)
 @RegisterCommand({"list", "listplayers"})
-public class ListPlayerCommand extends CommandBase<CommandSource> {
+public class ListPlayerCommand extends OldCommandBase<CommandSource> {
 
     @Inject private AFKHandler handler;
     @Inject private PlayerInfoConfigAdapter config;
@@ -54,7 +54,7 @@ public class ListPlayerCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).build();
+        return getSpecBuilderBase().build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/playerinfo/commands/SeenCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/playerinfo/commands/SeenCommand.java
@@ -6,10 +6,10 @@ package io.github.nucleuspowered.nucleus.modules.playerinfo.commands;
 
 import io.github.nucleuspowered.nucleus.NameUtil;
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.interfaces.InternalNucleusUser;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
@@ -39,7 +39,7 @@ import java.util.Map;
 @Permissions
 @RunAsync
 @RegisterCommand({"seen", "seenplayer"})
-public class SeenCommand extends CommandBase<CommandSource> {
+public class SeenCommand extends OldCommandBase<CommandSource> {
 
     private final String playerKey = "player";
 
@@ -52,7 +52,7 @@ public class SeenCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(GenericArguments.onlyOne(GenericArguments.user(Text.of(playerKey)))).executor(this).build();
+        return getSpecBuilderBase().arguments(GenericArguments.onlyOne(GenericArguments.user(Text.of(playerKey)))).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/powertool/commands/DeletePowertoolCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/powertool/commands/DeletePowertoolCommand.java
@@ -7,8 +7,8 @@ package io.github.nucleuspowered.nucleus.modules.powertool.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.config.loaders.UserConfigLoader;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.interfaces.InternalNucleusUser;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
@@ -31,13 +31,13 @@ import java.util.Optional;
 @NoWarmup
 @NoCost
 @RegisterCommand(value = {"delete", "del", "rm", "remove"}, subcommandOf = PowertoolCommand.class)
-public class DeletePowertoolCommand extends CommandBase<Player> {
+public class DeletePowertoolCommand extends OldCommandBase<Player> {
 
     @Inject private UserConfigLoader loader;
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).build();
+        return getSpecBuilderBase().build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/powertool/commands/ListPowertoolCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/powertool/commands/ListPowertoolCommand.java
@@ -7,8 +7,8 @@ package io.github.nucleuspowered.nucleus.modules.powertool.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.config.loaders.UserConfigLoader;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.interfaces.InternalNucleusUser;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
@@ -39,14 +39,14 @@ import java.util.stream.Collectors;
 @NoWarmup
 @NoCost
 @RegisterCommand(value = {"list", "ls"}, subcommandOf = PowertoolCommand.class)
-public class ListPowertoolCommand extends CommandBase<Player> {
+public class ListPowertoolCommand extends OldCommandBase<Player> {
 
     @Inject private UserConfigLoader loader;
     private PaginationService paginationService = null;
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).build();
+        return getSpecBuilderBase().build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/powertool/commands/PowertoolCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/powertool/commands/PowertoolCommand.java
@@ -8,8 +8,8 @@ import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.config.loaders.UserConfigLoader;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.interfaces.InternalNucleusUser;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
@@ -37,17 +37,17 @@ import java.util.Optional;
 @NoWarmup
 @NoCost
 @RegisterCommand({"powertool", "pt"})
-public class PowertoolCommand extends CommandBase<Player> {
+public class PowertoolCommand extends OldCommandBase<Player> {
     @Inject private UserConfigLoader loader;
     private final String commandKey = "command";
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().children(this.createChildCommands()).arguments(
+        return getSpecBuilderBase().children(this.createChildCommands()).arguments(
                 GenericArguments.optional(
                         GenericArguments.remainingJoinedStrings(Text.of(commandKey))
                 )
-        ).executor(this).build();
+        ).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/powertool/commands/TogglePowertoolCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/powertool/commands/TogglePowertoolCommand.java
@@ -7,8 +7,8 @@ package io.github.nucleuspowered.nucleus.modules.powertool.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.config.loaders.UserConfigLoader;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.interfaces.InternalNucleusUser;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
@@ -28,14 +28,14 @@ import org.spongepowered.api.text.Text;
 @NoWarmup
 @NoCost
 @RegisterCommand(value = {"toggle"}, subcommandOf = PowertoolCommand.class)
-public class TogglePowertoolCommand extends CommandBase<Player> {
+public class TogglePowertoolCommand extends OldCommandBase<Player> {
 
     private final String toggleKey = "toggle";
     @Inject private UserConfigLoader loader;
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(GenericArguments.optional(GenericArguments.onlyOne(GenericArguments.bool(Text.of(toggleKey))))).executor(this).build();
+        return getSpecBuilderBase().arguments(GenericArguments.optional(GenericArguments.onlyOne(GenericArguments.bool(Text.of(toggleKey))))).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/powertool/listeners/PowertoolListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/powertool/listeners/PowertoolListener.java
@@ -30,7 +30,7 @@ public class PowertoolListener extends ListenerBase {
 
     private CommandPermissionHandler getPermissionUtil() {
         if (s == null) {
-            s = permissionRegistry.getService(PowertoolCommand.class).orElseGet(() -> new CommandPermissionHandler(new PowertoolCommand()));
+            s = permissionRegistry.getService(PowertoolCommand.class).orElseGet(() -> new CommandPermissionHandler(new PowertoolCommand(), plugin));
         }
 
         return s;

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/spawn/commands/FirstSpawnCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/spawn/commands/FirstSpawnCommand.java
@@ -8,9 +8,9 @@ import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.LocationWithRotation;
 import io.github.nucleuspowered.nucleus.config.GeneralDataStore;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
@@ -21,13 +21,13 @@ import java.util.Optional;
 
 @Permissions(suggestedLevel = SuggestedLevel.USER)
 @RegisterCommand("firstspawn")
-public class FirstSpawnCommand extends CommandBase<Player> {
+public class FirstSpawnCommand extends OldCommandBase<Player> {
 
     @Inject private GeneralDataStore data;
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).build();
+        return getSpecBuilderBase().build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/spawn/commands/RemoveFirstSpawnCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/spawn/commands/RemoveFirstSpawnCommand.java
@@ -7,13 +7,12 @@ package io.github.nucleuspowered.nucleus.modules.spawn.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.config.GeneralDataStore;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.spec.CommandSpec;
-import org.spongepowered.api.entity.living.player.Player;
 
 /**
  * nucleus.firstspawn.remove.base
@@ -24,13 +23,13 @@ import org.spongepowered.api.entity.living.player.Player;
 @NoCooldown
 @NoCost
 @RunAsync
-public class RemoveFirstSpawnCommand extends CommandBase<CommandSource> {
+public class RemoveFirstSpawnCommand extends OldCommandBase<CommandSource> {
 
     @Inject private GeneralDataStore data;
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).build();
+        return getSpecBuilderBase().build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/spawn/commands/SetFirstSpawnCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/spawn/commands/SetFirstSpawnCommand.java
@@ -7,8 +7,8 @@ package io.github.nucleuspowered.nucleus.modules.spawn.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.config.GeneralDataStore;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.spec.CommandSpec;
@@ -23,13 +23,13 @@ import org.spongepowered.api.entity.living.player.Player;
 @NoCooldown
 @NoCost
 @RunAsync
-public class SetFirstSpawnCommand extends CommandBase<Player> {
+public class SetFirstSpawnCommand extends OldCommandBase<Player> {
 
     @Inject private GeneralDataStore data;
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().children(this.createChildCommands()).executor(this).build();
+        return getSpecBuilderBase().children(this.createChildCommands()).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/spawn/commands/SetSpawnCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/spawn/commands/SetSpawnCommand.java
@@ -5,8 +5,8 @@
 package io.github.nucleuspowered.nucleus.modules.spawn.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.spec.CommandSpec;
@@ -17,11 +17,11 @@ import org.spongepowered.api.entity.living.player.Player;
 @NoWarmup
 @NoCooldown
 @NoCost
-public class SetSpawnCommand extends CommandBase<Player> {
+public class SetSpawnCommand extends OldCommandBase<Player> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).build();
+        return getSpecBuilderBase().build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/spawn/commands/SpawnCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/spawn/commands/SpawnCommand.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.spawn.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.Sponge;
@@ -27,7 +27,7 @@ import java.util.Optional;
 
 @Permissions(suggestedLevel = SuggestedLevel.USER)
 @RegisterCommand("spawn")
-public class SpawnCommand extends CommandBase<Player> {
+public class SpawnCommand extends OldCommandBase<Player> {
 
     private final String key = "world";
 
@@ -40,11 +40,11 @@ public class SpawnCommand extends CommandBase<Player> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder()
+        return getSpecBuilderBase()
                 .arguments(
                         GenericArguments.optional(GenericArguments.requiringPermission(GenericArguments.onlyOne(GenericArguments.world(Text.of(key))),
                                 permissions.getPermissionWithSuffix("otherworlds"))))
-                .executor(this).build();
+                .build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TPNativeCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TPNativeCommand.java
@@ -4,8 +4,8 @@
  */
 package io.github.nucleuspowered.nucleus.modules.teleport.commands;
 
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
@@ -22,12 +22,12 @@ import org.spongepowered.api.text.Text;
 @NoWarmup
 @NoPermissions
 @RegisterCommand({ "teleportnative", "tpnative", "tpn" })
-public class TPNativeCommand extends CommandBase<CommandSource> {
+public class TPNativeCommand extends OldCommandBase<CommandSource> {
     private final String a = "args";
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(GenericArguments.remainingJoinedStrings(Text.of(a))).executor(this).build();
+        return getSpecBuilderBase().arguments(GenericArguments.remainingJoinedStrings(Text.of(a))).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportAcceptCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportAcceptCommand.java
@@ -6,8 +6,8 @@ package io.github.nucleuspowered.nucleus.modules.teleport.commands;
 
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.teleport.handlers.TeleportHandler;
 import org.spongepowered.api.command.CommandResult;
@@ -23,13 +23,13 @@ import org.spongepowered.api.entity.living.player.Player;
 @NoCooldown
 @NoCost
 @RegisterCommand({"tpaccept", "teleportaccept"})
-public class TeleportAcceptCommand extends CommandBase<Player> {
+public class TeleportAcceptCommand extends OldCommandBase<Player> {
 
     @Inject private TeleportHandler teleportHandler;
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).build();
+        return getSpecBuilderBase().build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportAllHereCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportAllHereCommand.java
@@ -5,8 +5,8 @@
 package io.github.nucleuspowered.nucleus.modules.teleport.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.modules.teleport.handlers.TeleportHandler;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
@@ -23,13 +23,13 @@ import javax.inject.Inject;
 @NoCost
 @NoCooldown
 @RegisterCommand({"tpall", "tpallhere"})
-public class TeleportAllHereCommand extends CommandBase<Player> {
+public class TeleportAllHereCommand extends OldCommandBase<Player> {
 
     @Inject private TeleportHandler handler;
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(GenericArguments.flags().flag("f").buildWith(GenericArguments.none())).executor(this).build();
+        return getSpecBuilderBase().arguments(GenericArguments.flags().flag("f").buildWith(GenericArguments.none())).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportAskAllHereCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportAskAllHereCommand.java
@@ -5,8 +5,8 @@
 package io.github.nucleuspowered.nucleus.modules.teleport.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.modules.teleport.handlers.TeleportHandler;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
@@ -25,13 +25,13 @@ import java.time.temporal.ChronoUnit;
 @NoCooldown
 @RegisterCommand({"tpaall", "tpaskall"})
 @RunAsync
-public class TeleportAskAllHereCommand extends CommandBase<Player> {
+public class TeleportAskAllHereCommand extends OldCommandBase<Player> {
 
     @Inject private TeleportHandler tpHandler;
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(GenericArguments.flags().flag("f").buildWith(GenericArguments.none())).executor(this).build();
+        return getSpecBuilderBase().arguments(GenericArguments.flags().flag("f").buildWith(GenericArguments.none())).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportAskCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportAskCommand.java
@@ -5,8 +5,11 @@
 package io.github.nucleuspowered.nucleus.modules.teleport.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
-import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoWarmup;
+import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
+import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.teleport.handlers.TeleportHandler;
@@ -30,7 +33,7 @@ import java.util.Map;
 @NoWarmup(generateConfigEntry = true)
 @RegisterCommand({"tpa", "teleportask"})
 @RunAsync
-public class TeleportAskCommand extends CommandBase<Player> {
+public class TeleportAskCommand extends OldCommandBase<Player> {
 
     @Inject private TeleportHandler tpHandler;
 
@@ -45,10 +48,10 @@ public class TeleportAskCommand extends CommandBase<Player> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder()
+        return getSpecBuilderBase()
                 .arguments(GenericArguments.requiringPermission(GenericArguments.flags().flag("f").buildWith(GenericArguments.none()),
                         permissions.getPermissionWithSuffix("force")), GenericArguments.onlyOne(GenericArguments.player(Text.of(playerKey))))
-                .executor(this).build();
+                .build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportAskHereCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportAskHereCommand.java
@@ -5,8 +5,11 @@
 package io.github.nucleuspowered.nucleus.modules.teleport.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
-import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoWarmup;
+import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
+import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.teleport.handlers.TeleportHandler;
@@ -27,7 +30,7 @@ import java.util.Map;
 @RunAsync
 @NoWarmup(generateConfigEntry = true)
 @RegisterCommand({"tpahere", "tpaskhere", "teleportaskhere"})
-public class TeleportAskHereCommand extends CommandBase<Player> {
+public class TeleportAskHereCommand extends OldCommandBase<Player> {
 
     @Inject private TeleportHandler tpHandler;
 
@@ -42,10 +45,10 @@ public class TeleportAskHereCommand extends CommandBase<Player> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder()
+        return getSpecBuilderBase()
                 .arguments(GenericArguments.requiringPermission(GenericArguments.flags().flag("f").buildWith(GenericArguments.none()),
                         permissions.getPermissionWithSuffix("force")), GenericArguments.onlyOne(GenericArguments.player(Text.of(playerKey))))
-                .executor(this).build();
+                .build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportCommand.java
@@ -9,10 +9,10 @@ import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.NoCostArgument;
 import io.github.nucleuspowered.nucleus.argumentparsers.NoWarmupArgument;
 import io.github.nucleuspowered.nucleus.argumentparsers.TwoPlayersArgument;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.ConfigCommandAlias;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.teleport.handlers.TeleportHandler;
@@ -32,7 +32,7 @@ import java.util.Optional;
 @Permissions(root = "teleport", alias = "teleport", suggestedLevel = SuggestedLevel.MOD)
 @RegisterCommand({})
 @ConfigCommandAlias("teleport")
-public class TeleportCommand extends CommandBase<CommandSource> {
+public class TeleportCommand extends OldCommandBase<CommandSource> {
 
     private String playerFromKey = "playerFrom";
     private String playerKey = "player";
@@ -48,7 +48,7 @@ public class TeleportCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this)
+        return getSpecBuilderBase()
                 .arguments(GenericArguments.flags().flag("f").buildWith(GenericArguments.none()),
 
                         // Either we get two arguments, or we get one.

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportDenyCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportDenyCommand.java
@@ -6,8 +6,8 @@ package io.github.nucleuspowered.nucleus.modules.teleport.commands;
 
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.teleport.handlers.TeleportHandler;
 import org.spongepowered.api.command.CommandResult;
@@ -23,13 +23,13 @@ import org.spongepowered.api.entity.living.player.Player;
 @NoCooldown
 @NoCost
 @RegisterCommand({"tpdeny", "teleportdeny"})
-public class TeleportDenyCommand extends CommandBase<Player> {
+public class TeleportDenyCommand extends OldCommandBase<Player> {
 
     @Inject private TeleportHandler teleportHandler;
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).build();
+        return getSpecBuilderBase().build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportHereCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportHereCommand.java
@@ -5,8 +5,8 @@
 package io.github.nucleuspowered.nucleus.modules.teleport.commands;
 
 import com.google.inject.Inject;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.teleport.handlers.TeleportHandler;
 import org.spongepowered.api.command.CommandResult;
@@ -25,7 +25,7 @@ import org.spongepowered.api.text.Text;
 @NoCooldown
 @NoCost
 @RegisterCommand({ "tphere", "tph" })
-public class TeleportHereCommand extends CommandBase<Player> {
+public class TeleportHereCommand extends OldCommandBase<Player> {
 
     private final String playerKey = "player";
 
@@ -33,7 +33,7 @@ public class TeleportHereCommand extends CommandBase<Player> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).arguments(
+        return getSpecBuilderBase().arguments(
             GenericArguments.onlyOne(GenericArguments.player(Text.of(playerKey)))
         ).build();
     }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportPositionCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportPositionCommand.java
@@ -5,8 +5,8 @@
 package io.github.nucleuspowered.nucleus.modules.teleport.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
@@ -24,7 +24,7 @@ import org.spongepowered.api.world.storage.WorldProperties;
 @NoCooldown
 @NoCost
 @RegisterCommand({"tppos"})
-public class TeleportPositionCommand extends CommandBase<CommandSource> {
+public class TeleportPositionCommand extends OldCommandBase<CommandSource> {
 
     private final String key = "player";
     private final String location = "world";
@@ -34,14 +34,14 @@ public class TeleportPositionCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder()
+        return getSpecBuilderBase()
                 .arguments(GenericArguments.flags().flag("f").buildWith(GenericArguments.none()),
                         GenericArguments.onlyOne(GenericArguments.playerOrSource(Text.of(key))),
                         GenericArguments.onlyOne(GenericArguments.optional(GenericArguments.world(Text.of(location)))),
                         GenericArguments.onlyOne(GenericArguments.integer(Text.of(x))),
                         GenericArguments.onlyOne(GenericArguments.integer(Text.of(y))),
                         GenericArguments.onlyOne(GenericArguments.integer(Text.of(z))))
-                .executor(this).build();
+                .build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportToggleCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportToggleCommand.java
@@ -5,8 +5,8 @@
 package io.github.nucleuspowered.nucleus.modules.teleport.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.interfaces.InternalNucleusUser;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
@@ -26,7 +26,7 @@ import java.util.Map;
 @NoCost
 @RegisterCommand({"tptoggle"})
 @RunAsync
-public class TeleportToggleCommand extends CommandBase<Player> {
+public class TeleportToggleCommand extends OldCommandBase<Player> {
 
     private final String key = "toggle";
 
@@ -39,7 +39,7 @@ public class TeleportToggleCommand extends CommandBase<Player> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this)
+        return getSpecBuilderBase()
                 .arguments(GenericArguments.optional(GenericArguments.onlyOne(GenericArguments.bool(Text.of(key))))).build();
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/vanish/commands/VanishCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/vanish/commands/VanishCommand.java
@@ -5,8 +5,8 @@
 package io.github.nucleuspowered.nucleus.modules.vanish.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.args.GenericArguments;
@@ -21,13 +21,13 @@ import org.spongepowered.api.text.Text;
 @NoCost
 @NoWarmup
 @RegisterCommand({"vanish", "v"})
-public class VanishCommand extends CommandBase<Player> {
+public class VanishCommand extends OldCommandBase<Player> {
 
     private final String b = "toggle";
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().arguments(GenericArguments.optional(GenericArguments.onlyOne(GenericArguments.bool(Text.of(b))))).executor(this)
+        return getSpecBuilderBase().arguments(GenericArguments.optional(GenericArguments.onlyOne(GenericArguments.bool(Text.of(b)))))
                 .build();
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warp/commands/DeleteWarpCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warp/commands/DeleteWarpCommand.java
@@ -8,13 +8,11 @@ import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.service.NucleusWarpService;
 import io.github.nucleuspowered.nucleus.argumentparsers.WarpParser;
-import io.github.nucleuspowered.nucleus.config.GeneralDataStore;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.modules.warp.config.WarpConfigAdapter;
-import io.github.nucleuspowered.nucleus.modules.warp.handlers.WarpHandler;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
@@ -31,13 +29,13 @@ import org.spongepowered.api.text.Text;
 @Permissions(root = "warp")
 @RunAsync
 @RegisterCommand(value = {"delete", "del"}, subcommandOf = WarpCommand.class)
-public class DeleteWarpCommand extends CommandBase<CommandSource> {
+public class DeleteWarpCommand extends OldCommandBase<CommandSource> {
 
     @Inject private WarpConfigAdapter adapter;
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this)
+        return getSpecBuilderBase()
                 .arguments(GenericArguments.onlyOne(new WarpParser(Text.of(WarpCommand.warpNameArg), adapter, false, false)))
                 .description(Text.of("Deletes a warp.")).build();
     }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warp/commands/ListWarpCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warp/commands/ListWarpCommand.java
@@ -7,11 +7,11 @@ package io.github.nucleuspowered.nucleus.modules.warp.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.service.NucleusWarpService;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.PermissionRegistry;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.warp.config.WarpConfigAdapter;
 import org.spongepowered.api.Sponge;
@@ -37,14 +37,14 @@ import java.util.stream.Collectors;
 @Permissions(root = "warp", suggestedLevel = SuggestedLevel.USER)
 @RunAsync
 @RegisterCommand(value = {"list"}, subcommandOf = WarpCommand.class)
-public class ListWarpCommand extends CommandBase<CommandSource> {
+public class ListWarpCommand extends OldCommandBase<CommandSource> {
 
     private final NucleusWarpService service = Sponge.getServiceManager().provideUnchecked(NucleusWarpService.class);
     @Inject private WarpConfigAdapter adapter;
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).description(Text.of("Lists the warps available to you.")).build();
+        return getSpecBuilderBase().description(Text.of("Lists the warps available to you.")).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warp/commands/SetWarpCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warp/commands/SetWarpCommand.java
@@ -6,9 +6,9 @@ package io.github.nucleuspowered.nucleus.modules.warp.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.service.NucleusWarpService;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
@@ -27,13 +27,13 @@ import java.util.regex.Pattern;
  */
 @Permissions(root = "warp")
 @RegisterCommand(value = {"set"}, subcommandOf = WarpCommand.class)
-public class SetWarpCommand extends CommandBase<Player> {
+public class SetWarpCommand extends OldCommandBase<Player> {
 
     private final Pattern warpRegex = Pattern.compile("^[A-Za-z][A-Za-z0-9]{0,25}$");
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).arguments(GenericArguments.onlyOne(GenericArguments.string(Text.of(WarpCommand.warpNameArg))))
+        return getSpecBuilderBase().arguments(GenericArguments.onlyOne(GenericArguments.string(Text.of(WarpCommand.warpNameArg))))
                 .description(Text.of("Sets a warp at the player's location.")).build();
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warp/commands/WarpCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warp/commands/WarpCommand.java
@@ -7,10 +7,10 @@ package io.github.nucleuspowered.nucleus.modules.warp.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.WarpParser;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.PermissionRegistry;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.warp.config.WarpConfigAdapter;
@@ -35,7 +35,7 @@ import java.util.Map;
  */
 @Permissions(suggestedLevel = SuggestedLevel.USER)
 @RegisterCommand("warp")
-public class WarpCommand extends CommandBase<Player> {
+public class WarpCommand extends OldCommandBase<Player> {
     static final String warpNameArg = Util.getMessageWithFormat("args.name.warpname");
 
     @Inject private WarpConfigAdapter adapter;
@@ -49,7 +49,7 @@ public class WarpCommand extends CommandBase<Player> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this)
+        return getSpecBuilderBase()
                 .children(this.createChildCommands()).arguments(
                         GenericArguments.onlyOne(GenericArguments.optionalWeak(GenericArguments.flags().flag("f", "-force").setAnchorFlags(false).buildWith(GenericArguments.none()))),
                         GenericArguments.onlyOne(new WarpParser(Text.of(warpNameArg), adapter, true))

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/CreateWorldCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/CreateWorldCommand.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.world.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.CatalogTypes;
 import org.spongepowered.api.Sponge;
@@ -35,7 +35,7 @@ import java.util.Optional;
  */
 @Permissions(root = "world", suggestedLevel = SuggestedLevel.ADMIN)
 @RegisterCommand(value = {"create"}, subcommandOf = WorldCommand.class)
-public class CreateWorldCommand extends CommandBase<CommandSource> {
+public class CreateWorldCommand extends OldCommandBase<CommandSource> {
 
     private final String name = "name";
     private final String dimension = "dimension";
@@ -45,13 +45,13 @@ public class CreateWorldCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().description(Text.of("Create World Command"))
+        return getSpecBuilderBase().description(Text.of("Create World Command"))
                 .arguments(GenericArguments.onlyOne(GenericArguments.string(Text.of(name))),
                         GenericArguments.onlyOne(GenericArguments.catalogedElement(Text.of(dimension), CatalogTypes.DIMENSION_TYPE)),
                         GenericArguments.onlyOne(GenericArguments.catalogedElement(Text.of(generator), CatalogTypes.GENERATOR_TYPE)),
                         GenericArguments.onlyOne(GenericArguments.catalogedElement(Text.of(gamemode), CatalogTypes.GAME_MODE)),
                         GenericArguments.onlyOne(GenericArguments.catalogedElement(Text.of(difficulty), CatalogTypes.DIFFICULTY)))
-                .executor(this).build();
+                .build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/DeleteWorldCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/DeleteWorldCommand.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.world.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
@@ -26,13 +26,13 @@ import org.spongepowered.api.world.storage.WorldProperties;
  */
 @Permissions(root = "world")
 @RegisterCommand(value = {"delete", "del"}, subcommandOf = WorldCommand.class)
-public class DeleteWorldCommand extends CommandBase<CommandSource> {
+public class DeleteWorldCommand extends OldCommandBase<CommandSource> {
 
     private final String world = "world";
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).arguments(GenericArguments.onlyOne(GenericArguments.world(Text.of(world))))
+        return getSpecBuilderBase().arguments(GenericArguments.onlyOne(GenericArguments.world(Text.of(world))))
                 .description(Text.of("Deletes a world.")).build();
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/ListWorldCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/ListWorldCommand.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.world.commands;
 
 import com.google.common.collect.Lists;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
@@ -33,11 +33,11 @@ import java.util.stream.Collectors;
  */
 @Permissions(root = "world", suggestedLevel = SuggestedLevel.ADMIN)
 @RegisterCommand(value = {"list", "ls"}, subcommandOf = WorldCommand.class)
-public class ListWorldCommand extends CommandBase<CommandSource> {
+public class ListWorldCommand extends OldCommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).description(Text.of("Lists worlds.")).build();
+        return getSpecBuilderBase().description(Text.of("Lists worlds.")).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/LoadWorldCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/LoadWorldCommand.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.world.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.CatalogTypes;
 import org.spongepowered.api.Sponge;
@@ -34,7 +34,7 @@ import java.util.Optional;
  */
 @Permissions(root = "world", suggestedLevel = SuggestedLevel.ADMIN)
 @RegisterCommand(value = {"load"}, subcommandOf = WorldCommand.class)
-public class LoadWorldCommand extends CommandBase<CommandSource> {
+public class LoadWorldCommand extends OldCommandBase<CommandSource> {
 
     private final String name = "name";
     private final String dimension = "dimension";
@@ -44,7 +44,7 @@ public class LoadWorldCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().description(Text.of("Load World Command"))
+        return getSpecBuilderBase().description(Text.of("Load World Command"))
                 .arguments(GenericArguments.seq(GenericArguments.onlyOne(GenericArguments.string(Text.of(name))),
                         GenericArguments.optional(
                                 GenericArguments.onlyOne(GenericArguments.catalogedElement(Text.of(dimension), CatalogTypes.DIMENSION_TYPE))),
@@ -52,7 +52,7 @@ public class LoadWorldCommand extends CommandBase<CommandSource> {
                         .optional(GenericArguments.onlyOne(GenericArguments.catalogedElement(Text.of(generator), CatalogTypes.GENERATOR_TYPE))),
                 GenericArguments.optional(GenericArguments.onlyOne(GenericArguments.catalogedElement(Text.of(gamemode), CatalogTypes.GAME_MODE))),
                 GenericArguments.optional(GenericArguments.onlyOne(GenericArguments.catalogedElement(Text.of(difficulty), CatalogTypes.DIFFICULTY)))))
-                .executor(this).build();
+                .build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/SetDifficultyWorldCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/SetDifficultyWorldCommand.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.world.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.CatalogTypes;
 import org.spongepowered.api.command.CommandResult;
@@ -30,18 +30,18 @@ import java.util.Optional;
  */
 @Permissions(root = "world", suggestedLevel = SuggestedLevel.ADMIN)
 @RegisterCommand(value = {"setdifficulty"}, subcommandOf = WorldCommand.class)
-public class SetDifficultyWorldCommand extends CommandBase<CommandSource> {
+public class SetDifficultyWorldCommand extends OldCommandBase<CommandSource> {
 
     private final String difficulty = "difficulty";
     private final String world = "world";
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().description(Text.of("Set Difficulty World Command"))
+        return getSpecBuilderBase().description(Text.of("Set Difficulty World Command"))
                 .arguments(GenericArguments.seq(
                         GenericArguments.onlyOne(GenericArguments.catalogedElement(Text.of(difficulty), CatalogTypes.DIFFICULTY)),
                         GenericArguments.optional(GenericArguments.onlyOne(GenericArguments.world(Text.of(world))))))
-                .executor(this).build();
+                .build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/SetGamemodeWorldCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/SetGamemodeWorldCommand.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.world.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.CatalogTypes;
 import org.spongepowered.api.command.CommandResult;
@@ -30,18 +30,18 @@ import java.util.Optional;
  */
 @Permissions(root = "world", suggestedLevel = SuggestedLevel.ADMIN)
 @RegisterCommand(value = {"setgamemode", "setgm"}, subcommandOf = WorldCommand.class)
-public class SetGamemodeWorldCommand extends CommandBase<CommandSource> {
+public class SetGamemodeWorldCommand extends OldCommandBase<CommandSource> {
 
     private final String gamemode = "gamemode";
     private final String world = "world";
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().description(Text.of("Set Gamemode World Command"))
+        return getSpecBuilderBase().description(Text.of("Set Gamemode World Command"))
                 .arguments(
                         GenericArguments.seq(GenericArguments.onlyOne(GenericArguments.catalogedElement(Text.of(gamemode), CatalogTypes.GAME_MODE))),
                         GenericArguments.optional(GenericArguments.onlyOne(GenericArguments.world(Text.of(world)))))
-                .executor(this).build();
+                .build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/SetSpawnWorldCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/SetSpawnWorldCommand.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.world.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
@@ -22,11 +22,11 @@ import org.spongepowered.api.text.Text;
  */
 @Permissions(root = "world", suggestedLevel = SuggestedLevel.ADMIN)
 @RegisterCommand(value = {"setspawn"}, subcommandOf = WorldCommand.class)
-public class SetSpawnWorldCommand extends CommandBase<Player> {
+public class SetSpawnWorldCommand extends OldCommandBase<Player> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().description(Text.of("Set World Spawn Command")).executor(this).build();
+        return getSpecBuilderBase().description(Text.of("Set World Spawn Command")).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/TeleportWorldCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/TeleportWorldCommand.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.world.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
@@ -30,17 +30,17 @@ import java.util.Optional;
  */
 @Permissions(root = "world", suggestedLevel = SuggestedLevel.ADMIN)
 @RegisterCommand(value = {"teleport", "tp"}, subcommandOf = WorldCommand.class)
-public class TeleportWorldCommand extends CommandBase<CommandSource> {
+public class TeleportWorldCommand extends OldCommandBase<CommandSource> {
 
     private final String world = "world";
     private final String player = "player";
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().description(Text.of("Teleport World Command"))
+        return getSpecBuilderBase().description(Text.of("Teleport World Command"))
                 .arguments(GenericArguments.seq(GenericArguments.world(Text.of(world)),
                         GenericArguments.optional(GenericArguments.onlyOne(GenericArguments.player(Text.of(player))))))
-                .executor(this).build();
+                .build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/WorldCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/WorldCommand.java
@@ -4,9 +4,9 @@
  */
 package io.github.nucleuspowered.nucleus.modules.world.commands;
 
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
@@ -21,11 +21,11 @@ import org.spongepowered.api.command.spec.CommandSpec;
  */
 @Permissions(suggestedLevel = SuggestedLevel.ADMIN)
 @RegisterCommand("world")
-public class WorldCommand extends CommandBase<CommandSource> {
+public class WorldCommand extends OldCommandBase<CommandSource> {
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder()
-                .executor(this)
+        return getSpecBuilderBase()
+
                 .children(this.createChildCommands())
                 .build();
     }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/WorldSpawnCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/WorldSpawnCommand.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.world.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
@@ -22,11 +22,11 @@ import org.spongepowered.api.text.Text;
  */
 @Permissions(root = "world", suggestedLevel = SuggestedLevel.ADMIN)
 @RegisterCommand(value = {"spawn"}, subcommandOf = WorldCommand.class)
-public class WorldSpawnCommand extends CommandBase<Player> {
+public class WorldSpawnCommand extends OldCommandBase<Player> {
 
     @Override
     public CommandSpec createSpec() {
-        return CommandSpec.builder().executor(this).description(Text.of("World Spawn Command")).build();
+        return getSpecBuilderBase().description(Text.of("World Spawn Command")).build();
     }
 
     @Override

--- a/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
+++ b/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
@@ -615,3 +615,8 @@ permission.spawnmob.other=Allows the user to spawn a mob on another player.
 
 permission.helpop.receive=Allows the user to receive message via /helpop
 
+# Command descriptions.
+description.time.desc=Gets the time for the specified world.
+description.mail.desc=Retrieves mail that has been sent to you.
+description.mail.send.desc=Sends a mail to the specified player.
+description.mail.clear.desc=Clears all mail in your inbox.

--- a/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
+++ b/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
@@ -617,6 +617,7 @@ permission.helpop.receive=Allows the user to receive message via /helpop
 
 # Command descriptions.
 description.time.desc=Gets the time for the specified world.
+description.time.set.desc=Sets the time for the specified world.
 description.mail.desc=Retrieves mail that has been sent to you.
 description.mail.send.desc=Sends a mail to the specified player.
 description.mail.clear.desc=Clears all mail in your inbox.

--- a/src/test/java/io/github/nucleuspowered/nucleus/tests/CommandBaseTests.java
+++ b/src/test/java/io/github/nucleuspowered/nucleus/tests/CommandBaseTests.java
@@ -6,9 +6,9 @@ package io.github.nucleuspowered.nucleus.tests;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.tests.util.TestModule;
 import org.junit.Assert;
 import org.junit.Test;
@@ -107,7 +107,7 @@ public class CommandBaseTests extends TestBase {
 
     @Permissions
     @RegisterCommand("test")
-    private class PlayerCommand extends CommandBase<Player> {
+    private class PlayerCommand extends OldCommandBase<Player> {
 
         @Override
         public CommandSpec createSpec() {
@@ -127,7 +127,7 @@ public class CommandBaseTests extends TestBase {
 
     @Permissions
     @RegisterCommand("test")
-    private class BasicCommand extends CommandBase {
+    private class BasicCommand extends OldCommandBase {
 
         @Override
         public CommandSpec createSpec() {

--- a/src/test/java/io/github/nucleuspowered/nucleus/tests/PermissionsTest.java
+++ b/src/test/java/io/github/nucleuspowered/nucleus/tests/PermissionsTest.java
@@ -6,10 +6,10 @@ package io.github.nucleuspowered.nucleus.tests;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.PermissionRegistry;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import io.github.nucleuspowered.nucleus.tests.util.TestModule;
 import org.junit.Assert;
 import org.junit.Test;
@@ -52,11 +52,11 @@ public class PermissionsTest extends TestBase {
         public String permission;
 
         @Parameterized.Parameter(1)
-        public Class<? extends CommandBase> clazz;
+        public Class<? extends OldCommandBase> clazz;
 
         @Test
         public void testPermissionIsValid() throws IllegalAccessException, InstantiationException {
-            CommandBase c = clazz.newInstance();
+            OldCommandBase c = clazz.newInstance();
             getInjector().injectMembers(c);
             c.postInit();
             Subject s = Mockito.mock(Subject.class);
@@ -90,11 +90,11 @@ public class PermissionsTest extends TestBase {
         public String permission;
 
         @Parameterized.Parameter(1)
-        public Class<? extends CommandBase> clazz;
+        public Class<? extends OldCommandBase> clazz;
 
         @Test
         public void testPermissionIsNotValid() throws IllegalAccessException, InstantiationException {
-            CommandBase c = clazz.newInstance();
+            OldCommandBase c = clazz.newInstance();
             getInjector().injectMembers(c);
             c.postInit();
             Subject s = Mockito.mock(Subject.class);
@@ -107,7 +107,7 @@ public class PermissionsTest extends TestBase {
 
     @Permissions
     @RegisterCommand({"test", "test2"})
-    public static class PermissionOne extends CommandBase {
+    public static class PermissionOne extends OldCommandBase {
 
         @Override
         public CommandSpec createSpec() {

--- a/src/test/java/io/github/nucleuspowered/nucleus/tests/sanity/SanityTests.java
+++ b/src/test/java/io/github/nucleuspowered/nucleus/tests/sanity/SanityTests.java
@@ -5,11 +5,10 @@
 package io.github.nucleuspowered.nucleus.tests.sanity;
 
 import com.google.common.reflect.ClassPath;
-import io.github.nucleuspowered.nucleus.internal.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.StandardModule;
 import io.github.nucleuspowered.nucleus.internal.annotations.NoPermissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
-import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.OldCommandBase;
 import org.junit.Assert;
 import org.junit.Test;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
@@ -17,7 +16,6 @@ import uk.co.drnaylor.quickstart.annotations.ModuleData;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class SanityTests {
@@ -39,25 +37,9 @@ public class SanityTests {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testThatAllCommandsHaveARegisterCommandAnnotation() throws IOException {
-        Set<ClassPath.ClassInfo> ci = ClassPath.from(this.getClass().getClassLoader()).getTopLevelClassesRecursive("io.github.nucleuspowered.nucleus.modules");
-        Set<Class<? extends StandardModule>> sc = ci.stream().map(ClassPath.ClassInfo::load).filter(CommandBase.class::isAssignableFrom)
-                .map(x -> (Class<? extends StandardModule>)x).collect(Collectors.toSet());
-
-        List<Class<?>> moduleList = sc.stream().filter(x -> !x.isAnnotationPresent(RegisterCommand.class)).collect(Collectors.toList());
-        if (!moduleList.isEmpty()) {
-            StringBuilder sb = new StringBuilder("Some commands do not have the RegisterCommand annotation: ");
-            moduleList.forEach(x -> sb.append(x.getName()).append(System.lineSeparator()));
-            Assert.fail(sb.toString());
-        }
-    }
-
-
-    @Test
-    @SuppressWarnings("unchecked")
     public void testThatAllCommandsHaveAPermissionAnnotation() throws IOException {
         Set<ClassPath.ClassInfo> ci = ClassPath.from(this.getClass().getClassLoader()).getTopLevelClassesRecursive("io.github.nucleuspowered.nucleus.modules");
-        Set<Class<? extends StandardModule>> sc = ci.stream().map(ClassPath.ClassInfo::load).filter(CommandBase.class::isAssignableFrom)
+        Set<Class<? extends StandardModule>> sc = ci.stream().map(ClassPath.ClassInfo::load).filter(OldCommandBase.class::isAssignableFrom)
                 .map(x -> (Class<? extends StandardModule>)x).collect(Collectors.toSet());
 
         List<Class<?>> moduleList = sc.stream().filter(x -> !x.isAnnotationPresent(NoPermissions.class) && !x.isAnnotationPresent(Permissions.class)).collect(Collectors.toList());

--- a/src/test/java/io/github/nucleuspowered/nucleus/tests/util/TestModule.java
+++ b/src/test/java/io/github/nucleuspowered/nucleus/tests/util/TestModule.java
@@ -5,9 +5,12 @@
 package io.github.nucleuspowered.nucleus.tests.util;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.TypeLiteral;
 import io.github.nucleuspowered.nucleus.Nucleus;
 import io.github.nucleuspowered.nucleus.config.CommandsConfig;
 import io.github.nucleuspowered.nucleus.internal.PermissionRegistry;
+import io.github.nucleuspowered.nucleus.internal.annotations.ModuleCommandSet;
+import io.github.nucleuspowered.nucleus.internal.command.AbstractCommand;
 import io.github.nucleuspowered.nucleus.modules.core.config.CoreConfig;
 import io.github.nucleuspowered.nucleus.modules.core.config.CoreConfigAdapter;
 import org.mockito.Mockito;
@@ -20,6 +23,8 @@ import org.spongepowered.api.config.DefaultConfig;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
 
 public class TestModule extends AbstractModule {
 
@@ -35,10 +40,13 @@ public class TestModule extends AbstractModule {
             throw new RuntimeException(e);
         }
 
+        Set<Class<? extends AbstractCommand>> sa = new HashSet<>();
+
         this.bind(Path.class).annotatedWith(DefaultConfig.class).toInstance(test2);
         this.bind(Path.class).annotatedWith(ConfigDir.class).toInstance(test);
         this.bind(Game.class).toInstance(Mockito.mock(Game.class));
         this.bind(Logger.class).toInstance(Mockito.mock(Logger.class));
+        this.bind(new TypeLiteral<Set<Class<? extends AbstractCommand>>>(){}).annotatedWith(ModuleCommandSet.class).toInstance(sa);
 
         CoreConfigAdapter mock = Mockito.mock(CoreConfigAdapter.class);
         PowerMockito.replace(PowerMockito.method(CoreConfigAdapter.class, "getNode")).with((obj, method, arguments) -> {


### PR DESCRIPTION
Originally, when I wrote the permission system, I developed it to be able to check for multiple permissions. However, this ability has been removed as I realised that supporting an `admin` permission would cause more problems for server owners, namely that negation permissions would not work when combined with these "super permissions".

Now, we just check for one permission, but this was never using the `CommandSpec` - this commit folds it in. Now, there is a method on `CommandBase` called `getSpecBuilderBase()` that automates this, setting the executor to the current command base, and also a new annotation, "Description".

As I think we are getting closer to a beta/testing (0.1) release - something I would like to be done by the weekend, we need some documentation for the commands. To do this, I've added this Description annotation rather than trying to add it directly to the class. This is so I can write a documentation generator that will generate YML files for the commands and permissions and just scan annotations as much as possible. These descriptions will also be used in game, so they are also localisable by starting each field with "loc:" then using the translation key.

I'll test this tonight to make sure it works - then will begin on the task of documenting things and writing such a generator.

This is a precursor to #72 