### PR TITLE
[WIP] Add support for "namecolor".

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/ChatUtil.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/ChatUtil.java
@@ -263,7 +263,7 @@ public class ChatUtil {
 
     private Text getName(CommandSource cs) {
         if (cs instanceof Player) {
-            return NameUtil.getNameWithHover((Player)cs, loader);
+            return NameUtil.getName((Player)cs, loader);
         }
 
         return Text.of(cs.getName());

--- a/src/main/java/io/github/nucleuspowered/nucleus/NameUtil.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/NameUtil.java
@@ -4,6 +4,7 @@
  */
 package io.github.nucleuspowered.nucleus;
 
+import com.google.common.collect.Maps;
 import io.github.nucleuspowered.nucleus.config.loaders.UserConfigLoader;
 import io.github.nucleuspowered.nucleus.internal.interfaces.InternalNucleusUser;
 import org.spongepowered.api.Sponge;
@@ -13,31 +14,43 @@ import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.service.user.UserStorageService;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.action.TextActions;
+import org.spongepowered.api.text.format.TextColor;
+import org.spongepowered.api.text.format.TextColors;
 import org.spongepowered.api.text.serializer.TextSerializers;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
 public class NameUtil {
+
+    private final static Map<Character, TextColor> colourMap = Maps.newHashMap();
+
+    static {
+        colourMap.put('0', TextColors.BLACK);
+        colourMap.put('1', TextColors.DARK_BLUE);
+        colourMap.put('2', TextColors.DARK_GREEN);
+        colourMap.put('3', TextColors.DARK_AQUA);
+        colourMap.put('4', TextColors.DARK_RED);
+        colourMap.put('5', TextColors.DARK_PURPLE);
+        colourMap.put('6', TextColors.GOLD);
+        colourMap.put('7', TextColors.GRAY);
+        colourMap.put('8', TextColors.DARK_GRAY);
+        colourMap.put('9', TextColors.BLUE);
+        colourMap.put('a', TextColors.GREEN);
+        colourMap.put('b', TextColors.AQUA);
+        colourMap.put('c', TextColors.RED);
+        colourMap.put('d', TextColors.LIGHT_PURPLE);
+        colourMap.put('e', TextColors.YELLOW);
+        colourMap.put('f', TextColors.WHITE);
+    }
+
     public static Text getNameFromCommandSource(CommandSource src) {
         if (!(src instanceof User)) {
             return Text.of(src.getName());
         }
 
         return getName((User)src);
-    }
-
-    public static Text getName(User player, InternalNucleusUser service) {
-        Optional<Text> n = service.getNicknameWithPrefix();
-        if (n.isPresent()) {
-            return n.get();
-        }
-
-        return getName(player);
-    }
-
-    public static Text getNameWithHover(User player, UserConfigLoader loader) {
-        return getName(player, loader).toBuilder().onHover(TextActions.showText(Text.of(player.getName()))).build();
     }
 
     public static Text getName(User player, UserConfigLoader loader) {
@@ -50,8 +63,18 @@ public class NameUtil {
         return getName(player);
     }
 
+    public static Text getName(User player, InternalNucleusUser service) {
+        Optional<Text> n = service.getNicknameWithPrefix();
+        if (n.isPresent()) {
+            return Text.of(getNameColour(player), n.get().toBuilder().onHover(TextActions.showText(Text.of(player.getName()))).build());
+        }
+
+        return getName(player);
+    }
+
     public static Text getName(User player) {
-        return player.get(Keys.DISPLAY_NAME).orElse(Text.of(player.getName()));
+        return Text.of(getNameColour(player), player.get(Keys.DISPLAY_NAME).orElse(Text.of(player.getName()))
+                .toBuilder().onHover(TextActions.showText(Text.of(player.getName()))).build());
     }
 
     public static String getSerialisedName(User player) {
@@ -70,5 +93,19 @@ public class NameUtil {
         }
 
         return Util.getMessageWithFormat("standard.unknown");
+    }
+
+    private static TextColor getNameColour(User player) {
+        Optional<String> os = Util.getOptionFromSubject(player, "namecolor", "namecolour");
+        if (os.isPresent()) {
+            String s = os.get();
+            if (s.length() == 1) {
+                return colourMap.getOrDefault(s.charAt(0), TextColors.NONE);
+            } else {
+                return Sponge.getRegistry().getType(TextColor.class, s.toUpperCase()).orElse(TextColors.NONE);
+            }
+        }
+
+        return TextColors.NONE;
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/Util.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/Util.java
@@ -12,7 +12,7 @@ import io.github.nucleuspowered.nucleus.internal.messages.MessageProvider;
 import io.github.nucleuspowered.nucleus.internal.qsml.module.StandardModule;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.command.CommandSource;
-import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.service.permission.Subject;
 import org.spongepowered.api.service.permission.option.OptionSubject;
 import org.spongepowered.api.text.Text;
@@ -169,9 +169,42 @@ public class Util {
         return ci.stream().map(ClassPath.ClassInfo::load).filter(base::isAssignableFrom).map(x -> (Class<? extends T>)x).collect(Collectors.toSet());
     }
 
-    public static Optional<OptionSubject> getSubject(Player player) {
+    public static Optional<OptionSubject> getSubject(User player) {
         Subject subject = player.getContainingCollection().get(player.getIdentifier());
         return subject instanceof OptionSubject ? Optional.of((OptionSubject) subject) : Optional.empty();
+    }
+
+    /**
+     * Utility method for getting the first available option from an {@link OptionSubject}
+     *
+     * @param player The {@link User} to get the subject from.
+     * @param options The option keys to check.
+     * @return An {@link Optional} that might contain a value.
+     */
+    public static Optional<String> getOptionFromSubject(User player, String... options) {
+        Optional<OptionSubject> optionSubjectOptional = getSubject(player);
+        if (!optionSubjectOptional.isPresent()) {
+            return Optional.empty();
+        }
+
+        OptionSubject optionSubject = optionSubjectOptional.get();
+        for (String option : options) {
+            String o = option.toLowerCase();
+
+            // Option for context.
+            Optional<String> os = optionSubject.getOption(player.getActiveContexts(), o);
+            if (os.isPresent()) {
+                return os;
+            }
+
+            // General option
+            os = optionSubject.getOption(o);
+            if (os.isPresent()) {
+                return os;
+            }
+        }
+
+        return Optional.empty();
     }
 
     /**

--- a/src/main/java/io/github/nucleuspowered/nucleus/config/UserService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/config/UserService.java
@@ -264,7 +264,7 @@ public class UserService extends AbstractSerialisableClassConfig<UserDataNode, C
                 return getNicknameAsText();
             }
 
-            return Optional.of(Text.join(TextSerializers.formattingCode('&').deserialize(p), getNicknameAsText().get()));
+            return Optional.of(Text.join(TextSerializers.FORMATTING_CODE.deserialize(p), getNicknameAsText().get()));
         }
 
         return Optional.empty();
@@ -281,7 +281,7 @@ public class UserService extends AbstractSerialisableClassConfig<UserDataNode, C
             return Optional.empty();
         }
 
-        nickname = TextSerializers.formattingCode('&').deserialize(os.get());
+        nickname = TextSerializers.FORMATTING_CODE.deserialize(os.get());
         return Optional.of(nickname);
     }
 
@@ -299,7 +299,7 @@ public class UserService extends AbstractSerialisableClassConfig<UserDataNode, C
             nickname = p + nickname;
         }
 
-        Text nick = TextSerializers.formattingCode('&').deserialize(nickname);
+        Text nick = TextSerializers.FORMATTING_CODE.deserialize(nickname);
         user.offer(Keys.DISPLAY_NAME, nick);
     }
 


### PR DESCRIPTION
See #153

This hasn't been tested yet, but might work. Using the option `namecolor` or `namecolour`, and either 0-9a-f colour codes or Sponge's names, a player's name can be coloured.