### PR TITLE
Improve startup speed.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ repositories {
 
 dependencies {
     compile "org.spongepowered:spongeapi:4.1.0-SNAPSHOT"
-    compile "uk.co.drnaylor:quickstart-moduleloader:0.1.4"
+    compile "uk.co.drnaylor:quickstart-moduleloader:0.1.5"
 
     testCompile "junit:junit:4.12"
     testCompile "org.mockito:mockito-all:1.10.19"
@@ -112,7 +112,7 @@ def private String getGitHash() {
 
 shadowJar {
     dependencies {
-        include(dependency('uk.co.drnaylor:quickstart-moduleloader:0.1.4'))
+        include(dependency('uk.co.drnaylor:quickstart-moduleloader:0.1.+'))
     }
 }
 build.dependsOn(shadowJar)

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/InternalServiceManager.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/InternalServiceManager.java
@@ -5,7 +5,6 @@
 package io.github.nucleuspowered.nucleus.internal;
 
 import com.google.common.collect.Maps;
-import com.google.inject.AbstractModule;
 import io.github.nucleuspowered.nucleus.Nucleus;
 
 import java.util.Map;
@@ -26,13 +25,7 @@ public final class InternalServiceManager {
         }
 
         serviceMap.put(key, service);
-        plugin.updateInjector(new AbstractModule() {
-            @Override
-            protected void configure() {
-                bind(key).toInstance(service);
-            }
-        });
-
+        plugin.preInjectorUpdate(key, service);
         return true;
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/guice/SubInjectorModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/guice/SubInjectorModule.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.internal.guice;
+
+import com.google.common.collect.Lists;
+import com.google.inject.AbstractModule;
+
+import java.util.List;
+
+@SuppressWarnings("unchecked")
+public class SubInjectorModule extends AbstractModule {
+
+    private final List<TypeHolder> t = Lists.newArrayList();
+
+    public <T> void addInjection(Class<T> clazz, T toInject) {
+        t.add(new TypeHolder(clazz, toInject));
+    }
+
+    public boolean isEmpty() {
+        return t.isEmpty();
+    }
+
+    @Override
+    protected void configure() {
+        t.forEach(k -> bind(k.clazz).toInstance(k.clazz.cast(k.instance)));
+    }
+
+    private class TypeHolder<T> {
+        private final Class<T> clazz;
+        private final T instance;
+
+        private TypeHolder(Class<T> clazz, T instance) {
+            this.clazz = clazz;
+            this.instance = instance;
+        }
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/qsml/NucleusConfigAdapter.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/qsml/NucleusConfigAdapter.java
@@ -5,7 +5,6 @@
 package io.github.nucleuspowered.nucleus.internal.qsml;
 
 import com.google.common.reflect.TypeToken;
-import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Nucleus;
 import ninja.leaping.configurate.ConfigurationNode;
@@ -19,7 +18,7 @@ public abstract class NucleusConfigAdapter<R> extends AbstractConfigAdapter<R> {
 
     @Override
     public void onAttach(String module, AbstractAdaptableConfig<?, ?> adapter) {
-        plugin.updateInjector(new ConfigModule(this));
+        plugin.preInjectorUpdate((Class)this.getClass(), this);
     }
 
     public final R getNodeOrDefault() {
@@ -45,21 +44,6 @@ public abstract class NucleusConfigAdapter<R> extends AbstractConfigAdapter<R> {
         } catch (ObjectMappingException e) {
             e.printStackTrace();
             return node;
-        }
-    }
-
-    private class ConfigModule extends AbstractModule {
-
-        private final NucleusConfigAdapter<R> adapter;
-
-        private ConfigModule(NucleusConfigAdapter<R> adapter) {
-            this.adapter = adapter;
-        }
-
-        @Override
-        @SuppressWarnings("unchecked")
-        protected void configure() {
-            bind((Class)adapter.getClass()).toInstance(adapter.getClass().cast(adapter));
         }
     }
 }

--- a/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
+++ b/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
@@ -49,6 +49,8 @@ nucleus.module.disabled.forceload=The plugin {0} ({1}) has requested that the mo
 nucleus.module.disabled.forceloadtwo=Be aware: this might cause conflicts with the {0} and so things might not work perfectly.
 nucleus.module.disabled=The plugin {0} ({1} has requested that the module {2} be disabled. It will not be loaded.
 
+nucleus.injector.duplicate=Attempted to register the class {0} in Guice when it has already been registered. Skipping.
+
 warmup.start=&aWarmup started: your command will be executed in &e{0}. &aDo not move or run a command.
 warmup.end=&aCompleted warmup. Executing command.
 warmup.cancel=&cYour warmup has been cancelled.


### PR DESCRIPTION
Creating loads of Guice injectors seems to cause a huge time penalty. This reduces the number of child injectors so that startup time is improved.