### PR TITLE
Add /info command.

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/ChatUtil.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/ChatUtil.java
@@ -184,14 +184,23 @@ public class ChatUtil {
 
     private StyleTuple getLastColourAndStyle(Text text, StyleTuple current) {
         List<Text> texts = flatten(text);
-        Optional<TextColor> otc = texts.stream().sorted(Comparator.reverseOrder()).filter(x -> x.getColor() != TextColors.NONE).map(Text::getColor).findFirst();
-        Optional<TextStyle> ots = texts.stream().sorted(Comparator.reverseOrder()).filter(x -> x.getStyle() != TextStyles.NONE).map(Text::getStyle).findFirst();
+        TextColor tc = TextColors.NONE;
+        TextStyle ts = TextStyles.NONE;
+        for (int i = texts.size() - 1; i > -1 || (tc != TextColors.NONE && ts != TextStyles.NONE); i--) {
+            if (tc == TextColors.NONE) {
+                tc = texts.get(i).getColor();
+            }
 
-        if (current == null) {
-            return new StyleTuple(otc.orElse(TextColors.NONE), ots.orElse(TextStyles.NONE));
+            if (ts == TextStyles.NONE) {
+                ts = texts.get(i).getStyle();
+            }
         }
 
-        return new StyleTuple(otc.orElse(current.colour), ots.orElse(current.style));
+        if (current == null) {
+            return new StyleTuple(tc, ts);
+        }
+
+        return new StyleTuple(tc != TextColors.NONE ? tc : current.colour, ts != TextStyles.NONE ? ts : current.style);
     }
 
     private List<Text> flatten(Text text) {

--- a/src/main/java/io/github/nucleuspowered/nucleus/Nucleus.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/Nucleus.java
@@ -4,6 +4,7 @@
  */
 package io.github.nucleuspowered.nucleus;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
@@ -25,6 +26,7 @@ import io.github.nucleuspowered.nucleus.internal.PermissionRegistry;
 import io.github.nucleuspowered.nucleus.internal.TextFileController;
 import io.github.nucleuspowered.nucleus.internal.guice.QuickStartInjectorModule;
 import io.github.nucleuspowered.nucleus.internal.guice.SubInjectorModule;
+import io.github.nucleuspowered.nucleus.internal.interfaces.Reloadable;
 import io.github.nucleuspowered.nucleus.internal.messages.ConfigMessageProvider;
 import io.github.nucleuspowered.nucleus.internal.messages.MessageProvider;
 import io.github.nucleuspowered.nucleus.internal.messages.ResourceMessageProvider;
@@ -60,6 +62,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -77,6 +80,7 @@ public class Nucleus {
     private ChatUtil chatUtil;
     private Injector injector;
     private SubInjectorModule subInjectorModule = new SubInjectorModule();
+    private List<Reloadable> reloadableList = Lists.newArrayList();
 
     private InternalServiceManager serviceManager = new InternalServiceManager(this);
     private MessageProvider messageProvider = new ResourceMessageProvider();
@@ -248,6 +252,10 @@ public class Nucleus {
             for (TextFileController tfc : textFileControllers.values()) {
                 tfc.load();
             }
+
+            for (Reloadable r : reloadableList) {
+                r.onReload();
+            }
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -324,6 +332,10 @@ public class Nucleus {
         if (!textFileControllers.containsKey(id)) {
             textFileControllers.put(id, new TextFileController(asset, file));
         }
+    }
+
+    public void registerReloadable(Reloadable reloadable) {
+        reloadableList.add(reloadable);
     }
 
     private Injector runInjectorUpdate() {

--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/InfoArgument.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/InfoArgument.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.argumentparsers;
+
+import com.google.common.base.Preconditions;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.modules.info.handlers.InfoHandler;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.ArgumentParseException;
+import org.spongepowered.api.command.args.CommandArgs;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.text.Text;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class InfoArgument extends CommandElement {
+
+    private final InfoHandler handler;
+
+    public InfoArgument(@Nullable Text key, InfoHandler handler) {
+        super(key);
+        Preconditions.checkNotNull(handler);
+        this.handler = handler;
+    }
+
+    @Nullable
+    @Override
+    protected Object parseValue(CommandSource source, CommandArgs args) throws ArgumentParseException {
+        String a = args.next();
+        Optional<List<String>> list = handler.getSection(a);
+        if (list.isPresent()) {
+            return new Result(handler.getInfoSections().stream().filter(a::equalsIgnoreCase).findFirst().get(), list.get());
+        }
+
+        throw args.createError(Util.getTextMessageWithFormat("args.info.noinfo", a));
+    }
+
+    @Override
+    public List<String> complete(CommandSource src, CommandArgs args, CommandContext context) {
+        try {
+            String p = args.peek();
+            return handler.getInfoSections().stream().filter(x -> x.toLowerCase().startsWith(p.toLowerCase())).collect(Collectors.toList());
+        } catch (Exception e) {
+            return handler.getInfoSections().stream().collect(Collectors.toList());
+        }
+    }
+
+    public static class Result {
+        public final String name;
+        public final List<String> text;
+
+        private Result(String name, List<String> text) {
+            this.name = name;
+            this.text = text;
+        }
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/TextFileController.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/TextFileController.java
@@ -33,6 +33,10 @@ public final class TextFileController {
      */
     private final List<String> fileContents = Lists.newArrayList();
 
+    public TextFileController(Path fileLocation) throws IOException {
+        this(null, fileLocation);
+    }
+
     public TextFileController(Asset asset, Path fileLocation) throws IOException {
         this.asset = asset;
         this.fileLocation = fileLocation;
@@ -42,10 +46,10 @@ public final class TextFileController {
     /**
      * Loads the file and refreshes the contents of the file in memory.
      *
-     * @throws IOException Thown if there is an issue getting the file.
+     * @throws IOException Thrown if there is an issue getting the file.
      */
     public void load() throws IOException {
-        if (!Files.exists(fileLocation)) {
+        if (asset != null && !Files.exists(fileLocation)) {
             // Create the file
             asset.copyToFile(fileLocation);
         }

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/interfaces/Reloadable.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/interfaces/Reloadable.java
@@ -1,0 +1,18 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.internal.interfaces;
+
+/**
+ * An interface that allows the class to be notified that there is a Nucleus reload.
+ */
+public interface Reloadable {
+
+    /**
+     * Reload the data associated with this {@link Reloadable}
+     *
+     * @throws Exception Thrown if there is an issue.
+     */
+    void onReload() throws Exception;
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/info/InfoModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/info/InfoModule.java
@@ -7,6 +7,7 @@ package io.github.nucleuspowered.nucleus.modules.info;
 import io.github.nucleuspowered.nucleus.internal.StandardModule;
 import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.info.config.InfoConfigAdapter;
+import io.github.nucleuspowered.nucleus.modules.info.handlers.InfoHandler;
 import org.spongepowered.api.Sponge;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
 
@@ -30,5 +31,10 @@ public class InfoModule extends StandardModule {
                 MOTD_KEY,
                 Sponge.getAssetManager().getAsset(nucleus, "motd.txt").get(),
                 nucleus.getConfigDirPath().resolve("motd.txt"));
+
+        InfoHandler ih = new InfoHandler(nucleus);
+        serviceManager.registerService(InfoHandler.class, ih);
+        nucleus.registerReloadable(ih);
+        ih.onReload();
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/info/commands/InfoCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/info/commands/InfoCommand.java
@@ -1,0 +1,142 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.info.commands;
+
+import com.google.common.collect.Lists;
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.ChatUtil;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.argumentparsers.InfoArgument;
+import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
+import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import io.github.nucleuspowered.nucleus.modules.info.handlers.InfoHandler;
+import io.github.nucleuspowered.nucleus.modules.info.handlers.InfoHelper;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.command.source.ConsoleSource;
+import org.spongepowered.api.service.pagination.PaginationList;
+import org.spongepowered.api.service.pagination.PaginationService;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.action.TextActions;
+import org.spongepowered.api.text.format.TextColors;
+import org.spongepowered.api.text.format.TextStyles;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@Permissions(suggestedLevel = SuggestedLevel.USER)
+@RunAsync
+@NoCooldown
+@NoCost
+@NoWarmup
+@RegisterCommand({"info", "einfo"})
+public class InfoCommand extends CommandBase<CommandSource> {
+
+    @Inject private InfoHandler infoHandler;
+    @Inject private ChatUtil chatUtil;
+
+    private final String key = "section";
+
+    @Override
+    public CommandElement[] getArguments() {
+        return new CommandElement[] {
+            GenericArguments.optional(new InfoArgument(Text.of(key), infoHandler))
+        };
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        Optional<InfoArgument.Result> oir = args.getOne(key);
+        if (oir.isPresent()) {
+            // Get the list.
+            List<String> info = oir.get().text;
+            Optional<String> os = getTitle(info);
+            String title;
+            if (os.isPresent()) {
+                title = Util.getMessageWithFormat("command.info.title.section", os.get());
+
+                // Just in case the list is immutable.
+                info = Lists.newArrayList(info);
+                info.remove(0);
+
+                // Remove blank lines.
+                Iterator<String> i = info.iterator();
+                while (i.hasNext()) {
+                    String n = i.next();
+                    if (n.isEmpty() || n.matches("^\\s+$")) {
+                        i.remove();
+                    } else {
+                        break;
+                    }
+                }
+            } else {
+                title = Util.getMessageWithFormat("command.info.title.section", oir.get().name);
+            }
+
+            InfoHelper.sendInfo(info, src, chatUtil, title);
+            return CommandResult.success();
+        }
+
+        // Create a list of pages to load.
+        Set<String> sections = infoHandler.getInfoSections();
+        if (sections.isEmpty()) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.info.none"));
+            return CommandResult.empty();
+        }
+
+        // Create the text.
+        List<Text> s = Lists.newArrayList();
+        sections.forEach(x -> {
+            Text.Builder tb = Text.builder().append(Text.builder(x)
+                    .color(TextColors.GREEN).style(TextStyles.ITALIC)
+                    .onHover(TextActions.showText(Util.getTextMessageWithFormat("command.info.hover", x)))
+                    .onClick(TextActions.runCommand("/info " + x)).build());
+
+            // If there is a title, then add it.
+            getTitle(infoHandler.getSection(x).get()).ifPresent(sub ->
+                    tb.append(Text.of(TextColors.GOLD, " - ")).append(chatUtil.getServerMessageFromTemplate(sub, src, true)));
+
+            s.add(tb.build());
+        });
+
+        PaginationService ps = Sponge.getServiceManager().provideUnchecked(PaginationService.class);
+        PaginationList.Builder pb = ps.builder().contents()
+                .header(Util.getTextMessageWithFormat("command.info.header.default"))
+                .title(Util.getTextMessageWithFormat("command.info.title.default"))
+                .contents(s)
+                .padding(Text.of(TextColors.GOLD, "-"));
+
+        if (src instanceof ConsoleSource) {
+            pb.linesPerPage(-1);
+        }
+
+        pb.sendTo(src);
+        return CommandResult.success();
+    }
+
+    private Optional<String> getTitle(List<String> info) {
+        if (!info.isEmpty()) {
+            String sec1 = info.get(0);
+            if (sec1.startsWith("#")) {
+                // Get rid of the # and spaces, then limit to 50 characters.
+                sec1 = sec1.replaceFirst("#\\s*", "");
+                if (sec1.length() > 50) {
+                    sec1 = sec1.substring(0, 50);
+                }
+
+                return Optional.of(sec1);
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/info/commands/MotdCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/info/commands/MotdCommand.java
@@ -39,7 +39,7 @@ public class MotdCommand extends CommandBase<CommandSource> {
             return CommandResult.empty();
         }
 
-        InfoHelper.sendMotd(otfc.get(), src, chatUtil, infoConfigAdapter.getNodeOrDefault().getMotdTitle());
+        InfoHelper.sendInfo(otfc.get(), src, chatUtil, infoConfigAdapter.getNodeOrDefault().getMotdTitle());
         return CommandResult.success();
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/info/handlers/InfoHandler.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/info/handlers/InfoHandler.java
@@ -1,0 +1,107 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.info.handlers;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import io.github.nucleuspowered.nucleus.Nucleus;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.internal.TextFileController;
+import io.github.nucleuspowered.nucleus.internal.interfaces.Reloadable;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.asset.AssetManager;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class InfoHandler implements Reloadable {
+
+    private final Map<String, TextFileController> infoFiles = Maps.newHashMap();
+    private final Nucleus plugin;
+    private final Pattern validFile = Pattern.compile("[a-zA-Z0-9_\\.\\-]+\\.txt", Pattern.CASE_INSENSITIVE);
+
+    public InfoHandler(Nucleus plugin) {
+        this.plugin = plugin;
+    }
+
+    public Set<String> getInfoSections() {
+        return ImmutableSet.copyOf(infoFiles.keySet());
+    }
+
+    /**
+     * Gets the text associated with the specified key, if it exists.
+     *
+     * <p>
+     *     While it is not normal to return an optional of a collection (usually preferring an empty collection)
+     *     in this case, a "not present" value is different to an "empty file" value.
+     * </p>
+     *
+     * @param name The name of the section to retrieve the keys from.
+     * @return An {@link Optional} potentially containing the list of strings.
+     *
+     */
+    public Optional<List<String>> getSection(String name) {
+        Optional<String> os = infoFiles.keySet().stream().filter(name::equalsIgnoreCase).findFirst();
+        if (os.isPresent()) {
+            return Optional.of(infoFiles.get(name).getFileContents());
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public void onReload() throws Exception {
+        // Get the config directory, check to see if "info/" exists.
+        Path infoDir = plugin.getConfigDirPath().resolve("info");
+        if (!Files.exists(infoDir)) {
+            Files.createDirectories(infoDir);
+            AssetManager am = Sponge.getAssetManager();
+
+            // They exist.
+            am.getAsset(plugin, "info.txt").get().copyToFile(infoDir.resolve("info.txt"));
+            am.getAsset(plugin, "colors.txt").get().copyToFile(infoDir.resolve("colors.txt"));
+        } else if (!Files.isDirectory(infoDir)) {
+            throw new IllegalStateException("The file " + infoDir.toAbsolutePath().toString() + " should be a directory.");
+        }
+
+        // Get all txt files.
+        List<Path> files;
+        try (Stream<Path> sp = Files.list(infoDir)) {
+            files = sp.filter(Files::isRegularFile)
+              .filter(x -> validFile.matcher(x.getFileName().toString()).matches()).collect(Collectors.toList());
+        }
+
+        // Collect them and put the resultant controllers into a temporary map.
+        Map<String, TextFileController> mst = Maps.newHashMap();
+        files.forEach(x -> {
+            try {
+                String name = x.getFileName().toString();
+                name = name.substring(0, name.length() - 4);
+                if (mst.keySet().stream().anyMatch(name::equalsIgnoreCase)) {
+                    plugin.getLogger().warn(Util.getMessageWithFormat("info.load.duplicate", x.getFileName().toString()));
+
+                    // This is a function, so return is appropriate, not break.
+                    return;
+                }
+
+                mst.put(name, new TextFileController(x));
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        });
+
+        // All good - replace it all!
+        infoFiles.clear();
+        infoFiles.putAll(mst);
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/info/handlers/InfoHelper.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/info/handlers/InfoHelper.java
@@ -19,9 +19,13 @@ import java.util.List;
 
 public class InfoHelper {
 
-    public static void sendMotd(TextFileController tfc, CommandSource src, ChatUtil chatUtil, String motdTitle) {
+    public static void sendInfo(TextFileController tfc, CommandSource src, ChatUtil chatUtil, String motdTitle) {
+        sendInfo(tfc.getFileContents(), src, chatUtil, motdTitle);
+    }
+
+    public static void sendInfo(List<String> tfc, CommandSource src, ChatUtil chatUtil, String motdTitle) {
         // Get the text.
-        List<Text> textList = chatUtil.getFromStrings(tfc.getFileContents(), src);
+        List<Text> textList = chatUtil.getFromStrings(tfc, src);
 
         PaginationService ps = Sponge.getServiceManager().provideUnchecked(PaginationService.class);
         PaginationList.Builder pb = ps.builder().contents(textList).padding(Text.of(TextColors.GOLD, "-"));

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/info/listeners/InfoListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/info/listeners/InfoListener.java
@@ -44,7 +44,7 @@ public class InfoListener extends ListenerBase {
         // Send message one second later on the Async thread.
         Sponge.getScheduler().createAsyncExecutor(plugin).schedule(() -> {
                 if (player.hasPermission(getMotdPermission())) {
-                    plugin.getTextFileController(InfoModule.MOTD_KEY).ifPresent(x -> InfoHelper.sendMotd(x, player, chatUtil, ica.getNodeOrDefault().getMotdTitle()));
+                    plugin.getTextFileController(InfoModule.MOTD_KEY).ifPresent(x -> InfoHelper.sendInfo(x, player, chatUtil, ica.getNodeOrDefault().getMotdTitle()));
                 }
             }, 500, TimeUnit.MILLISECONDS);
     }

--- a/src/main/resources/assets/io/github/nucleuspowered/nucleus/colors.txt
+++ b/src/main/resources/assets/io/github/nucleuspowered/nucleus/colors.txt
@@ -1,0 +1,27 @@
+#Minecraft Color Codes
+In Nucleus, to use these color codes in chat or other server messages, prefix the number or letter with the "&" symbol.
+
+&0 0 Black
+&1 1 Dark Blue
+&2 2 Dark Green
+&3 3 Dark Aqua
+&4 4 Dark Red
+&5 5 Dark Purple
+&6 6 Gold
+&7 7 Gray
+&8 8 Dark Gray
+&9 9 Blue
+&a a Green
+&b b Aqua
+&c c Red
+&d d Light Purple
+&e e Yellow
+&f f White
+
+&r k Magic &kMagic
+&l l Bold
+&m m Strikethrough
+&n n Underline
+&o o Italic
+
+&r r Reset

--- a/src/main/resources/assets/io/github/nucleuspowered/nucleus/info.txt
+++ b/src/main/resources/assets/io/github/nucleuspowered/nucleus/info.txt
@@ -1,0 +1,2 @@
+#Default info page
+Hello! This page is the default info page for your server! You (or a server admin) can change this content

--- a/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
+++ b/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
@@ -205,6 +205,8 @@ args.gameprofile.format=&cThe name is not of the right format.
 args.permissiongroup.noservice=&cNo permissions plugin is installed.
 args.permissiongroup.nogroup=&cThe group "{0}" does not exist.
 
+args.info.noinfo=&cThere is no info page with the name "{0}".
+
 commandlog.message={0} ran the command: /{1} {2}
 
 # Commands
@@ -645,6 +647,12 @@ command.nucleus.permission.success=&aCommands have been executed.
 
 command.motd.nocontroller=&cCould not get the MOTD.
 
+command.info.title.default=&6Info
+command.info.title.section=&6Info: {0}
+command.info.header.default=&bClick on a title to view that section.
+command.info.hover=Click here or run "/info {0}" to read the section "{0}".
+command.info.none=&6There are no info pages for this server.
+
 # Ban
 ban.defaultreason=The BanHammer has spoken!
 
@@ -691,6 +699,9 @@ blacklist.hover={0} is blacklisted.
 broadcast.tag=&a[Broadcast]
 
 gameprofile.new=&eThe user {0} has not logged onto the server before. They have been added to the system.
+
+# Info
+info.load.duplicate=Duplicate file name detected - {0}. It has not been loaded - note that case does not matter.
 
 # Teleport
 teleport.success=&aYou have teleported to &e{0}&a''s location.


### PR DESCRIPTION
This command works by dropping a series of text files into your config/nucleus/info folder. The command will pick each one up and treat each as a separate section.

To show a title of up to 50 characters on the `/info` list and as the title, prefix the first line with "#".

See #149 