### PR TITLE
Add ability to template broadcasts.

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/BroadcastCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/BroadcastCommand.java
@@ -4,11 +4,13 @@
  */
 package io.github.nucleuspowered.nucleus.modules.admin.commands;
 
+import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.ChatUtil;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
 import io.github.nucleuspowered.nucleus.modules.admin.config.AdminConfigAdapter;
+import io.github.nucleuspowered.nucleus.modules.admin.config.BroadcastConfig;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
@@ -16,7 +18,8 @@ import org.spongepowered.api.command.args.CommandElement;
 import org.spongepowered.api.command.args.GenericArguments;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.channel.MessageChannel;
-import org.spongepowered.api.text.serializer.TextSerializers;
+
+import java.util.List;
 
 @RunAsync
 @NoCooldown
@@ -37,18 +40,22 @@ public class BroadcastCommand extends CommandBase<CommandSource> {
     @Override
     public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
         String m = args.<String>getOne(message).get();
-        MessageChannel.TO_ALL.send(src, constructMessage(m));
-        return CommandResult.success();
-    }
+        BroadcastConfig bc = adminConfigAdapter.getNodeOrDefault().getBroadcastMessage();
+        List<String> messages = Lists.newArrayList();
 
-    private Text constructMessage(String message) {
-        String colour = adminConfigAdapter.getNodeOrDefault().getColorCode().substring(0, 1);
-        if (colour.isEmpty()) {
-            colour = "a";
+        String p = bc.getPrefix();
+        if (!p.trim().isEmpty()) {
+            messages.add(p);
         }
 
-        String tag = adminConfigAdapter.getNodeOrDefault().getTag();
-        return Text.builder().append(TextSerializers.formattingCode('&').deserialize(tag))
-                .append(chatUtil.addUrlsToAmpersandFormattedString(" &" + colour + message)).build();
+        messages.add(m);
+
+        String s = bc.getSuffix();
+        if (!s.trim().isEmpty()) {
+            messages.add(s);
+        }
+
+        MessageChannel.TO_ALL.send(src, chatUtil.getPlayerMessageFromTemplate(String.join(" ", messages.toArray(new CharSequence[messages.size()])), src, true));
+        return CommandResult.success();
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/config/AdminConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/config/AdminConfig.java
@@ -4,23 +4,18 @@
  */
 package io.github.nucleuspowered.nucleus.modules.admin.config;
 
+import io.github.nucleuspowered.nucleus.configurate.annotations.RemoveSettings;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
 @ConfigSerializable
+@RemoveSettings({"tag", "colorCode"})
 public class AdminConfig {
 
-    @Setting(comment = "loc:config.broadcast.tag")
-    private String tag = "[Broadcast]";
+    @Setting(value = "broadcast-message-template", comment = "loc:config.broadcast.template")
+    private BroadcastConfig broadcastMessage = new BroadcastConfig();
 
-    @Setting(comment = "loc:config.broadcast.msg")
-    private String colorCode = "a";
-
-    public String getTag() {
-        return tag;
-    }
-
-    public String getColorCode() {
-        return colorCode;
+    public BroadcastConfig getBroadcastMessage() {
+        return broadcastMessage;
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/config/BroadcastConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/config/BroadcastConfig.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.admin.config;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+@ConfigSerializable
+public class BroadcastConfig {
+
+    @Setting
+    private String prefix = "&a[Broadcast]";
+
+    @Setting
+    private String suffix = "";
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public String getSuffix() {
+        return suffix;
+    }
+}

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -101,8 +101,7 @@ config.kits.separate=If this is set to true, each kit has its own permission nod
 
 config.jail.commands=The commands that players are allowed to execute in jail. Do not include the slash.
 
-config.broadcast.tag=The tag for the broadcast message. Uses standard Minecraft colour codes, prefixed with an ampersand (&).
-config.broadcast.msg=The colour code for the message, no ampersand.
+config.broadcast.template='The prefix and suffix when sending a broadcast message. Accepts chat tokens such as {{displayname}}, {{name}}, etc.'
 
 config.teleport.warmup=The time, in seconds, that a player must remain still before teleportation. Players with "nucleus.teleport.exempt.warmup" or admin permissions will be exempt from this.
 config.command.teleport.warmup=Teleportation warmups must be set in the main config.


### PR DESCRIPTION
See #193 

Allows for use of `{{displayname}}`, `{{name}}`, `{{prefix}}`, `{{suffix}}`