### PR TITLE
Move fly into its own module.

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/FlyModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/FlyModule.java
@@ -1,0 +1,12 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.fly;
+
+import io.github.nucleuspowered.nucleus.internal.StandardModule;
+import uk.co.drnaylor.quickstart.annotations.ModuleData;
+
+@ModuleData(id = "fly", name = "Fly")
+public class FlyModule extends StandardModule {
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/commands/FlyCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/commands/FlyCommand.java
@@ -2,7 +2,7 @@
  * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
  * at the root of this project for more details.
  */
-package io.github.nucleuspowered.nucleus.modules.misc.commands;
+package io.github.nucleuspowered.nucleus.modules.fly.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/listeners/FlyListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/listeners/FlyListener.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.fly.listeners;
+
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.config.loaders.UserConfigLoader;
+import io.github.nucleuspowered.nucleus.internal.ListenerBase;
+import io.github.nucleuspowered.nucleus.internal.interfaces.InternalNucleusUser;
+import io.github.nucleuspowered.nucleus.modules.core.config.CoreConfigAdapter;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.Transform;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.Order;
+import org.spongepowered.api.event.entity.DisplaceEntityEvent;
+import org.spongepowered.api.event.filter.Getter;
+import org.spongepowered.api.event.network.ClientConnectionEvent;
+import org.spongepowered.api.world.World;
+
+public class FlyListener extends ListenerBase {
+
+    @Inject private UserConfigLoader ucl;
+    @Inject private CoreConfigAdapter cca;
+
+    // Do it first, so other plugins can have a say.
+    @Listener(order = Order.FIRST)
+    public void onPlayerJoin(ClientConnectionEvent.Join event) {
+        try {
+            Player pl = event.getTargetEntity();
+            InternalNucleusUser uc = plugin.getUserLoader().getUser(pl);
+
+            // Let's just reset these...
+            uc.setFlying(uc.isFlyingSafe());
+
+            // If in the air, flying!
+            if (uc.isFlyingSafe() && pl.getLocation().add(0, -1, 0).getBlockType().getId().equals(BlockTypes.AIR.getId())) {
+                pl.offer(Keys.IS_FLYING, true);
+            }
+        } catch (Exception e) {
+            if (cca.getNodeOrDefault().isDebugmode()) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    // Only fire if there is no cancellation at the end.
+    @Listener(order = Order.LAST)
+    public void onPlayerTransferWorld(DisplaceEntityEvent event,
+                                      @Getter("getTargetEntity") Entity target,
+                                      @Getter("getFromTransform") Transform<World> twfrom,
+                                      @Getter("getToTransform") Transform<World> twto) {
+
+        if (!(target instanceof Player)) {
+            return;
+        }
+
+        InternalNucleusUser uc;
+        try {
+            uc = plugin.getUserLoader().getUser((Player)target);
+            if (!uc.isFlying()) {
+                return;
+            }
+        } catch (Exception e) {
+            if (cca.getNodeOrDefault().isDebugmode()) {
+                e.printStackTrace();
+            }
+
+            return;
+        }
+
+        // If we have a player, and this happens...
+        boolean isFlying = target.get(Keys.IS_FLYING).orElse(false);
+
+        // If we're moving world...
+        if (!twfrom.getExtent().getUniqueId().equals(twto.getExtent().getUniqueId())) {
+            // Next tick, they can fly...
+            Sponge.getScheduler().createTaskBuilder().execute(() -> {
+                target.offer(Keys.CAN_FLY, true);
+                if (isFlying) {
+                    target.offer(Keys.IS_FLYING, true);
+                }
+            }).submit(plugin);
+        }
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/listeners/MiscListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/listeners/MiscListener.java
@@ -7,39 +7,15 @@ package io.github.nucleuspowered.nucleus.modules.misc.listeners;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.config.loaders.UserConfigLoader;
 import io.github.nucleuspowered.nucleus.internal.ListenerBase;
-import io.github.nucleuspowered.nucleus.internal.interfaces.InternalNucleusUser;
 import io.github.nucleuspowered.nucleus.modules.core.config.CoreConfigAdapter;
-import org.spongepowered.api.block.BlockTypes;
-import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
-import org.spongepowered.api.event.Order;
 import org.spongepowered.api.event.entity.DamageEntityEvent;
-import org.spongepowered.api.event.network.ClientConnectionEvent;
 
 public class MiscListener extends ListenerBase {
 
     @Inject private UserConfigLoader ucl;
     @Inject private CoreConfigAdapter cca;
-
-    // Do it first, so other plugins can have a say.
-    @Listener(order = Order.FIRST)
-    public void onPlayerJoin(ClientConnectionEvent.Join event) {
-        try {
-            Player pl = event.getTargetEntity();
-            InternalNucleusUser uc = plugin.getUserLoader().getUser(pl);
-
-            // Let's just reset these...
-            uc.setFlying(uc.isFlyingSafe());
-
-            // If in the air, flying!
-            if (uc.isFlyingSafe() && pl.getLocation().add(0, -1, 0).getBlockType().getId().equals(BlockTypes.AIR.getId())) {
-                pl.offer(Keys.IS_FLYING, true);
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
 
     // For /god
     @Listener


### PR DESCRIPTION
* Add fly on world change check.
* Allow disabling fly completely to allow players to use EssentialCmds at the same time (still)

Allows for some sidestepping of #174.