### PR TITLE
[WIP] Add way to apply default permissions.

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/SetupPermissionsCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/SetupPermissionsCommand.java
@@ -1,0 +1,118 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.core.commands;
+
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.internal.PermissionRegistry;
+import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
+import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
+import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import io.github.nucleuspowered.nucleus.modules.core.config.CoreConfigAdapter;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.*;
+import org.spongepowered.api.service.permission.PermissionService;
+import org.spongepowered.api.service.permission.Subject;
+import org.spongepowered.api.text.Text;
+
+import javax.annotation.Nullable;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Permissions(suggestedLevel = SuggestedLevel.NONE)
+@NoWarmup
+@NoCooldown
+@NoCost
+@RegisterCommand(value = "setupperms", subcommandOf = NucleusCommand.class)
+public class SetupPermissionsCommand extends CommandBase<CommandSource> {
+
+    @Inject private CoreConfigAdapter cca;
+    @Inject private PermissionRegistry permissionRegistry;
+
+    private final String roleKey = "Nucleus Role";
+    private final String groupKey = "Permission Group";
+
+    @Override
+    public CommandElement[] getArguments() {
+        return new CommandElement[] {
+            GenericArguments.onlyOne(GenericArguments.enumValue(Text.of(roleKey), SuggestedLevel.class)),
+            GenericArguments.onlyOne(new GroupArgument(Text.of(groupKey)))
+        };
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        String command = cca.getNodeOrDefault().getPermissionCommand();
+        if (command.isEmpty()) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.nucleus.permission.nocommand"));
+            return CommandResult.empty();
+        }
+
+        if (!command.toLowerCase().contains("{{group}}") || !command.toLowerCase().contains("{{perm}}")) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.nucleus.permission.notokens"));
+            return CommandResult.empty();
+        }
+
+        SuggestedLevel sl = args.<SuggestedLevel>getOne(roleKey).get();
+        String group = args.<String>getOne(groupKey).get();
+
+        // Register all the commands.
+        List<Map.Entry<String, PermissionInformation>> l = permissionRegistry.getPermissions().entrySet().stream()
+                .filter(x -> x.getValue().level == sl).collect(Collectors.toList());
+        for (Map.Entry<String, PermissionInformation> x : l) {
+            String c = command.replaceAll("\\{\\{group\\}\\}", group).replaceAll("\\{\\{perm\\}\\}", x.getKey());
+            Sponge.getCommandManager().process(src, c);
+        }
+
+        src.sendMessage(Util.getTextMessageWithFormat("command.nucleus.permission.success"));
+        return CommandResult.success();
+    }
+
+    private static class GroupArgument extends CommandElement {
+
+        GroupArgument(@Nullable Text key) {
+            super(key);
+        }
+
+        @Nullable
+        @Override
+        protected Object parseValue(CommandSource source, CommandArgs args) throws ArgumentParseException {
+            String a = args.next();
+            Optional<String> ls = getGroups(args).stream().filter(x -> x.equalsIgnoreCase(a)).findFirst();
+            if (ls.isPresent()) {
+                return ls.get();
+            }
+
+            throw args.createError(Util.getTextMessageWithFormat("args.permissiongroup.nogroup", a));
+        }
+
+        @Override
+        public List<String> complete(CommandSource src, CommandArgs args, CommandContext context) {
+            try {
+                String a = args.peek();
+                return getGroups(args).stream().filter(x -> x.toLowerCase().contains(a)).collect(Collectors.toList());
+            } catch (Exception e) {
+                return Collections.emptyList();
+            }
+        }
+
+        private Set<String> getGroups(CommandArgs args) throws ArgumentParseException {
+            Optional<PermissionService> ops = Sponge.getServiceManager().provide(PermissionService.class);
+            if (!ops.isPresent()) {
+                throw args.createError(Util.getTextMessageWithFormat("args.permissiongroup.noservice"));
+            }
+
+            PermissionService ps = ops.get();
+            Iterable<Subject> is = ps.getGroupSubjects().getAllSubjects();
+            Set<String> groups = Sets.newHashSet();
+            is.forEach(x -> groups.add(x.getIdentifier()));
+            return groups;
+        }
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/core/config/CoreConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/core/config/CoreConfig.java
@@ -16,11 +16,18 @@ public class CoreConfig {
     @Setting(value = "use-custom-message-file", comment = "loc:config.custommessages")
     private boolean custommessages = false;
 
+    @Setting(value = "permission-command", comment = "loc:config.permissioncommand")
+    private String permissionCommand = "";
+
     public boolean isDebugmode() {
         return debugmode;
     }
 
     public boolean isCustommessages() {
         return custommessages;
+    }
+
+    public String getPermissionCommand() {
+        return permissionCommand;
     }
 }

--- a/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
+++ b/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
@@ -131,6 +131,8 @@ config.staffchat.template='The prefix to the staff chat message. Use the followi
 
 config.staffchat.colour=A Minecraft colour code the denotes the colour to display Staff Chat channel messages in.
 
+config.permissioncommand='The command to run when auto adding permissions to groups. {{group}} refers to the name of the group you are adding permissions to, {{perm}} refers to the permission.'
+
 afk.toafk=&7* &r{0} &7is now AFK.
 afk.fromafk=&7* &r{0} &7is no longer AFK.
 afk.kickedafk=has been kicked for being AFK too long.
@@ -187,6 +189,9 @@ args.boundedinteger.nonumber=&cThe argument must be a number.
 
 args.gameprofile.none=&cThere are no users with the name {0}.
 args.gameprofile.format=&cThe name is not of the right format.
+
+args.permissiongroup.noservice=&cNo permissions plugin is installed.
+args.permissiongroup.nogroup=&cThe group "{0}" does not exist.
 
 commandlog.message={0} ran the command: /{1} {2}
 
@@ -622,6 +627,10 @@ command.enchant.overwrite=&cThe enchantments &e{0} &cwould be removed if you app
 command.enchant.success=&e{0} &alevel &e{1} &ahas been applied to the item in your hand.
 command.enchant.error=&cUnable to enchant the item in your hand with &e{0} &clevel &e{1}.
 
+command.nucleus.permission.notokens='&cNo {{group}} or {{perm}} token, please check your configuration.'
+command.nucleus.permission.nocommand=&cNo permission command was supplied in the configuration.
+command.nucleus.permission.success=&aCommands have been executed.
+
 # Ban
 ban.defaultreason=The BanHammer has spoken!
 
@@ -919,3 +928,6 @@ description.firstjoinkit.redeem.desc=Redeems the first join kit.
 description.staffchat.desc=Allows the user to chat in the staff chat channel.
 
 description.enchant.desc=Allows the user to enchant items.
+
+description.nucleus.setupperms.desc=Allows the user to add the recommended permissions for either USER, MOD or ADMIN roles to a specified group.
+


### PR DESCRIPTION
It occurred to me a while ago, and again when browsing the EssentialCmds forum thread, that with a load of permissions, server owners like a quick and easy way to apply the defaults. `PermissionDescription`s can potentially go some way to doing this, but some permission plugins just won't touch it.

So, I've written essentially what is a batch command processor, that takes a group and a Nucleus role (as shown on the website), and puts all relevant permissions into the group. However, the permission command must be user specified in the main config file, under `core.permission-command`. A suitable command that would work with PEX would be:

```
pex group {{group}} perm {{perm}} 1
```

The admin could then run `/nucleus setupperms USER user` to add all `USER` permissions to the group `user`, **as long as they have permission to add permissions** as Nucleus will run the command as the user.