### PR TITLE
Prevent incorrect config adapters being used.

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/StandardModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/StandardModule.java
@@ -13,6 +13,7 @@ import io.github.nucleuspowered.nucleus.config.CommandsConfig;
 import io.github.nucleuspowered.nucleus.internal.annotations.ModuleCommandSet;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.command.AbstractCommand;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import ninja.leaping.configurate.commented.SimpleCommentedConfigurationNode;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
@@ -30,7 +31,9 @@ import java.util.stream.Collectors;
 
 public abstract class StandardModule implements Module {
 
-    private Optional<AbstractConfigAdapter<?>> adapter = null;
+    // We use an optional here to signify we've looked - so we don't perform another lookup. So, null -> do lookup,
+    // Optional.empty() -> did not exist, don't look again.
+    private Optional<NucleusConfigAdapter<?>> adapter = null;
 
     @Inject protected Nucleus nucleus;
     @Inject protected InternalServiceManager serviceManager;
@@ -45,10 +48,11 @@ public abstract class StandardModule implements Module {
             adapter.ifPresent(x -> nucleus.getInjector().injectMembers(x));
         }
 
-        return adapter;
+        // We need to use the right type...
+        return adapter.isPresent() ? Optional.of(adapter.get()) : Optional.empty();
     }
 
