### PR TITLE
Add "fix" for older servers using API 4.1-BETA

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/annotations/SkipOnError.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/annotations/SkipOnError.java
@@ -1,0 +1,17 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.internal.annotations;
+
+import java.lang.annotation.*;
+
+/**
+ * If the Guice injector is unable to create an instance of a class with this annotation, then Nucleus and QSML
+ * will not fail to load a module.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface SkipOnError {
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/core/listeners/CoreListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/core/listeners/CoreListener.java
@@ -4,18 +4,13 @@
  */
 package io.github.nucleuspowered.nucleus.modules.core.listeners;
 
-import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.config.loaders.UserConfigLoader;
 import io.github.nucleuspowered.nucleus.internal.ListenerBase;
 import io.github.nucleuspowered.nucleus.internal.interfaces.InternalNucleusUser;
 import org.spongepowered.api.Sponge;
-import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.Order;
-import org.spongepowered.api.event.game.GameReloadEvent;
 import org.spongepowered.api.event.network.ClientConnectionEvent;
-import org.spongepowered.api.text.Text;
-import org.spongepowered.api.text.format.TextColors;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
@@ -65,13 +60,5 @@ public class CoreListener extends ListenerBase {
                 e.printStackTrace();
             }
         }, 200, TimeUnit.MILLISECONDS);
-    }
-
-    @Listener
-    public void onGameReload(final GameReloadEvent event) {
-        plugin.reload();
-        CommandSource requester = event.getCause().first(CommandSource.class).orElse(Sponge.getServer().getConsole());
-        requester.sendMessage(Text.of(TextColors.YELLOW, "[Nucleus] ", Util.getTextMessageWithFormat("command.reload.one")));
-        requester.sendMessage(Text.of(TextColors.YELLOW, "[Nucleus] ", Util.getTextMessageWithFormat("command.reload.two")));
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/core/listeners/ReloadListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/core/listeners/ReloadListener.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.core.listeners;
+
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.internal.ListenerBase;
+import io.github.nucleuspowered.nucleus.internal.annotations.SkipOnError;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.game.GameReloadEvent;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
+
+@SkipOnError
+public class ReloadListener extends ListenerBase {
+
+    @Listener
+    public void onGameReload(final GameReloadEvent event) {
+        plugin.reload();
+        CommandSource requester = event.getCause().first(CommandSource.class).orElse(Sponge.getServer().getConsole());
+        requester.sendMessage(Text.of(TextColors.YELLOW, "[Nucleus] ", Util.getTextMessageWithFormat("command.reload.one")));
+        requester.sendMessage(Text.of(TextColors.YELLOW, "[Nucleus] ", Util.getTextMessageWithFormat("command.reload.two")));
+    }
+}

--- a/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
+++ b/src/main/resources/assets/io/github/nucleuspowered/nucleus/messages.properties
@@ -33,6 +33,7 @@ startup.postinit={0} is now entering the post-init phase.
 startup.moduleloading={0} is now loading and enabling modules. This may take a few seconds.
 startup.modulenotloaded={0} was unable to load modules and has aborted loading.
 startup.moduleloaded={0} has completed loading modules.
+startup.injectablenotloaded=The {0} was not loaded because of an injection error, but loading will continue.
 startup.started={0} has started.
 startup.stopped={0} is performing server shutdown tasks.
 


### PR DESCRIPTION
I hate things like this, but let's keep Pixelmon on board for now.

The `GameReloadEvent` was causing issues with the injector in older versions. Fixes #177 