### PR TITLE
Rearrange fly logic.

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/api/data/NucleusUser.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/data/NucleusUser.java
@@ -60,7 +60,7 @@ public interface NucleusUser {
 
     /**
      * Gets whether Nucleus thinks the player should be flying. Note, this means the player has been subject to
-     * the /god command.
+     * the /fly command.
      *
      * @return <code>true</code> if so.
      */
@@ -68,12 +68,11 @@ public interface NucleusUser {
 
     /**
      * Sets whether Nucleus thinks the player should be flying. This does not necessarily mean that the player is
-     * actually flying.
+     * actually flying, this is more for across restarts/reconnects/world transfer.
      *
      * @param fly <code>true</code> if so, <code>false</code> otherwise.
-     * @return <code>true</code> if successful.
      */
-    boolean setFlying(boolean fly);
+    void setFlying(boolean fly);
 
     /**
      * If the player is jailed, gets the {@link JailData}

--- a/src/main/java/io/github/nucleuspowered/nucleus/config/UserService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/config/UserService.java
@@ -30,7 +30,6 @@ import ninja.leaping.configurate.gson.GsonConfigurationLoader;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.entity.Transform;
-import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.text.Text;
@@ -143,22 +142,8 @@ public class UserService extends AbstractSerialisableClassConfig<UserDataNode, C
     }
 
     @Override
-    public boolean setFlying(boolean fly) {
-        if (user.isOnline()) {
-            Player pl = user.getPlayer().get();
-
-            // Only if we don't want to fly, offer IS_FLYING as false.
-            if (!fly && !pl.offer(Keys.IS_FLYING, false).isSuccessful()) {
-                return false;
-            }
-
-            if (!pl.offer(Keys.CAN_FLY, fly).isSuccessful()) {
-                return false;
-            }
-        }
-
+    public void setFlying(boolean fly) {
         data.setFly(fly);
-        return true;
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/FlyModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/FlyModule.java
@@ -4,9 +4,14 @@
  */
 package io.github.nucleuspowered.nucleus.modules.fly;
 
-import io.github.nucleuspowered.nucleus.internal.qsml.module.StandardModule;
+import io.github.nucleuspowered.nucleus.internal.qsml.module.ConfigurableModule;
+import io.github.nucleuspowered.nucleus.modules.fly.config.FlyConfigAdapter;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
 
 @ModuleData(id = "fly", name = "Fly")
-public class FlyModule extends StandardModule {
+public class FlyModule extends ConfigurableModule<FlyConfigAdapter> {
+    @Override
+    public FlyConfigAdapter getAdapter() {
+        return new FlyConfigAdapter();
+    }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/commands/FlyCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/commands/FlyCommand.java
@@ -59,16 +59,22 @@ public class FlyCommand extends CommandBase<CommandSource> {
         InternalNucleusUser uc = plugin.getUserLoader().getUser(pl);
         boolean fly = args.<Boolean>getOne(toggle).orElse(!pl.get(Keys.CAN_FLY).orElse(false));
 
-        if (!uc.setFlying(fly)) {
+        if (!setFlying(pl, fly)) {
             src.sendMessages(Util.getTextMessageWithFormat("command.fly.error"));
             return CommandResult.empty();
         }
 
+        uc.setFlying(fly);
         if (pl != src) {
             src.sendMessages(Util.getTextMessageWithFormat(fly ? "command.fly.player.on" : "command.fly.player.off", pl.getName()));
         }
 
         pl.sendMessage(Util.getTextMessageWithFormat(fly ? "command.fly.on" : "command.fly.off"));
         return CommandResult.success();
+    }
+
+    private boolean setFlying(Player pl, boolean fly) {
+        // Only if we don't want to fly, offer IS_FLYING as false.
+        return !(!fly && !pl.offer(Keys.IS_FLYING, false).isSuccessful()) && pl.offer(Keys.CAN_FLY, fly).isSuccessful();
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/config/FlyConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/config/FlyConfig.java
@@ -1,0 +1,19 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.fly.config;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+@ConfigSerializable
+public class FlyConfig {
+
+    @Setting(value = "save-all-flystate-on-quit", comment = "loc:config.fly.stateonquit")
+    private boolean saveOnQuit = true;
+
+    public boolean isSaveOnQuit() {
+        return saveOnQuit;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/config/FlyConfigAdapter.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/config/FlyConfigAdapter.java
@@ -1,0 +1,31 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.fly.config;
+
+import com.google.common.reflect.TypeToken;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.commented.SimpleCommentedConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+
+public class FlyConfigAdapter extends NucleusConfigAdapter<FlyConfig> {
+
+    private TypeToken<FlyConfig> tt = TypeToken.of(FlyConfig.class);
+
+    @Override
+    protected FlyConfig getDefaultObject() {
+        return new FlyConfig();
+    }
+
+    @Override
+    protected FlyConfig convertFromConfigurateNode(ConfigurationNode node) throws ObjectMappingException {
+        return node.getValue(tt, getDefaultObject());
+    }
+
+    @Override
+    protected ConfigurationNode insertIntoConfigurateNode(FlyConfig data) throws ObjectMappingException {
+        return SimpleCommentedConfigurationNode.root().setValue(tt, data);
+    }
+}

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -153,6 +153,8 @@ config.teleport.quiet=If true, by default, a target player will not be informed 
 
 config.spawn.onlogin=If true, players will be sent to the default world spawn on login, unless they are sent to the first login spawn, or they have the "nucleus.spawn.exempt.onjoin" permission.
 
+config.fly.stateonquit=If true, if a player is flying when they disconnect, this state is remembered. If false, this information is only retained between player disconnects if /fly was used.
+
 afk.toafk=&7* &r{0} &7is now AFK.
 afk.fromafk=&7* &r{0} &7is no longer AFK.
 afk.kickedafk=has been kicked for being AFK too long.


### PR DESCRIPTION
* A new option allows admins to set whether the fly state of a user is saved on logout, regardless of the source of flying.
* Try to not get confused logic when setting fly state - do it in the command, not in the service.

With a bit of luck, might fix #174