### PR TITLE
Allow /setspawn to set the rotation

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/api/data/NucleusWorld.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/data/NucleusWorld.java
@@ -4,7 +4,10 @@
  */
 package io.github.nucleuspowered.nucleus.api.data;
 
+import com.flowpowered.math.vector.Vector3d;
 import io.github.nucleuspowered.nucleus.Nucleus;
+
+import java.util.Optional;
 
 /**
  * Represents data held about a world in {@link Nucleus}.
@@ -24,4 +27,10 @@ public interface NucleusWorld {
      * @param lockWeather <code>true</code> if the weather should be locked, <code>false</code> otherwise.
      */
     void setLockWeather(boolean lockWeather);
+
+    Optional<Vector3d> getSpawnRotation();
+
+    void setSpawnRotation(Vector3d rotation);
+
+    void clearSpawnRotation();
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/config/CommandsConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/config/CommandsConfig.java
@@ -4,12 +4,15 @@
  */
 package io.github.nucleuspowered.nucleus.config;
 
+import com.google.common.reflect.TypeToken;
 import io.github.nucleuspowered.nucleus.config.bases.AbstractStandardNodeConfig;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import ninja.leaping.configurate.commented.SimpleCommentedConfigurationNode;
 import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
 
 import java.nio.file.Path;
+import java.util.Map;
 
 public class CommandsConfig extends AbstractStandardNodeConfig<CommentedConfigurationNode, HoconConfigurationLoader> {
 
@@ -18,7 +21,7 @@ public class CommandsConfig extends AbstractStandardNodeConfig<CommentedConfigur
     }
 
     @Override
