### PR TITLE
Separate out the migrators.

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/annotations/NoCooldown.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/annotations/NoCooldown.java
@@ -11,6 +11,7 @@ import java.lang.annotation.*;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Inherited
 @Documented
 public @interface NoCooldown {
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/annotations/NoCost.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/annotations/NoCost.java
@@ -11,6 +11,7 @@ import java.lang.annotation.*;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Inherited
 @Documented
 public @interface NoCost {
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/annotations/NoWarmup.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/annotations/NoWarmup.java
@@ -11,6 +11,7 @@ import java.lang.annotation.*;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Inherited
 @Documented
 public @interface NoWarmup {
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/annotations/RunAsync.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/annotations/RunAsync.java
@@ -12,6 +12,7 @@ import java.lang.annotation.*;
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
+@Inherited
 @Documented
 public @interface RunAsync {
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/command/MigratorCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/command/MigratorCommand.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.internal.command;
+
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoCooldown;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoCost;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoWarmup;
+import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.migrators.DataMigrator;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+
+import java.util.Arrays;
+
+/**
+ * The {@link MigratorCommand} is common command logic for all {@link DataMigrator}s.
+ *
+ * <p>
+ *     The constructor in the derived class must not have any paramters, the class should be defined within the constructor.
+ *     This is thanks to Type Erasure...
+ * </p>
+ *
+ * @param <M> The {@link DataMigrator} the command represents.
+ */
+@NoCost
+@NoCooldown
+@NoWarmup
+@RunAsync
+public abstract class MigratorCommand<M extends DataMigrator> extends CommandBase<CommandSource> {
+
+    private final Class<M> migratorClass;
+
+    public MigratorCommand(Class<M> migratorClass) {
+        this.migratorClass = migratorClass;
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        DataMigrator.PluginDependency pd = migratorClass.getAnnotation(DataMigrator.PluginDependency.class);
+        boolean deps = true;
+        if (pd != null && pd.value().length > 0) {
+            deps = Arrays.asList(pd.value()).stream().allMatch(x -> Sponge.getPluginManager().getPlugin(x).isPresent());
+        }
+
+        if (deps) {
+            try {
+                // I imagine that there may be a few questions that you may be asking here.
+                //
+                // 1) Why is there an injector here?
+                // 2) Why not just bung the logic in this class?
+                //
+                // Using an injector allows us to put all our handlers into the class easily, much like with a command.
+                // The code in the migrator existed in this command originally anyway, so using an injector made it easy
+                // to move the code.
+                //
+                // Of course, that brings us to why the logic is not in this class anyway - again, due to the injector!
+                // We use Guice to inject members into all our command classes, it's part of the magic that allows us
+                // to have a module system. EssentialCmds uses a static class to access configuration, and the injector
+                // will try to load the class. Normally, this is fine... until the class does not exist - such as when
+                // EssentialCmds is NOT installed! We then get an error on the console, and confuse the user. So, moving
+                // that logic into a class that loads on demand means that the nasty error no longer occurs.
+                plugin.getInjector().getInstance(migratorClass).migrate(src);
+                return CommandResult.success();
+            } catch (Exception | NoClassDefFoundError e) {
+                e.printStackTrace();
+                if (pd != null && pd.value().length > 0) {
+                    src.sendMessage(Util.getTextMessageWithFormat("command.nucleus.migrate.error.plugin", String.join(", ", (CharSequence[]) pd.value())));
+                } else {
+                    src.sendMessage(Util.getTextMessageWithFormat("command.nucleus.migrate.error.noplugin"));
+                }
+            }
+        } else {
+            src.sendMessage(Util.getTextMessageWithFormat("command.nucleus.migrate.noplugin", String.join(", ", (CharSequence[]) pd.value())));
+        }
+
+        return CommandResult.empty();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/migrators/DataMigrator.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/migrators/DataMigrator.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.internal.migrators;
+
+import io.github.nucleuspowered.nucleus.Nucleus;
+import org.slf4j.Logger;
+import org.spongepowered.api.command.CommandSource;
+
+import javax.inject.Inject;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Defines the migrator method.
+ */
+public abstract class DataMigrator {
+
+    @Inject protected Nucleus plugin;
+    @Inject protected Logger logger;
+
+    /**
+     * Migrates data to Nucleus from a data source.
+     *
+     * @param src The {@link CommandSource} that requested the migration.
+     * @throws Exception Any injections.
+     */
+    public abstract void migrate(CommandSource src) throws Exception;
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    public @interface PluginDependency {
+
+        /**
+         * The IDs of any dependencies.
+         *
+         * @return The dependencies.
+         */
+        String[] value() default {};
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/migrators/EssCmdsMigrator.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/migrators/EssCmdsMigrator.java
@@ -14,7 +14,6 @@ import io.github.hsyyid.essentialcmds.managers.config.HomeConfig;
 import io.github.hsyyid.essentialcmds.managers.config.JailConfig;
 import io.github.hsyyid.essentialcmds.utils.Mail;
 import io.github.hsyyid.essentialcmds.utils.Utils;
-import io.github.nucleuspowered.nucleus.Nucleus;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.JailData;
 import io.github.nucleuspowered.nucleus.api.data.MuteData;
@@ -32,7 +31,6 @@ import io.github.nucleuspowered.nucleus.modules.rules.config.RulesConfig;
 import io.github.nucleuspowered.nucleus.modules.rules.config.RulesConfigAdapter;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
-import org.slf4j.Logger;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.entity.Transform;
@@ -48,17 +46,17 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public class EssCmdsMigrator {
+@DataMigrator.PluginDependency("io.github.hsyyid.essentialcmds")
+public class EssCmdsMigrator extends DataMigrator {
 
-    @Inject private Nucleus plugin;
     @Inject private UserConfigLoader userConfigLoader;
     @Inject private WorldConfigLoader worldConfigLoader;
-    @Inject private Logger logger;
     @Inject(optional = true) private JailHandler jailHandler;
     @Inject(optional = true) private MuteHandler muteHandler;
     @Inject(optional = true) private MailHandler mailHandler;
     @Inject(optional = true) private RulesConfigAdapter rca;
 
+    @Override
     public void migrate(CommandSource src) throws Exception {
         src.sendMessage(Util.getTextMessageWithFormat("command.nucleus.migrate.begin"));
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/MigrateCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/MigrateCommand.java
@@ -4,57 +4,25 @@
  */
 package io.github.nucleuspowered.nucleus.modules.core.commands;
 
-import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
-import io.github.nucleuspowered.nucleus.internal.migrators.EssCmdsMigrator;
-import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
 
 /**
- * Saves the data files.
- *
- * Permission: nucleus.nucleus.migrate
+ * Base command for migration
  */
 @RunAsync
 @NoCooldown
 @NoCost
 @NoWarmup
 @Permissions(root = "nucleus")
-@RegisterCommand(value = "migrate", subcommandOf = NucleusCommand.class)
+@RegisterCommand(value = "migrate", subcommandOf = NucleusCommand.class, hasExecutor = false)
 public class MigrateCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
-        if (Sponge.getPluginManager().getPlugin("io.github.hsyyid.essentialcmds").isPresent()) {
-            try {
-                // I imagine that there may be a few questions that you may be asking here.
-                //
-                // 1) Why is there an injector here?
-                // 2) Why not just bung the logic in this class?
-                //
-                // Using an injector allows us to put all our handlers into the class easily, much like with a command.
-                // The code in the migrator existed in this command originally anyway, so using an injector made it easy
-                // to move the code.
-                //
-                // Of course, that brings us to why the logic is not in this class anyway - again, due to the injector!
-                // We use Guice to inject members into all our command classes, it's part of the magic that allows us
-                // to have a module system. EssentialCmds uses a static class to access configuration, and the injector
-                // will try to load the class. Normally, this is fine... until the class does not exist - such as when
-                // EssentialCmds is NOT installed! We then get an error on the console, and confuse the user. So, moving
-                // that logic into a class that loads on demand means that the nasty error no longer occurs.
-                plugin.getInjector().getInstance(EssCmdsMigrator.class).migrate(src);
-                return CommandResult.success();
-            } catch (Exception e) {
-                e.printStackTrace();
-                src.sendMessage(Util.getTextMessageWithFormat("command.nucleus.migrate.error"));
-            }
-        } else {
-            src.sendMessage(Util.getTextMessageWithFormat("command.nucleus.migrate.noessentialcmds"));
-        }
-
         return CommandResult.empty();
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/migrators/EssCmdsMigratorCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/migrators/EssCmdsMigratorCommand.java
@@ -1,0 +1,19 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.core.commands.migrators;
+
+import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
+import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.MigratorCommand;
+import io.github.nucleuspowered.nucleus.internal.migrators.EssCmdsMigrator;
+import io.github.nucleuspowered.nucleus.modules.core.commands.MigrateCommand;
+
+@Permissions(root = "nucleus.migrate")
+@RegisterCommand(value = "esscmds", subcommandOf = MigrateCommand.class)
+public class EssCmdsMigratorCommand extends MigratorCommand<EssCmdsMigrator> {
+    public EssCmdsMigratorCommand() {
+        super(EssCmdsMigrator.class);
+    }
+}

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -490,8 +490,9 @@ command.nucleus.migrate.blacklist=&aMigrated blacklisted items.
 command.nucleus.migrate.mail=&aMigrated mail.
 command.nucleus.migrate.rules=&aMigrated rules.
 command.nucleus.migrate.weather=&aMigrated worlds with locked weather.
-command.nucleus.migrate.error=&cAn error occurred trying to migrate EssentialCmds data. Please check the console for more details.
-command.nucleus.migrate.noessentialcmds=&cYou do not have EssentialCmds installed.
+command.nucleus.migrate.error.noplugin=&cAn error occurred trying to migrate data. Please check the console for more details.
+command.nucleus.migrate.error.plugin=&cAn error occurred trying to migrate data from the plugin(s) "{0}". Please check the console for more details.
+command.nucleus.migrate.noplugin=&cThe plugin(s) "{0}" need to be installed for the requested migration.
 
 command.nucleus.save.start=&aStarted data save task.
 


### PR DESCRIPTION
This allows for the prevention of duplicate code.

Part of the roadmap for #221

Moves `/nucleus migrate` to `/nucleus migrate esscmds`, so we can have `/nucleus migrate <blah>`