### PR TITLE
Prevent logging portals for /back by default.

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/back/config/BackConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/back/config/BackConfig.java
@@ -16,11 +16,18 @@ public class BackConfig {
     @Setting(comment = "loc:config.back.onteleport")
     private boolean onTeleport = true;
 
+    @Setting(comment = "loc:config.back.onportal")
+    private boolean onPortal = false;
+
     public boolean isOnDeath() {
         return onDeath;
     }
 
     public boolean isOnTeleport() {
         return onTeleport;
+    }
+
+    public boolean isOnPortal() {
+        return onPortal;
     }
 }

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -128,6 +128,7 @@ config.message.helpop.prefix=The prefix to any message received via /helpop.
 
 config.back.ondeath=Log player''s location on death.
 config.back.onteleport=Log player''s last location on warp.
+config.back.onportal=Log player''s last location after travelling through a portal.
 
 config.blacklist.environment=If true, blacklisted items cannot be interacted with, mined, or placed.
 config.blacklist.inventory=If true, blacklisted items cannot exist in a player''s inventory, be dropped, or picked up.
@@ -806,6 +807,7 @@ permission.helpop.receive=Allows the user to receive message via /helpop
 
 permission.back.ondeath=Sets the player''s /back location on death
 permission.back.onteleport=Sets the player''s /back location on returnable teleports.
+permission.back.onportal=Sets the player''s /back location on portal teleports.
 
 permission.enchant.unsafe=Allows setting enchantments and levels that are not ordinarily available to the held item.
 


### PR DESCRIPTION
* Add config option for logging portal teleports for /back.
* Add @Getter methods to filter out non-player targets. Fixes #209.