### PR TITLE
Use new id for the Blossom Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'idea'
     id 'eclipse'
     id 'com.github.hierynomus.license' version '0.12.1'
-    id 'net.ellune.blossom' version '1.0.1'
+    id 'ninja.miserable.blossom' version '1.0.1'
     id 'maven'
     id 'com.github.johnrengelman.shadow' version '1.2.3'
     id "com.qixalite.spongestart" version "1.4.3"
@@ -15,8 +15,6 @@ ext.url = 'http://nucleuspowered.org'
 
 group 'io.github.nucleuspowered'
 version '0.6.0-SNAPSHOT'
-
-apply plugin: 'net.ellune.blossom'
 
 defaultTasks 'licenseFormat'
 


### PR DESCRIPTION
This switches to the new plugin id for the [Blossom Gradle plugin](https://plugins.gradle.org/plugin/ninja.miserable.blossom).