-    protected HoconConfigurationLoader getLoader(Path file) {
+    protected HoconConfigurationLoader getLoader(Path file, Map<TypeToken<?>, TypeSerializer<?>> typeSerializerList) {
         return HoconConfigurationLoader.builder().setPath(file).build();
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/config/GeneralDataStore.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/config/GeneralDataStore.java
@@ -21,6 +21,7 @@ import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.SimpleConfigurationNode;
 import ninja.leaping.configurate.gson.GsonConfigurationLoader;
 import ninja.leaping.configurate.loader.ConfigurationLoader;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
 import org.spongepowered.api.entity.Transform;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
@@ -45,7 +46,7 @@ public class GeneralDataStore extends AbstractSerialisableClassConfig<GeneralDat
     }
 
     @Override
-    protected ConfigurationLoader<ConfigurationNode> getLoader(Path file) {
+    protected ConfigurationLoader<ConfigurationNode> getLoader(Path file, Map<TypeToken<?>, TypeSerializer<?>> typeSerializerList) {
         return GsonConfigurationLoader.builder().setPath(file).build();
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/config/MessageConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/config/MessageConfig.java
@@ -5,14 +5,17 @@
 package io.github.nucleuspowered.nucleus.config;
 
 import com.google.common.base.Preconditions;
+import com.google.common.reflect.TypeToken;
 import io.github.nucleuspowered.nucleus.config.bases.AbstractStandardNodeConfig;
 import io.github.nucleuspowered.nucleus.internal.messages.ResourceMessageProvider;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import ninja.leaping.configurate.commented.SimpleCommentedConfigurationNode;
 import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
 
 import javax.annotation.Nonnull;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.Optional;
 
 public class MessageConfig extends AbstractStandardNodeConfig<CommentedConfigurationNode, HoconConfigurationLoader> {
@@ -31,7 +34,7 @@ public class MessageConfig extends AbstractStandardNodeConfig<CommentedConfigura
     }
 
     @Override
-    protected HoconConfigurationLoader getLoader(Path file) {
+    protected HoconConfigurationLoader getLoader(Path file, Map<TypeToken<?>, TypeSerializer<?>> typeSerializerList) {
         return HoconConfigurationLoader.builder().setPath(file).build();
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/config/UserService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/config/UserService.java
@@ -26,6 +26,7 @@ import io.github.nucleuspowered.nucleus.modules.nickname.config.NicknameConfigAd
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.SimpleConfigurationNode;
 import ninja.leaping.configurate.gson.GsonConfigurationLoader;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.entity.Transform;
 import org.spongepowered.api.entity.living.player.Player;
@@ -70,7 +71,7 @@ public class UserService extends AbstractSerialisableClassConfig<UserDataNode, C
     }
 
     @Override
-    protected GsonConfigurationLoader getLoader(Path file) {
+    protected GsonConfigurationLoader getLoader(Path file, Map<TypeToken<?>, TypeSerializer<?>> typeSerializerList) {
         return GsonConfigurationLoader.builder().setPath(file).build();
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/config/WorldService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/config/WorldService.java
@@ -4,42 +4,52 @@
  */
 package io.github.nucleuspowered.nucleus.config;
 
+import com.flowpowered.math.vector.Vector3d;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
 import com.google.common.reflect.TypeToken;
 import io.github.nucleuspowered.nucleus.Nucleus;
 import io.github.nucleuspowered.nucleus.api.data.NucleusWorld;
 import io.github.nucleuspowered.nucleus.config.bases.AbstractSerialisableClassConfig;
 import io.github.nucleuspowered.nucleus.config.serialisers.WorldDataNode;
+import io.github.nucleuspowered.nucleus.config.typeserialisers.Vector3dTypeSerialiser;
 import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.ConfigurationOptions;
 import ninja.leaping.configurate.SimpleConfigurationNode;
 import ninja.leaping.configurate.gson.GsonConfigurationLoader;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializerCollection;
 import org.spongepowered.api.world.World;
 
 import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 public class WorldService extends AbstractSerialisableClassConfig<WorldDataNode, ConfigurationNode, GsonConfigurationLoader> implements NucleusWorld {
 
+    private static final Map<TypeToken<?>, TypeSerializer<?>> serializerMap;
+
+    static {
+        serializerMap = Maps.newHashMap();
+        serializerMap.put(TypeToken.of(Vector3d.class), new Vector3dTypeSerialiser());
+    }
+
     private final Nucleus plugin;
 
-    // TODO: Think about whether we need the world object, or just the UUID.
-    private final World world;
+    private final UUID world;
 
     public WorldService(Nucleus plugin, Path worldPath, World world) throws Exception {
-        super(worldPath, TypeToken.of(WorldDataNode.class), WorldDataNode::new);
+        super(worldPath, TypeToken.of(WorldDataNode.class), WorldDataNode::new, true, serializerMap);
         Preconditions.checkNotNull(world);
         Preconditions.checkNotNull(plugin);
         this.plugin = plugin;
-        this.world = world;
+        this.world = world.getUniqueId();
         load();
     }
 
-    public World getWorld() {
-        return world;
-    }
-
     public UUID getUniqueID() {
-        return world.getUniqueId();
+        return world;
     }
 
     @Override
@@ -53,8 +63,37 @@ public class WorldService extends AbstractSerialisableClassConfig<WorldDataNode,
     }
 
     @Override
-    protected GsonConfigurationLoader getLoader(Path file) {
-        return GsonConfigurationLoader.builder().setPath(file).build();
+    public Optional<Vector3d> getSpawnRotation() {
+        return data.getSpawnRotation();
+    }
+
+    @Override
+    public void setSpawnRotation(Vector3d rotation) {
+        data.setSpawnRotation(rotation);
+    }
+
+    @Override
+    public void clearSpawnRotation() {
+        data.setSpawnRotation(null);
+    }
+
+    @Override
+    protected GsonConfigurationLoader getLoader(Path file, Map<TypeToken<?>, TypeSerializer<?>> typeSerializerList) {
+        GsonConfigurationLoader.Builder gsb = GsonConfigurationLoader.builder();
+
+        if (!typeSerializerList.isEmpty()) {
+            ConfigurationOptions co = gsb.getDefaultOptions();
+            TypeSerializerCollection tsc = co.getSerializers();
+            typeSerializerList.forEach((t, s) -> {
+                // Normal unsafe magic.
+                tsc.registerType((TypeToken)t, (TypeSerializer)s);
+            });
+
+            co.setSerializers(tsc);
+            gsb.setDefaultOptions(co);
+        }
+
+        return gsb.setPath(file).build();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/config/bases/AbstractConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/config/bases/AbstractConfig.java
@@ -4,12 +4,15 @@
  */
 package io.github.nucleuspowered.nucleus.config.bases;
 
+import com.google.common.reflect.TypeToken;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.loader.ConfigurationLoader;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Map;
 
 public abstract class AbstractConfig<T extends ConfigurationNode, L extends ConfigurationLoader<T>> {
 
@@ -17,5 +20,5 @@ public abstract class AbstractConfig<T extends ConfigurationNode, L extends Conf
 
     public abstract void save() throws IOException, ObjectMappingException;
 
-    protected abstract L getLoader(Path file);
+    protected abstract L getLoader(Path file, Map<TypeToken<?>, TypeSerializer<?>> typeSerializerList);
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/config/bases/AbstractSerialisableClassConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/config/bases/AbstractSerialisableClassConfig.java
@@ -5,13 +5,16 @@
 package io.github.nucleuspowered.nucleus.config.bases;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
 import com.google.common.reflect.TypeToken;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.loader.ConfigurationLoader;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.function.Supplier;
 
 /**
@@ -33,10 +36,15 @@ public abstract class AbstractSerialisableClassConfig<D, T extends Configuration
     }
 
     public AbstractSerialisableClassConfig(Path file, TypeToken<D> dataType, Supplier<D> defaultData, boolean load) throws Exception {
+        this(file, dataType, defaultData, load, Maps.newHashMap());
+    }
+
+    public AbstractSerialisableClassConfig(Path file, TypeToken<D> dataType, Supplier<D> defaultData, boolean load, Map<TypeToken<?>, TypeSerializer<?>> lts) throws Exception {
         Preconditions.checkNotNull(file);
         Preconditions.checkNotNull(dataType);
         Preconditions.checkNotNull(defaultData);
-        this.loader = getLoader(file);
+
+        this.loader = getLoader(file, lts);
         this.dataType = dataType;
         this.defaultData = defaultData;
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/config/bases/AbstractStandardNodeConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/config/bases/AbstractStandardNodeConfig.java
@@ -4,12 +4,16 @@
  */
 package io.github.nucleuspowered.nucleus.config.bases;
 
+import com.google.common.collect.Maps;
+import com.google.common.reflect.TypeToken;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.loader.ConfigurationLoader;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Map;
 
 public abstract class AbstractStandardNodeConfig<T extends ConfigurationNode, L extends ConfigurationLoader<T>> extends AbstractConfig<T, L> {
 
@@ -17,7 +21,11 @@ public abstract class AbstractStandardNodeConfig<T extends ConfigurationNode, L 
     protected T node;
 
     protected AbstractStandardNodeConfig(Path file) throws Exception {
-        loader = getLoader(file);
+        this(file, Maps.newHashMap());
+    }
+
+    protected AbstractStandardNodeConfig(Path file, Map<TypeToken<?>, TypeSerializer<?>> serializerMap) throws Exception {
+        loader = getLoader(file, serializerMap);
         load();
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/config/serialisers/WorldDataNode.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/config/serialisers/WorldDataNode.java
@@ -4,8 +4,12 @@
  */
 package io.github.nucleuspowered.nucleus.config.serialisers;
 
+import com.flowpowered.math.vector.Vector3d;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
 
 /**
  * Contains the config entries for any World Config.
@@ -15,11 +19,23 @@ public class WorldDataNode {
     @Setting("lock-weather")
     private boolean lockWeather = false;
 
+    @Setting("spawn-rotation")
+    @Nullable
+    private Vector3d spawnRotation = null;
+
     public boolean isLockWeather() {
         return lockWeather;
     }
 
     public void setLockWeather(boolean lockWeather) {
         this.lockWeather = lockWeather;
+    }
+
+    public Optional<Vector3d> getSpawnRotation() {
+        return Optional.ofNullable(spawnRotation);
+    }
+
+    public void setSpawnRotation(@Nullable Vector3d spawnRotation) {
+        this.spawnRotation = spawnRotation;
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/config/typeserialisers/Vector3dTypeSerialiser.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/config/typeserialisers/Vector3dTypeSerialiser.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.config.typeserialisers;
+
+import com.flowpowered.math.vector.Vector3d;
+import com.google.common.reflect.TypeToken;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
+
+public class Vector3dTypeSerialiser implements TypeSerializer<Vector3d> {
+
+    @Override
+    public Vector3d deserialize(TypeToken<?> type, ConfigurationNode value) throws ObjectMappingException {
+        return new Vector3d(value.getNode("rotx").getDouble(), value.getNode("roty").getDouble(), value.getNode("rotz").getDouble());
+    }
+
+    @Override
+    public void serialize(TypeToken<?> type, Vector3d obj, ConfigurationNode value) throws ObjectMappingException {
+        value.getNode("rotx").setValue(obj.getX());
+        value.getNode("roty").setValue(obj.getY());
+        value.getNode("rotz").setValue(obj.getZ());
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/spawn/commands/SetSpawnCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/spawn/commands/SetSpawnCommand.java
@@ -5,16 +5,15 @@
 package io.github.nucleuspowered.nucleus.modules.spawn.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.internal.annotations.NoCooldown;
-import io.github.nucleuspowered.nucleus.internal.annotations.NoCost;
-import io.github.nucleuspowered.nucleus.internal.annotations.NoWarmup;
-import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
-import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.config.loaders.WorldConfigLoader;
+import io.github.nucleuspowered.nucleus.internal.annotations.*;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.args.CommandElement;
 import org.spongepowered.api.entity.living.player.Player;
+
+import javax.inject.Inject;
 
 @RegisterCommand({"setspawn"})
 @Permissions
@@ -23,6 +22,9 @@ import org.spongepowered.api.entity.living.player.Player;
 @NoCost
 public class SetSpawnCommand extends CommandBase<Player> {
 
+    @Inject
+    private WorldConfigLoader wcl;
+
     @Override
     public CommandElement[] getArguments() {
         return super.getArguments();
@@ -30,6 +32,8 @@ public class SetSpawnCommand extends CommandBase<Player> {
 
     @Override
     public CommandResult executeCommand(Player src, CommandContext args) throws Exception {
+        // Minecraft does not set the rotation of the player at the spawn point, so we'll do it for them!
+        wcl.getWorld(src.getWorld().getUniqueId()).setSpawnRotation(src.getRotation());
         src.getWorld().getProperties().setSpawnPosition(src.getLocation().getBlockPosition());
         src.sendMessage(Util.getTextMessageWithFormat("command.setspawn.success", src.getWorld().getName()));
         return CommandResult.success();

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/spawn/commands/SpawnCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/spawn/commands/SpawnCommand.java
@@ -6,6 +6,7 @@ package io.github.nucleuspowered.nucleus.modules.spawn.commands;
 
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.config.loaders.WorldConfigLoader;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
@@ -33,6 +34,7 @@ import java.util.Optional;
 public class SpawnCommand extends CommandBase<Player> {
 
     @Inject(optional = true) private BackHandler backHandler;
+    @Inject private WorldConfigLoader wcl;
 
     private final String key = "world";
 
@@ -61,7 +63,8 @@ public class SpawnCommand extends CommandBase<Player> {
             return CommandResult.empty();
         }
 
-        if (src.setLocationSafely(new Location<>(ow.get(), wp.getSpawnPosition()))) {
+        // If we don't have a rotation, then use the current rotation
+        if (src.setLocationAndRotationSafely(new Location<>(ow.get(), wp.getSpawnPosition()), wcl.getWorld(wp.getUniqueId()).getSpawnRotation().orElse(src.getRotation()))) {
             if (backHandler != null) {
                 backHandler.setLastLocationInternal(src, currentLocation);
             }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/spawn/listeners/SpawnListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/spawn/listeners/SpawnListener.java
@@ -4,14 +4,18 @@
  */
 package io.github.nucleuspowered.nucleus.modules.spawn.listeners;
 
+import com.flowpowered.math.vector.Vector3d;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.config.GeneralDataStore;
+import io.github.nucleuspowered.nucleus.config.loaders.WorldConfigLoader;
 import io.github.nucleuspowered.nucleus.internal.ListenerBase;
+import io.github.nucleuspowered.nucleus.modules.core.config.CoreConfigAdapter;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.Transform;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.entity.living.humanoid.player.RespawnPlayerEvent;
 import org.spongepowered.api.event.network.ClientConnectionEvent;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
@@ -22,6 +26,8 @@ import java.util.Optional;
 public class SpawnListener extends ListenerBase {
 
     @Inject private GeneralDataStore store;
+    @Inject private WorldConfigLoader wcl;
+    @Inject private CoreConfigAdapter cca;
 
     // No point in having a filter here - only players are going to appear!
     @Listener
@@ -38,6 +44,35 @@ public class SpawnListener extends ListenerBase {
             if (!ofs.isPresent() || !pl.setLocationAndRotationSafely(ofs.get().getLocation(), ofs.get().getRotation())) {
                 WorldProperties w = Sponge.getServer().getDefaultWorld().get();
                 pl.setLocation(new Location<>(Sponge.getServer().getWorld(w.getUniqueId()).get(), w.getSpawnPosition().toDouble()));
+            }
+        }
+    }
+
+    @Listener
+    public void onRespawn(RespawnPlayerEvent event) {
+        if (event.isBedSpawn()) {
+            // Nope, we don't care.
+            return;
+        }
+
+        // If we have a spawn to the world in the standard spawn location, add our rotation.
+        try {
+            // ...of course, that depends on our rotation.
+            Optional<Vector3d> ov = wcl.getWorld(event.getToTransform().getExtent()).getSpawnRotation();
+            if (ov.isPresent()) {
+                // Compare current transform to spawn.
+                Transform<World> to = event.getToTransform();
+                Location<World> spawn = event.getToTransform().getExtent().getSpawnLocation();
+
+                // We're spawning in the same place if this is true, so set the rotation.
+                if (to.getLocation().getBlockPosition().equals(spawn.getBlockPosition())) {
+                    to.setRotation(ov.get());
+                    event.setToTransform(to);
+                }
+            }
+        } catch (Exception e) {
+            if (cca.getNodeOrDefault().isDebugmode()) {
+                e.printStackTrace();
             }
         }
     }


### PR DESCRIPTION
Vanilla Minecraft does not allow for rotation to be set for the spawn point, only the location. We store the rotation and try to apply it if we detect a location that is consistent with the spawn point on respawn.

Closes #154