### PR TITLE
Prevent players from selecting other's names as nicknames

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/api/events/NucleusChangeNicknameEvent.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/events/NucleusChangeNicknameEvent.java
@@ -1,0 +1,22 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.api.events;
+
+import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.event.user.TargetUserEvent;
+import org.spongepowered.api.text.Text;
+
+/**
+ * Fired when a player requests a nickname.
+ */
+public interface NucleusChangeNicknameEvent extends Cancellable, TargetUserEvent {
+
+    /**
+     * The new nickname for the {@link #getTargetUser()}
+     *
+     * @return The nickname.
+     */
+    Text getNewNickname();
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/nickname/events/ChangeNicknameEvent.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/nickname/events/ChangeNicknameEvent.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.nickname.events;
+
+import io.github.nucleuspowered.nucleus.api.events.NucleusChangeNicknameEvent;
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.impl.AbstractEvent;
+import org.spongepowered.api.text.Text;
+
+public class ChangeNicknameEvent extends AbstractEvent implements NucleusChangeNicknameEvent {
+
+    private final Cause cause;
+    private final Text newNickname;
+    private final User target;
+    private boolean cancel = false;
+
+    public ChangeNicknameEvent(Cause cause, Text newNickname, User target) {
+        this.cause = cause;
+        this.newNickname = newNickname;
+        this.target = target;
+    }
+
+    @Override
+    public Text getNewNickname() {
+        return newNickname;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+
+    @Override
+    public Cause getCause() {
+        return cause;
+    }
+
+    @Override
+    public User getTargetUser() {
+        return target;
+    }
+}

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -549,6 +549,8 @@ command.nick.success.base=&aYour nickname has been set
 command.nick.success.other=&e{0}&a''s nickname has been set
 command.nick.tooshort=&cThat nickname is too short.
 command.nick.toolong=&cThat nickname is too long.
+command.nick.nameinuse=&cThe name &r{0} &cis already someone''s Minecraft username and cannot be used as a nickname.
+command.nick.eventcancel=&cThe nickname change was cancelled by another plugin.
 
 command.delnick.success.base=&aYour nickname was removed.
 command.delnick.success.other=&e{0}&a''s nickname was removed.


### PR DESCRIPTION
 * Add NucleusChangeNicknameEvent for other plugins to hook into

Fixes #227