### PR TITLE
Add group based chat formatting, resolves #257

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/config/ChatConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/config/ChatConfig.java
@@ -6,6 +6,14 @@ package io.github.nucleuspowered.nucleus.modules.chat.config;
 
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.service.permission.Subject;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @ConfigSerializable
 public class ChatConfig {
@@ -13,14 +21,19 @@ public class ChatConfig {
     @Setting(value = "modifychat", comment = "loc:config.chat.modify")
     private boolean modifychat = true;
 
-    @Setting("template")
-    private ChatTemplateConfig template = new ChatTemplateConfig();
+    @Setting("templates")
+    private Map<String, ChatTemplateConfig> template = new HashMap<String, ChatTemplateConfig>() {{
+        put("Default", new ChatTemplateConfig());
+    }};
 
     public boolean isModifychat() {
         return modifychat;
     }
 
-    public ChatTemplateConfig getTemplate() {
-        return template;
+    public ChatTemplateConfig getTemplate(Player player) {
+        List<Subject> groups = player.getSubjectData().getAllParents().values().stream().flatMap(Collection::stream).collect(Collectors.toList());
+        groups.sort((x, y) -> y.getParents().size() - x.getParents().size());
+
+        return template.containsKey(groups.get(0).getIdentifier()) ? template.get(groups.get(0).getIdentifier()) : template.get("Default");
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/config/ChatConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/config/ChatConfig.java
@@ -22,7 +22,10 @@ public class ChatConfig {
     private boolean modifychat = true;
 
     @Setting("templates")
-    private Map<String, ChatTemplateConfig> template = new HashMap<String, ChatTemplateConfig>() {{
+    private ChatTemplateConfig template = new ChatTemplateConfig();
+
+    @Setting(value = "group-templates", comment = "loc:config.chat.group-templates")
+    private Map<String, ChatTemplateConfig> groupTemplates = new HashMap<String, ChatTemplateConfig>() {{
         put("Default", new ChatTemplateConfig());
     }};
 
@@ -34,6 +37,6 @@ public class ChatConfig {
         List<Subject> groups = player.getSubjectData().getAllParents().values().stream().flatMap(Collection::stream).collect(Collectors.toList());
         groups.sort((x, y) -> y.getParents().size() - x.getParents().size());
 
-        return template.containsKey(groups.get(0).getIdentifier()) ? template.get(groups.get(0).getIdentifier()) : template.get("Default");
+        return groupTemplates.containsKey(groups.get(0).getIdentifier()) ? groupTemplates.get(groups.get(0).getIdentifier()) : template;
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/listeners/ChatListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/listeners/ChatListener.java
@@ -107,8 +107,8 @@ public class ChatListener extends ListenerBase {
 
         Text rawMessage = event.getRawMessage();
         event.setMessage(
-                chatUtil.getPlayerMessageFromTemplate(config.getTemplate().getPrefix(), player, true),
+                chatUtil.getPlayerMessageFromTemplate(config.getTemplate(player).getPrefix(), player, true),
                 useMessage(player, rawMessage),
-                chatUtil.getPlayerMessageFromTemplate(config.getTemplate().getSuffix(), player, false));
+                chatUtil.getPlayerMessageFromTemplate(config.getTemplate(player).getSuffix(), player, false));
     }
 }

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -87,6 +87,7 @@ config.custommessages=If true, a "messages.conf" file will be generated and used
 config.chat.modify=If "true", Nucleus will attempt to modify the chat
 config.chat.template.prefix='Sets the prefix to a message. {{prefix}} - prefix (set as an option in a permission plugin), {{suffix}} - suffix (set as an option in a permission plugin), {{name}} - real name, {{displayname}} - display name'
 config.chat.template.suffix='Sets the suffix to a message. {{prefix}} - prefix (set as an option in a permission plugin), {{suffix}} - suffix (set as an option in a permission plugin), {{name}} - real name, {{displayname}} - display name'
+config.chat.group-templates=Group templates override the default chat template based on the users group.
 
 config.afk.time=The amount of time, in seconds, of inactivity before the player will be marked as AFK. Set to 0 to disable, or use the permission "nucleus.afk.exempt.toggle".
 config.afk.timetokick=The amount of time, in seconds, of inactivity before the player will be kicked. Set to 0 to disable, or use the permission "nucleus.afk.exempt.kick".


### PR DESCRIPTION
Gives users the ability to change how chat is formatted based on a users parents. If a user has multiple parents the chat formatting for the parent which inherits most is used. When first run the templates section generates as:

```
chat {
    # If "true", Nucleus will attempt to modify the chat
    modifychat=true
    templates {
        Default {
            # Sets the prefix to a message. {{prefix}} - prefix (set as an option in a permission plugin), {{suffix}} - suffix (set as an option in a permission plugin), {{name}} - real name, {{displayname}} - display name
            prefix="{{prefix}} {{displayname}}&f: "
            # Sets the suffix to a message. {{prefix}} - prefix (set as an option in a permission plugin), {{suffix}} - suffix (set as an option in a permission plugin), {{name}} - real name, {{displayname}} - display name
            suffix=" {{suffix}}"
        }
    }
}
```

I tested it using the following config:
```
chat {
    # If "true", Nucleus will attempt to modify the chat
    modifychat=true
    templates {
        Default {
            # Sets the prefix to a message. {{prefix}} - prefix (set as an option in a permission plugin), {{suffix}} - suffix (set as an option in a permission plugin), {{name}} - real name, {{displayname}} - display name
            prefix="{{prefix}} {{displayname}} &f> "
            # Sets the suffix to a message. {{prefix}} - prefix (set as an option in a permission plugin), {{suffix}} - suffix (set as an option in a permission plugin), {{name}} - real name, {{displayname}} - display name
            suffix=" {{suffix}}"
        }
        User {
            # Sets the prefix to a message. {{prefix}} - prefix (set as an option in a permission plugin), {{suffix}} - suffix (set as an option in a permission plugin), {{name}} - real name, {{displayname}} - display name
            prefix="{{prefix}} {{displayname}} &f>> "
            # Sets the suffix to a message. {{prefix}} - prefix (set as an option in a permission plugin), {{suffix}} - suffix (set as an option in a permission plugin), {{name}} - real name, {{displayname}} - display name
            suffix=" {{suffix}}"
        }
        Owner {
            # Sets the prefix to a message. {{prefix}} - prefix (set as an option in a permission plugin), {{suffix}} - suffix (set as an option in a permission plugin), {{name}} - real name, {{displayname}} - display name
            prefix="{{prefix}} {{displayname}} &f>>> "
            # Sets the suffix to a message. {{prefix}} - prefix (set as an option in a permission plugin), {{suffix}} - suffix (set as an option in a permission plugin), {{name}} - real name, {{displayname}} - display name
            suffix=" {{suffix}}"
        }
    }
}
```

Tested with PEx b131, 3 groups were created Default, User and Owner. Owner inherited User which inherited Default. All groups also had prefixes which was the name of the group. The results were as follows:

User group: Default
On chat: [Default] I_Oblivion_I > Testing

User group: User
On chat: [User] I_Oblivion_I >> Testing

User group: Owner
On chat: [Owner] I_Oblivion_I >>> Testing

User groups: Default, User, Owner
On chat: [Owner] I_Oblivion_I >>> Testing

User groups: Default, Owner
On chat: [Owner] I_Oblivion_I >>> Testing

User groups: Default, User
On chat: [User] I_Oblivion_I >> Testing