### PR TITLE
Add Staff chat channel.

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/config/UserService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/config/UserService.java
@@ -57,6 +57,9 @@ public class UserService extends AbstractSerialisableClassConfig<UserDataNode, C
     private Transform<World> lastLocation = null;
     private boolean logLastLocation = true;
 
+    // Use for /staffchat
+    private boolean inStaffChat = false;
+
     // Used as a cache.
     private Text nickname = null;
 
@@ -519,6 +522,16 @@ public class UserService extends AbstractSerialisableClassConfig<UserDataNode, C
     @Override
     public void setLogLastLocation(boolean logLastLocation) {
         this.logLastLocation = logLastLocation;
+    }
+
+    @Override
+    public boolean isInStaffChat() {
+        return inStaffChat;
+    }
+
+    @Override
+    public void setInStaffChat(boolean inStaffChat) {
+        this.inStaffChat = inStaffChat;
     }
 
     private String getNickPrefix() {

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/StandardModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/StandardModule.java
@@ -149,16 +149,7 @@ public abstract class StandardModule implements Module {
                 .collect(Collectors.toSet());
 
         Injector injector = nucleus.getInjector();
-        commandsToLoad.stream().map(x -> {
-            try {
-                ListenerBase lb = x.newInstance();
-                injector.injectMembers(lb);
-                return lb;
-            } catch (InstantiationException | IllegalAccessException e) {
-                e.printStackTrace();
-                return null;
-            }
-        }).filter(lb -> lb != null).forEach(c -> {
+        commandsToLoad.stream().map(injector::getInstance).filter(lb -> lb != null).forEach(c -> {
             // Register suggested permissions
             c.getPermissions().forEach((k, v) -> nucleus.getPermissionRegistry().registerOtherPermission(k, v));
             Sponge.getEventManager().registerListeners(nucleus, c);
@@ -173,16 +164,7 @@ public abstract class StandardModule implements Module {
                 .collect(Collectors.toSet());
 
         Injector injector = nucleus.getInjector();
-        commandsToLoad.stream().map(x -> {
-            try {
-                TaskBase lb = x.newInstance();
-                injector.injectMembers(lb);
-                return lb;
-            } catch (InstantiationException | IllegalAccessException e) {
-                e.printStackTrace();
-                return null;
-            }
-        }).filter(lb -> lb != null).forEach(c -> {
+        commandsToLoad.stream().map(injector::getInstance).filter(lb -> lb != null).forEach(c -> {
             c.getPermissions().forEach((k, v) -> nucleus.getPermissionRegistry().registerOtherPermission(k, v));
             Task.Builder tb = Sponge.getScheduler().createTaskBuilder().execute(c).interval(c.secondsPerRun(), TimeUnit.SECONDS);
             if (c.isAsync()) {

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/interfaces/InternalNucleusUser.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/interfaces/InternalNucleusUser.java
@@ -112,4 +112,8 @@ public interface InternalNucleusUser extends NucleusUser {
     boolean isLogLastLocation();
 
     void setLogLastLocation(boolean logLastLocation);
+
+    boolean isInStaffChat();
+
+    void setInStaffChat(boolean inStaffChat);
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/listeners/ChatListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/listeners/ChatListener.java
@@ -13,6 +13,7 @@ import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformati
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.chat.config.ChatConfig;
 import io.github.nucleuspowered.nucleus.modules.chat.config.ChatConfigAdapter;
+import io.github.nucleuspowered.nucleus.modules.staffchat.StaffChatMessageChannel;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.Order;
@@ -32,11 +33,13 @@ public class ChatListener extends ListenerBase {
 
     private final Map<String[], Function<String, String>> replacements;
 
-    @Inject private ChatConfigAdapter cca;
-    @Inject private ChatUtil chatUtil;
+    private final ChatConfigAdapter cca;
+    private final ChatUtil chatUtil;
 
-    // Zero args for the injector
-    public ChatListener() {
+    @Inject
+    public ChatListener(ChatUtil chatUtil, ChatConfigAdapter cca) {
+        this.chatUtil = chatUtil;
+        this.cca = cca;
         replacements = createReplacements();
     }
 
@@ -79,6 +82,11 @@ public class ChatListener extends ListenerBase {
     // We do this first so that other plugins can alter it later if needs be.
     @Listener(order = Order.EARLY)
     public void onPlayerChat(MessageChannelEvent.Chat event, @First Player player) {
+        if (event.getChannel().isPresent() && event.getChannel().get() instanceof StaffChatMessageChannel) {
+            // Staff chat. Not interested in applying these transforms.
+            return;
+        }
+
         ChatConfig config = cca.getNodeOrDefault();
         if (!config.isModifychat()) {
             return;
@@ -90,6 +98,4 @@ public class ChatListener extends ListenerBase {
                 useMessage(player, rawMessage),
                 chatUtil.getFromTemplate(config.getTemplate().getSuffix(), player, false));
     }
-
-
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/StaffChatMessageChannel.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/StaffChatMessageChannel.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.staffchat;
+
+import com.google.common.base.Preconditions;
+import io.github.nucleuspowered.nucleus.ChatUtil;
+import io.github.nucleuspowered.nucleus.Nucleus;
+import io.github.nucleuspowered.nucleus.modules.staffchat.commands.StaffChatCommand;
+import io.github.nucleuspowered.nucleus.modules.staffchat.config.StaffChatConfig;
+import io.github.nucleuspowered.nucleus.modules.staffchat.config.StaffChatConfigAdapter;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.channel.MessageChannel;
+import org.spongepowered.api.text.channel.MessageReceiver;
+import org.spongepowered.api.text.chat.ChatType;
+import org.spongepowered.api.text.serializer.TextSerializers;
+import uk.co.drnaylor.quickstart.exceptions.IncorrectAdapterTypeException;
+import uk.co.drnaylor.quickstart.exceptions.NoModuleException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class StaffChatMessageChannel implements MessageChannel {
+
+    static StaffChatMessageChannel INSTANCE = null;
+
+    public static StaffChatMessageChannel getInstance() {
+        Preconditions.checkState(INSTANCE != null, "StaffChatMessageChannel#Instance");
+        return INSTANCE;
+    }
+
+    private final Nucleus plugin;
+    private final ChatUtil chatUtil;
+    private StaffChatConfigAdapter scca;
+    private String basePerm;
+
+    StaffChatMessageChannel(Nucleus plugin) {
+        this.plugin = plugin;
+        chatUtil = plugin.getChatUtil();
+    }
+
+    // No injections, we have to do it the hard way!
+    private StaffChatConfig getConfig() {
+        if (scca == null) {
+            try {
+                scca = plugin.getModuleContainer().getConfigAdapterForModule(StaffChatModule.moduleID, StaffChatConfigAdapter.class);
+            } catch (NoModuleException | IncorrectAdapterTypeException e) {
+                e.printStackTrace();
+                return new StaffChatConfig();
+            }
+        }
+
+        return scca.getNodeOrDefault();
+    }
+
+    @Override
+    @Nonnull
+    public Optional<Text> transformMessage(@Nullable Object sender, MessageReceiver recipient, Text original, ChatType type) {
+        if (!(sender instanceof Player)) {
+            sender = Sponge.getServer().getConsole();
+        }
+
+        StaffChatConfig c = getConfig();
+        Text prefix = chatUtil.getFromTemplate(c.getMessageTemplate(), (CommandSource)sender, false);
+        return Optional.of(Text.of(prefix, TextSerializers.FORMATTING_CODE.deserialize(String.format("&%s%s", c.getMessageColour(), original.toPlain()))));
+    }
+
+    @Override
+    @Nonnull
+    public Collection<MessageReceiver> getMembers() {
+        List<MessageReceiver> c = Sponge.getServer().getOnlinePlayers().stream().filter(x -> x.hasPermission(getPermission())).collect(Collectors.toList());
+        c.add(Sponge.getServer().getConsole());
+        return c;
+    }
+
+    private String getPermission() {
+        if (basePerm == null) {
+            basePerm = plugin.getPermissionRegistry().getService(StaffChatCommand.class).get().getBase();
+        }
+
+        return basePerm;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/StaffChatModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/StaffChatModule.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.staffchat;
+
+import io.github.nucleuspowered.nucleus.internal.StandardModule;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
+import io.github.nucleuspowered.nucleus.modules.staffchat.config.StaffChatConfigAdapter;
+import uk.co.drnaylor.quickstart.annotations.ModuleData;
+
+import java.util.Optional;
+
+@ModuleData(id = StaffChatModule.moduleID, name = "Staff Chat")
+public class StaffChatModule extends StandardModule {
+
+    static final String moduleID = "staff-chat";
+
+    @Override
+    public Optional<NucleusConfigAdapter<?>> createConfigAdapter() {
+        return Optional.of(new StaffChatConfigAdapter());
+    }
+
+    @Override
+    protected void performPreTasks() throws Exception {
+        super.performPreTasks();
+
+        StaffChatMessageChannel.INSTANCE = new StaffChatMessageChannel(nucleus);
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/commands/StaffChatCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/commands/StaffChatCommand.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.staffchat.commands;
+
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.config.loaders.UserConfigLoader;
+import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
+import io.github.nucleuspowered.nucleus.internal.interfaces.InternalNucleusUser;
+import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import io.github.nucleuspowered.nucleus.modules.staffchat.StaffChatMessageChannel;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.serializer.TextSerializers;
+
+import java.util.Optional;
+
+@Permissions(suggestedLevel = SuggestedLevel.MOD)
+@RunAsync
+@NoWarmup
+@NoCooldown
+@NoCost
+@RegisterCommand({"staffchat", "sc", "a"})
+public class StaffChatCommand extends CommandBase<CommandSource> {
+
+    private final String message = "message";
+
+    @Inject private UserConfigLoader loader;
+
+    @Override
+    public CommandElement[] getArguments() {
+        return new CommandElement[] {
+            GenericArguments.optional(GenericArguments.remainingJoinedStrings(Text.of(message)))
+        };
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        Optional<String> toSend = args.getOne(message);
+        StaffChatMessageChannel scmc = StaffChatMessageChannel.getInstance();
+        if (toSend.isPresent()) {
+            scmc.send(src, TextSerializers.FORMATTING_CODE.deserialize(toSend.get()));
+            return CommandResult.success();
+        }
+
+        if (!(src instanceof Player)) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.staffchat.consoletoggle"));
+            return CommandResult.empty();
+        }
+
+        boolean result;
+        InternalNucleusUser user = loader.getUser((Player)src);
+        result = !user.isInStaffChat();
+        user.setInStaffChat(result);
+
+        src.sendMessage(Util.getTextMessageWithFormat("command.staffchat." + (result ? "on" : "off")));
+        return CommandResult.success();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/config/StaffChatConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/config/StaffChatConfig.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.staffchat.config;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+@ConfigSerializable
+public class StaffChatConfig {
+
+    @Setting(comment = "loc:config.staffchat.template")
+    private String messageTemplate = "&b[STAFF] &r{{displayname}}&b: ";
+
+    @Setting(comment = "loc:config.staffchat.colour")
+    private String messageColour = "b";
+
+    public String getMessageTemplate() {
+        return messageTemplate;
+    }
+
+    public String getMessageColour() {
+        if (messageColour.isEmpty() || !messageColour.matches("^[0-9a-f]")) {
+            return "b";
+        }
+
+        return messageColour.substring(0, 1);
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/config/StaffChatConfigAdapter.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/config/StaffChatConfigAdapter.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.staffchat.config;
+
+import com.google.common.reflect.TypeToken;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.commented.SimpleCommentedConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+
+public class StaffChatConfigAdapter extends NucleusConfigAdapter<StaffChatConfig> {
+
+    @Override
+    protected StaffChatConfig getDefaultObject() {
+        return new StaffChatConfig();
+    }
+
+    @Override
+    protected StaffChatConfig convertFromConfigurateNode(ConfigurationNode node) throws ObjectMappingException {
+        return node.getValue(TypeToken.of(StaffChatConfig.class), new StaffChatConfig());
+    }
+
+    @Override
+    protected ConfigurationNode insertIntoConfigurateNode(StaffChatConfig data) throws ObjectMappingException {
+        return SimpleCommentedConfigurationNode.root().setValue(TypeToken.of(StaffChatConfig.class), data);
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/listener/StaffChatListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/listener/StaffChatListener.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.staffchat.listener;
+
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.config.loaders.UserConfigLoader;
+import io.github.nucleuspowered.nucleus.internal.ListenerBase;
+import io.github.nucleuspowered.nucleus.modules.staffchat.StaffChatMessageChannel;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.Order;
+import org.spongepowered.api.event.filter.cause.First;
+import org.spongepowered.api.event.message.MessageChannelEvent;
+
+public class StaffChatListener extends ListenerBase {
+
+    @Inject private UserConfigLoader loader;
+
+    @Listener(order = Order.FIRST)
+    public void onMessage(MessageChannelEvent.Chat event, @First Player player) {
+        if (inAdminChat(player)) {
+            event.setMessage(event.getRawMessage());
+            event.setChannel(StaffChatMessageChannel.getInstance());
+        }
+    }
+
+    private boolean inAdminChat(Player player) {
+        try {
+            return loader.getUser(player).isInStaffChat();
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
+++ b/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
@@ -127,6 +127,10 @@ config.blacklist.inventory=If true, blacklisted items cannot exist in a player''
 
 config.rules.ruleset=The server rules, displayed when /rules is run. Supports Minecraft colour codes, prefixed with ampersands (&).
 
+config.staffchat.template='The prefix to the staff chat message. Use the following tokens: {{prefix}} - prefix (set as an option in a permission plugin), {{suffix}} - suffix (set as an option in a permission plugin), {{name}} - real name, {{displayname}} - display name.'
+
+config.staffchat.colour=A Minecraft colour code the denotes the colour to display Staff Chat channel messages in.
+
 afk.toafk=&7* &r{0} &7is now AFK.
 afk.fromafk=&7* &r{0} &7is no longer AFK.
 afk.kickedafk=has been kicked for being AFK too long.
@@ -598,6 +602,11 @@ command.firstkit.set.success=&aNew players will now receive the current contents
 command.firstkit.clear.success=&aNew players will no longer receive items when they first join the server.
 command.firstkit.redeem.success=&aRedeemed the first join kit.
 command.firstkit.redeem.reject=&c{0} items were not added to your inventory - possibly because it was full.
+
+command.staffchat.on=&bYou are now chatting in the Staff Chat Channel.
+command.staffchat.off=&bYou are no longer chatting in the Staff Chat Channel.
+
+command.staffchat.consoletoggle=&cToggle is not available for non-players, use /a <message>.
 
 # Ban
 ban.defaultreason=The BanHammer has spoken!


### PR DESCRIPTION
Adds #130.

Module: `staff-chat`
Command: `staffchat, sc, a` - toggles or sends a one off message.
Permission: `nucleus.staffchat.base` - suggests that mods and admins should have the permission.

Staff chat channel toggling persists only during the lifetime of the server session, guaranteed only when the user is logged on.