-    public Optional<AbstractConfigAdapter<?>> createConfigAdapter() {
+    public Optional<NucleusConfigAdapter<?>> createConfigAdapter() {
         return Optional.empty();
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/AdminModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/AdminModule.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.admin;
 
 import io.github.nucleuspowered.nucleus.internal.StandardModule;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.admin.config.AdminConfigAdapter;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
-import uk.co.drnaylor.quickstart.config.AbstractConfigAdapter;
 
 import java.util.Optional;
 
@@ -15,7 +15,7 @@ import java.util.Optional;
 public class AdminModule extends StandardModule {
 
     @Override
-    public Optional<AbstractConfigAdapter<?>> createConfigAdapter() {
+    public Optional<NucleusConfigAdapter<?>> createConfigAdapter() {
         return Optional.of(new AdminConfigAdapter());
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/afk/AFKModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/afk/AFKModule.java
@@ -5,10 +5,10 @@
 package io.github.nucleuspowered.nucleus.modules.afk;
 
 import io.github.nucleuspowered.nucleus.internal.StandardModule;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.afk.config.AFKConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.afk.handlers.AFKHandler;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
-import uk.co.drnaylor.quickstart.config.AbstractConfigAdapter;
 
 import java.util.Optional;
 
@@ -16,7 +16,7 @@ import java.util.Optional;
 public class AFKModule extends StandardModule {
 
     @Override
-    public Optional<AbstractConfigAdapter<?>> createConfigAdapter() {
+    public Optional<NucleusConfigAdapter<?>> createConfigAdapter() {
         return Optional.of(new AFKConfigAdapter());
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/back/BackModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/back/BackModule.java
@@ -7,11 +7,11 @@ package io.github.nucleuspowered.nucleus.modules.back;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.api.service.NucleusBackService;
 import io.github.nucleuspowered.nucleus.internal.StandardModule;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.back.config.BackConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.back.handlers.BackHandler;
 import org.spongepowered.api.Game;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
-import uk.co.drnaylor.quickstart.config.AbstractConfigAdapter;
 
 import java.util.Optional;
 
@@ -21,7 +21,7 @@ public class BackModule extends StandardModule {
     @Inject private Game game;
 
     @Override
-    public Optional<AbstractConfigAdapter<?>> createConfigAdapter() {
+    public Optional<NucleusConfigAdapter<?>> createConfigAdapter() {
         return Optional.of(new BackConfigAdapter());
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/blacklist/BlacklistModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/blacklist/BlacklistModule.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.blacklist;
 
 import io.github.nucleuspowered.nucleus.internal.StandardModule;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.blacklist.config.BlacklistConfigAdapter;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
-import uk.co.drnaylor.quickstart.config.AbstractConfigAdapter;
 
 import java.util.Optional;
 
@@ -15,7 +15,7 @@ import java.util.Optional;
 public class BlacklistModule extends StandardModule {
 
     @Override
-    public Optional<AbstractConfigAdapter<?>> createConfigAdapter() {
+    public Optional<NucleusConfigAdapter<?>> createConfigAdapter() {
         return Optional.of(new BlacklistConfigAdapter());
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/ChatModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/ChatModule.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.chat;
 
 import io.github.nucleuspowered.nucleus.internal.StandardModule;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.chat.config.ChatConfigAdapter;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
-import uk.co.drnaylor.quickstart.config.AbstractConfigAdapter;
 
 import java.util.Optional;
 
@@ -15,7 +15,7 @@ import java.util.Optional;
 public class ChatModule extends StandardModule {
 
     @Override
-    public Optional<AbstractConfigAdapter<?>> createConfigAdapter() {
+    public Optional<NucleusConfigAdapter<?>> createConfigAdapter() {
         return Optional.of(new ChatConfigAdapter());
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/connectionmessages/ConnectionMessagesModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/connectionmessages/ConnectionMessagesModule.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.connectionmessages;
 
 import io.github.nucleuspowered.nucleus.internal.StandardModule;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.connectionmessages.config.ConnectionMessagesConfigAdapter;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
-import uk.co.drnaylor.quickstart.config.AbstractConfigAdapter;
 
 import java.util.Optional;
 
@@ -15,7 +15,7 @@ import java.util.Optional;
 public class ConnectionMessagesModule extends StandardModule {
 
     @Override
-    public Optional<AbstractConfigAdapter<?>> createConfigAdapter() {
+    public Optional<NucleusConfigAdapter<?>> createConfigAdapter() {
         return Optional.of(new ConnectionMessagesConfigAdapter());
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/core/CoreModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/core/CoreModule.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.core;
 
 import io.github.nucleuspowered.nucleus.internal.StandardModule;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.core.config.CoreConfigAdapter;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
-import uk.co.drnaylor.quickstart.config.AbstractConfigAdapter;
 
 import java.util.Optional;
 
@@ -15,7 +15,7 @@ import java.util.Optional;
 public class CoreModule extends StandardModule {
 
     @Override
-    public Optional<AbstractConfigAdapter<?>> createConfigAdapter() {
+    public Optional<NucleusConfigAdapter<?>> createConfigAdapter() {
         return Optional.of(new CoreConfigAdapter());
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/JailModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/JailModule.java
@@ -9,12 +9,12 @@ import io.github.nucleuspowered.nucleus.Nucleus;
 import io.github.nucleuspowered.nucleus.api.service.NucleusJailService;
 import io.github.nucleuspowered.nucleus.internal.InternalServiceManager;
 import io.github.nucleuspowered.nucleus.internal.StandardModule;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.jail.config.JailConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.jail.handlers.JailHandler;
 import org.slf4j.Logger;
 import org.spongepowered.api.Game;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
-import uk.co.drnaylor.quickstart.config.AbstractConfigAdapter;
 
 import java.util.Optional;
 
@@ -27,7 +27,7 @@ public class JailModule extends StandardModule {
     @Inject private InternalServiceManager serviceManager;
 
     @Override
-    public Optional<AbstractConfigAdapter<?>> createConfigAdapter() {
+    public Optional<NucleusConfigAdapter<?>> createConfigAdapter() {
         return Optional.of(new JailConfigAdapter());
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/jump/JumpModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/jump/JumpModule.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.jump;
 
 import io.github.nucleuspowered.nucleus.internal.StandardModule;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.jump.config.JumpConfigAdapter;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
-import uk.co.drnaylor.quickstart.config.AbstractConfigAdapter;
 
 import java.util.Optional;
 
@@ -15,7 +15,7 @@ import java.util.Optional;
 public class JumpModule extends StandardModule {
 
     @Override
-    public Optional<AbstractConfigAdapter<?>> createConfigAdapter() {
+    public Optional<NucleusConfigAdapter<?>> createConfigAdapter() {
         return Optional.of(new JumpConfigAdapter());
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/jump/config/JumpConfigAdapter.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/jump/config/JumpConfigAdapter.java
@@ -5,20 +5,17 @@
 package io.github.nucleuspowered.nucleus.modules.jump.config;
 
 import com.google.common.reflect.TypeToken;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.commented.SimpleCommentedConfigurationNode;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import uk.co.drnaylor.quickstart.config.AbstractConfigAdapter;
 
-public class JumpConfigAdapter extends AbstractConfigAdapter<JumpConfig> {
+public class JumpConfigAdapter extends NucleusConfigAdapter<JumpConfig> {
 
     @Override
-    protected ConfigurationNode generateDefaults(ConfigurationNode node) {
-        try {
-            return node.setValue(TypeToken.of(JumpConfig.class), new JumpConfig());
-        } catch (ObjectMappingException e) {
-            return node;
-        }
+    protected JumpConfig getDefaultObject() {
+        return new JumpConfig();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/kit/KitModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/kit/KitModule.java
@@ -7,12 +7,12 @@ package io.github.nucleuspowered.nucleus.modules.kit;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.api.service.NucleusKitService;
 import io.github.nucleuspowered.nucleus.internal.StandardModule;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.kit.config.KitConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.kit.handlers.KitHandler;
 import org.slf4j.Logger;
 import org.spongepowered.api.Game;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
-import uk.co.drnaylor.quickstart.config.AbstractConfigAdapter;
 
 import java.util.Optional;
 
@@ -39,7 +39,7 @@ public class KitModule extends StandardModule {
     }
 
     @Override
-    public Optional<AbstractConfigAdapter<?>> createConfigAdapter() {
+    public Optional<NucleusConfigAdapter<?>> createConfigAdapter() {
         return Optional.of(new KitConfigAdapter());
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/message/MessageModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/message/MessageModule.java
@@ -7,11 +7,11 @@ package io.github.nucleuspowered.nucleus.modules.message;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.api.service.NucleusPrivateMessagingService;
 import io.github.nucleuspowered.nucleus.internal.StandardModule;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.message.config.MessageConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.message.handlers.MessageHandler;
 import org.spongepowered.api.Game;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
-import uk.co.drnaylor.quickstart.config.AbstractConfigAdapter;
 
 import java.util.Optional;
 
@@ -21,7 +21,7 @@ public class MessageModule extends StandardModule {
     @Inject private Game game;
 
     @Override
-    public Optional<AbstractConfigAdapter<?>> createConfigAdapter() {
+    public Optional<NucleusConfigAdapter<?>> createConfigAdapter() {
         return Optional.of(new MessageConfigAdapter());
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/mob/MobModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/mob/MobModule.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.mob;
 
 import io.github.nucleuspowered.nucleus.internal.StandardModule;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.mob.config.MobConfigAdapter;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
-import uk.co.drnaylor.quickstart.config.AbstractConfigAdapter;
 
 import java.util.Optional;
 
@@ -15,7 +15,7 @@ import java.util.Optional;
 public class MobModule extends StandardModule {
 
     @Override
-    public Optional<AbstractConfigAdapter<?>> createConfigAdapter() {
+    public Optional<NucleusConfigAdapter<?>> createConfigAdapter() {
         return Optional.of(new MobConfigAdapter());
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/nickname/NicknameModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/nickname/NicknameModule.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.nickname;
 
 import io.github.nucleuspowered.nucleus.internal.StandardModule;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.nickname.config.NicknameConfigAdapter;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
-import uk.co.drnaylor.quickstart.config.AbstractConfigAdapter;
 
 import java.util.Optional;
 
@@ -15,7 +15,7 @@ import java.util.Optional;
 public class NicknameModule extends StandardModule {
 
     @Override
-    public Optional<AbstractConfigAdapter<?>> createConfigAdapter() {
+    public Optional<NucleusConfigAdapter<?>> createConfigAdapter() {
         return Optional.of(new NicknameConfigAdapter());
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/playerinfo/PlayerInfoModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/playerinfo/PlayerInfoModule.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.playerinfo;
 
 import io.github.nucleuspowered.nucleus.internal.StandardModule;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.playerinfo.config.PlayerInfoConfigAdapter;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
-import uk.co.drnaylor.quickstart.config.AbstractConfigAdapter;
 
 import java.util.Optional;
 
@@ -15,7 +15,7 @@ import java.util.Optional;
 public class PlayerInfoModule extends StandardModule {
 
     @Override
-    public Optional<AbstractConfigAdapter<?>> createConfigAdapter() {
+    public Optional<NucleusConfigAdapter<?>> createConfigAdapter() {
         return Optional.of(new PlayerInfoConfigAdapter());
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/rules/RulesModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/rules/RulesModule.java
@@ -5,9 +5,9 @@
 package io.github.nucleuspowered.nucleus.modules.rules;
 
 import io.github.nucleuspowered.nucleus.internal.StandardModule;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.rules.config.RulesConfigAdapter;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
-import uk.co.drnaylor.quickstart.config.AbstractConfigAdapter;
 
 import java.util.Optional;
 
@@ -15,7 +15,7 @@ import java.util.Optional;
 public class RulesModule extends StandardModule {
 
     @Override
-    public Optional<AbstractConfigAdapter<?>> createConfigAdapter() {
+    public Optional<NucleusConfigAdapter<?>> createConfigAdapter() {
         return Optional.of(new RulesConfigAdapter());
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warp/WarpModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warp/WarpModule.java
@@ -7,12 +7,12 @@ package io.github.nucleuspowered.nucleus.modules.warp;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.api.service.NucleusWarpService;
 import io.github.nucleuspowered.nucleus.internal.StandardModule;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.warp.config.WarpConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.warp.handlers.WarpHandler;
 import org.slf4j.Logger;
 import org.spongepowered.api.Game;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
-import uk.co.drnaylor.quickstart.config.AbstractConfigAdapter;
 
 import java.util.Optional;
 
@@ -41,7 +41,7 @@ public class WarpModule extends StandardModule {
     }
 
     @Override
-    public Optional<AbstractConfigAdapter<?>> createConfigAdapter() {
+    public Optional<NucleusConfigAdapter<?>> createConfigAdapter() {
         return Optional.of(new WarpConfigAdapter());
     }
 }

--- a/src/test/java/io/github/nucleuspowered/nucleus/tests/sanity/SanityTests.java
+++ b/src/test/java/io/github/nucleuspowered/nucleus/tests/sanity/SanityTests.java
@@ -6,9 +6,11 @@ package io.github.nucleuspowered.nucleus.tests.sanity;
 
 import com.google.common.reflect.ClassPath;
 import io.github.nucleuspowered.nucleus.internal.StandardModule;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
 import org.junit.Assert;
 import org.junit.Test;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
+import uk.co.drnaylor.quickstart.config.AbstractConfigAdapter;
 
 import java.io.IOException;
 import java.util.List;
@@ -27,6 +29,21 @@ public class SanityTests {
         List<Class<?>> moduleList = sc.stream().filter(x -> !x.isAnnotationPresent(ModuleData.class)).collect(Collectors.toList());
         if (!moduleList.isEmpty()) {
             StringBuilder sb = new StringBuilder("Some modules do not have the ModuleData annotation: ");
+            moduleList.forEach(x -> sb.append(x.getName()).append(System.lineSeparator()));
+            Assert.fail(sb.toString());
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testThatAnythingThatIsAnAbstractConfigAdapterIsAlsoANucleusConfigAdapter() throws IOException {
+        Set<ClassPath.ClassInfo> ci = ClassPath.from(this.getClass().getClassLoader()).getTopLevelClassesRecursive("io.github.nucleuspowered.nucleus.modules");
+        Set<Class<? extends AbstractConfigAdapter<?>>> sc = ci.stream().map(ClassPath.ClassInfo::load).filter(AbstractConfigAdapter.class::isAssignableFrom)
+                .map(x -> (Class<? extends AbstractConfigAdapter<?>>)x).collect(Collectors.toSet());
+
+        List<Class<?>> moduleList = sc.stream().filter(x -> !NucleusConfigAdapter.class.isAssignableFrom(x)).collect(Collectors.toList());
+        if (!moduleList.isEmpty()) {
+            StringBuilder sb = new StringBuilder("Some config adapters are not of the NucleusConfigAdapter type: ");
             moduleList.forEach(x -> sb.append(x.getName()).append(System.lineSeparator()));
             Assert.fail(sb.toString());
         }


### PR DESCRIPTION
This is a bug fix to the issue discovered in #101 where a config adapter was not being attached correctly. This is due to a method not firing. A test has been added to flag up the non use of the `NucleusConfigAdapter`.

Needs testing. 