### PR TITLE
Add warn and note modules. Resolve #261 and #262

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/api/data/NoteData.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/data/NoteData.java
@@ -7,6 +7,7 @@ package io.github.nucleuspowered.nucleus.api.data;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
+import java.time.Instant;
 import java.util.UUID;
 
 @ConfigSerializable
@@ -17,11 +18,15 @@ public class NoteData {
     @Setting
     private String note;
 
+    @Setting
+    private long date;
+
     public NoteData() { }
 
-    public NoteData(UUID noter, String note) {
+    public NoteData(Instant date, UUID noter, String note) {
         this.noter = noter;
         this.note = note;
+        this.date = date.toEpochMilli();
     }
 
     public String getNote() {
@@ -33,4 +38,7 @@ public class NoteData {
         return noter;
     }
 
+    public Instant getDate() {
+        return Instant.ofEpochMilli(date);
+    }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/api/data/NoteData.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/data/NoteData.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.api.data;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+import java.util.UUID;
+
+@ConfigSerializable
+public class NoteData {
+    @Setting
+    private UUID noter;
+
+    @Setting
+    private String note;
+
+    public NoteData() { }
+
+    public NoteData(UUID noter, String note) {
+        this.noter = noter;
+        this.note = note;
+    }
+
+    public String getNote() {
+        return note;
+    }
+
+
+    public UUID getNoter() {
+        return noter;
+    }
+
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/api/data/NucleusUser.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/data/NucleusUser.java
@@ -73,8 +73,39 @@ public interface NucleusUser {
 
     /**
      * Clears all of the users active warnings
+     *
+     * @return <code>true</code> if successful.
      */
     boolean clearWarnings();
+
+    /**
+     * Gets the notes of the user
+     *
+     * @return The {@link List} of {@link NoteData}s that represent the users notes.
+     */
+    List<NoteData> getNotes();
+
+    /**
+     * Adds a {@link NoteData} to the users notes
+     *
+     * @param note The note to add.
+     */
+    void addNote(NoteData note);
+
+    /**
+     * Removes a {@link NoteData} from the users notes
+     *
+     * @param note The note to remove.
+     * @return <code>true</code> if successful.
+     */
+    boolean removeNote(NoteData note);
+
+    /**
+     * Clears all of the users notes
+     *
+     * @return <code>true</code> if successful.
+     */
+    boolean clearNotes();
 
     /**
      * Gets whether Nucleus thinks the player should be invulnerable. Note, this means the player has been subject to

--- a/src/main/java/io/github/nucleuspowered/nucleus/api/data/NucleusUser.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/data/NucleusUser.java
@@ -50,6 +50,13 @@ public interface NucleusUser {
     List<WarnData> getWarnings();
 
     /**
+     * Sets the {@link List} of {@link WarnData}s that represent the users active warnings
+     *
+     * @param warnings The new {@link List} of {@link WarnData}s.
+     */
+    void setWarnings(List<WarnData> warnings);
+
+    /**
      * Adds a {@link WarnData} to the users active warnings
      *
      * @param warning The warning to add.

--- a/src/main/java/io/github/nucleuspowered/nucleus/api/data/NucleusUser.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/data/NucleusUser.java
@@ -50,13 +50,6 @@ public interface NucleusUser {
     List<WarnData> getWarnings();
 
     /**
-     * Gets the expired warnings of the user
-     *
-     * @return The {@link List} of {@link WarnData}s that represent the users expired warnings.
-     */
-    List<WarnData> getExpiredWarnings();
-
-    /**
      * Adds a {@link WarnData} to the users active warnings
      *
      * @param warning The warning to add.

--- a/src/main/java/io/github/nucleuspowered/nucleus/api/data/NucleusUser.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/data/NucleusUser.java
@@ -43,6 +43,40 @@ public interface NucleusUser {
     @NonnullByDefault UUID getUniqueID();
 
     /**
+     * Gets the active warnings of the user
+     *
+     * @return The {@link List} of {@link WarnData}s that represent the users active warnings.
+     */
+    List<WarnData> getWarnings();
+
+    /**
+     * Gets the expired warnings of the user
+     *
+     * @return The {@link List} of {@link WarnData}s that represent the users expired warnings.
+     */
+    List<WarnData> getExpiredWarnings();
+
+    /**
+     * Adds a {@link WarnData} to the users active warnings
+     *
+     * @param warning The warning to add.
+     */
+    void addWarning(WarnData warning);
+
+    /**
+     * Removes a {@link WarnData} from the users active warnings
+     *
+     * @param warning The warning to remove.
+     * @return <code>true</code> if successful.
+     */
+    boolean removeWarning(WarnData warning);
+
+    /**
+     * Clears all of the users active warnings
+     */
+    boolean clearWarnings();
+
+    /**
      * Gets whether Nucleus thinks the player should be invulnerable. Note, this means the player has been subject to
      * the /god command.
      *

--- a/src/main/java/io/github/nucleuspowered/nucleus/api/data/WarnData.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/data/WarnData.java
@@ -28,12 +28,22 @@ public class WarnData extends EndTimestamp {
     @Setting
     private Long timeFromNextLogin;
 
+    @Setting
+    private boolean expired = false;
+
     public WarnData() { }
 
     public WarnData(UUID warner, String reason) {
         this.warner = warner;
         this.reason = reason;
     }
+
+    public WarnData(UUID warner, String reason, boolean expired) {
+        this.warner = warner;
+        this.reason = reason;
+        this.expired = expired;
+    }
+
 
     /**
      * Creates the data.
@@ -86,5 +96,9 @@ public class WarnData extends EndTimestamp {
         }
 
         return Optional.of(Duration.of(timeFromNextLogin, ChronoUnit.SECONDS));
+    }
+
+    public boolean isExpired() {
+        return expired;
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/api/data/WarnData.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/data/WarnData.java
@@ -28,8 +28,7 @@ public class WarnData extends EndTimestamp {
     @Setting
     private Long timeFromNextLogin;
 
-    public WarnData() {
-    }
+    public WarnData() { }
 
     public WarnData(UUID warner, String reason) {
         this.warner = warner;

--- a/src/main/java/io/github/nucleuspowered/nucleus/api/data/WarnData.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/data/WarnData.java
@@ -29,19 +29,24 @@ public class WarnData extends EndTimestamp {
     private Long timeFromNextLogin;
 
     @Setting
+    private long date;
+
+    @Setting
     private boolean expired = false;
 
     public WarnData() { }
 
-    public WarnData(UUID warner, String reason) {
+    public WarnData(Instant date, UUID warner, String reason) {
         this.warner = warner;
         this.reason = reason;
+        this.date = date.toEpochMilli();
     }
 
-    public WarnData(UUID warner, String reason, boolean expired) {
+    public WarnData(Instant date, UUID warner, String reason, boolean expired) {
         this.warner = warner;
         this.reason = reason;
         this.expired = expired;
+        this.date = date.toEpochMilli();
     }
 
 
@@ -51,10 +56,12 @@ public class WarnData extends EndTimestamp {
      * @param warner       The UUID of the warner
      * @param endtimestamp The end timestamp
      * @param reason       The reason
+     * @param date         The date
      */
-    public WarnData(UUID warner, String reason, Instant endtimestamp) {
-        this(warner, reason);
+    public WarnData(Instant date, UUID warner, String reason, Instant endtimestamp) {
+        this(date, warner, reason);
         this.endtimestamp = endtimestamp.getEpochSecond();
+        this.date = date.toEpochMilli();
     }
 
     /**
@@ -63,10 +70,12 @@ public class WarnData extends EndTimestamp {
      * @param warner            The UUID of the muter
      * @param reason            The reason
      * @param timeFromNextLogin The time to warn for from next login.
+     * @param date              The date
      */
-    public WarnData(UUID warner, String reason, Duration timeFromNextLogin) {
-        this(warner, reason);
+    public WarnData(Instant date, UUID warner, String reason, Duration timeFromNextLogin) {
+        this(date, warner, reason);
         this.timeFromNextLogin = timeFromNextLogin.getSeconds();
+        this.date = date.toEpochMilli();
     }
 
     public String getReason() {
@@ -96,6 +105,10 @@ public class WarnData extends EndTimestamp {
         }
 
         return Optional.of(Duration.of(timeFromNextLogin, ChronoUnit.SECONDS));
+    }
+
+    public Instant getDate() {
+        return Instant.ofEpochMilli(date);
     }
 
     public boolean isExpired() {

--- a/src/main/java/io/github/nucleuspowered/nucleus/api/data/WarnData.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/data/WarnData.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.api.data;
+
+import io.github.nucleuspowered.nucleus.api.data.interfaces.EndTimestamp;
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import java.util.UUID;
+
+@ConfigSerializable
+public class WarnData extends EndTimestamp {
+    @Setting
+    private UUID warner;
+
+    @Setting
+    private Long endtimestamp;
+
+    @Setting
+    private String reason;
+
+    @Setting
+    private Long timeFromNextLogin;
+
+    public WarnData() {
+    }
+
+    public WarnData(UUID warner, String reason) {
+        this.warner = warner;
+        this.reason = reason;
+    }
+
+    /**
+     * Creates the data.
+     *
+     * @param warner       The UUID of the warner
+     * @param endtimestamp The end timestamp
+     * @param reason       The reason
+     */
+    public WarnData(UUID warner, String reason, Instant endtimestamp) {
+        this(warner, reason);
+        this.endtimestamp = endtimestamp.getEpochSecond();
+    }
+
+    /**
+     * Creates the data.
+     *
+     * @param warner            The UUID of the muter
+     * @param reason            The reason
+     * @param timeFromNextLogin The time to warn for from next login.
+     */
+    public WarnData(UUID warner, String reason, Duration timeFromNextLogin) {
+        this(warner, reason);
+        this.timeFromNextLogin = timeFromNextLogin.getSeconds();
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    /**
+     * Gets the timestamp for the end of the warning.
+     *
+     * @return An {@link Instant}
+     */
+    public Optional<Instant> getEndTimestamp() {
+        if (endtimestamp == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(Instant.ofEpochSecond(endtimestamp));
+    }
+
+    public UUID getWarner() {
+        return warner;
+    }
+
+    public Optional<Duration> getTimeFromNextLogin() {
+        if (timeFromNextLogin == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(Duration.of(timeFromNextLogin, ChronoUnit.SECONDS));
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/api/service/NucleusNoteService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/service/NucleusNoteService.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.api.service;
+
+import io.github.nucleuspowered.nucleus.api.data.NoteData;
+import org.spongepowered.api.entity.living.player.User;
+
+import java.util.List;
+
+/**
+ * A service that determines whether a player has notes.
+ */
+public interface NucleusNoteService {
+
+    /**
+     * Gets all notes for a specific user
+     *
+     * @param user The {@link User} to check.
+     * @return A list of {@link NoteData}.
+     */
+    List<NoteData> getNotes(User user);
+
+    /**
+     * Adds a note to a player.
+     *
+     * @param user The {@link User} to add a note to.
+     * @param note The {@link NoteData} to add.
+     * @return <code>true</code> if the note was added.
+     */
+    boolean addNote(User user, NoteData note);
+
+    /**
+     * Removes a note from a player.
+     *
+     * @param user The {@link User} to remove a note from.
+     * @param note The {@link NoteData} to remove.
+     * @return <code>true</code> if the note was removed.
+     */
+    boolean removeNote(User user, NoteData note);
+
+    /**
+     * Clears all notes from a player.
+     *
+     * @param user The {@link User} to remove all notes from.
+     * @return <code>true</code> if all notes were removed.
+     */
+    boolean clearNotes(User user);
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/api/service/NucleusWarnService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/service/NucleusWarnService.java
@@ -23,6 +23,15 @@ public interface NucleusWarnService {
     List<WarnData> getWarnings(User user);
 
     /**
+     * Gets warnings for a specific user
+     *
+     * @param user The {@link User} to get warnings from.
+     * @param expired If expired warnings should be returned.
+     * @return A list of {@link WarnData}.
+     */
+    List<WarnData> getWarnings(User user, boolean expired);
+
+    /**
      * Adds a warning to a player for a specified duration.
      *
      * @param user The {@link User} to warn.

--- a/src/main/java/io/github/nucleuspowered/nucleus/api/service/NucleusWarnService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/service/NucleusWarnService.java
@@ -26,10 +26,11 @@ public interface NucleusWarnService {
      * Gets warnings for a specific user
      *
      * @param user The {@link User} to get warnings from.
-     * @param expired If expired warnings should be returned.
+     * @param includeActive If active warnings should be included.
+     * @param includeExpired If expired warnings should be included.
      * @return A list of {@link WarnData}.
      */
-    List<WarnData> getWarnings(User user, boolean expired);
+    List<WarnData> getWarnings(User user, boolean includeActive, boolean includeExpired);
 
     /**
      * Adds a warning to a player for a specified duration.
@@ -50,12 +51,24 @@ public interface NucleusWarnService {
     boolean removeWarning(User user, WarnData warning);
 
     /**
-     * Clears all warnings from a player.
+     * Removes a warning from a player.
+     *
+     * @param user The {@link User} to remove a warning from.
+     * @param warning The {@link WarnData} to remove.
+     * @param permanent If the warning should be removed permanently.
+     * @return <code>true</code> if the warning was removed.
+     */
+    boolean removeWarning(User user, WarnData warning, boolean permanent);
+
+    /**
+     * Clears warnings from a player.
      *
      * @param user The {@link User} to remove all warnings from.
+     * @param clearActive If active warnings should be removed.
+     * @param clearExpired If expired warnings should be removed.
      * @return <code>true</code> if all warnings were removed.
      */
-    boolean clearWarnings(User user);
+    boolean clearWarnings(User user, boolean clearActive, boolean clearExpired);
 
     /**
      * Updates a current users warnings

--- a/src/main/java/io/github/nucleuspowered/nucleus/api/service/NucleusWarnService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/service/NucleusWarnService.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.api.service;
+
+import io.github.nucleuspowered.nucleus.api.data.WarnData;
+import org.spongepowered.api.entity.living.player.User;
+
+import java.util.List;
+
+/**
+ * A service that determines whether a player has warnings.
+ */
+public interface NucleusWarnService {
+
+    /**
+     * Gets all warnings for a specific user
+     *
+     * @param user The {@link User} to check.
+     * @return A list of {@link WarnData}.
+     */
+    List<WarnData> getWarnings(User user);
+
+    /**
+     * Adds a warning to a player for a specified duration.
+     *
+     * @param user The {@link User} to warn.
+     * @param warning The {@link WarnData} to add.
+     * @return <code>true</code> if the warning was added.
+     */
+    boolean addWarning(User user, WarnData warning);
+
+    /**
+     * Removes a warning from a player.
+     *
+     * @param user The {@link User} to remove a warning from.
+     * @param warning The {@link WarnData} to remove.
+     * @return <code>true</code> if the warning was removed.
+     */
+    boolean removeWarning(User user, WarnData warning);
+
+    /**
+     * Clears all warnings from a player.
+     *
+     * @param user The {@link User} to remove all warnings from.
+     * @return <code>true</code> if all warnings were removed.
+     */
+    boolean clearWarnings(User user);
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/api/service/NucleusWarnService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/service/NucleusWarnService.java
@@ -47,4 +47,12 @@ public interface NucleusWarnService {
      * @return <code>true</code> if all warnings were removed.
      */
     boolean clearWarnings(User user);
+
+    /**
+     * Updates a current users warnings
+     *
+     * @param user The {@link User} to update.
+     * @return <code>true</code> if all warnings were updated.
+     */
+    boolean updateWarnings(User user);
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/NoteArgument.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/NoteArgument.java
@@ -79,7 +79,7 @@ public class NoteArgument extends CommandElement {
 
     @Override
     public Text getUsage(CommandSource src) {
-        return Text.of("<user> <index>");
+        return Text.of("<user> <ID>");
     }
 
     public static class Result {

--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/NoteArgument.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/NoteArgument.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.argumentparsers;
+
+import io.github.nucleuspowered.nucleus.Nucleus;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.api.data.NoteData;
+import io.github.nucleuspowered.nucleus.modules.note.handlers.NoteHandler;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.ArgumentParseException;
+import org.spongepowered.api.command.args.CommandArgs;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.service.user.UserStorageService;
+import org.spongepowered.api.text.Text;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class NoteArgument extends CommandElement {
+
+    private Nucleus plugin;
+    private NoteHandler handler;
+
+    public NoteArgument(@Nullable Text key, Nucleus plugin, NoteHandler handler) {
+        super(key);
+        this.plugin = plugin;
+        this.handler = handler;
+    }
+
+    @Nullable
+    @Override
+    protected Object parseValue(CommandSource source, CommandArgs args) throws ArgumentParseException {
+        Optional<String> optPlayer = args.nextIfPresent();
+        if (!optPlayer.isPresent()) {
+            throw args.createError(Util.getTextMessageWithFormat("args.note.nouserarg"));
+        }
+        String player = optPlayer.get();
+
+        Optional<User> optUser = Sponge.getServiceManager().provideUnchecked(UserStorageService.class).get(player);
+        if (!optUser.isPresent()) {
+            throw args.createError(Util.getTextMessageWithFormat("args.note.nouser", player));
+        }
+        User user = optUser.get();
+
+        Optional<String> optIndex = args.nextIfPresent();
+        if (!optIndex.isPresent()) {
+            throw args.createError(Util.getTextMessageWithFormat("args.note.noindex", user.getName()));
+        }
+
+        List<NoteData> noteData = handler.getNotes(user);
+        int index;
+        try {
+            index = Integer.parseInt(optIndex.get()) - 1;
+            if (index >= noteData.size() || index < 0) {
+                throw args.createError(Util.getTextMessageWithFormat("args.note.nonotedata", optIndex.get(), user.getName()));
+            }
+        } catch (NumberFormatException ex) {
+            throw args.createError(Util.getTextMessageWithFormat("args.note.indexnotnumber"));
+        }
+
+        if (!noteData.isEmpty()) {
+            return new Result(user, noteData.get(index));
+        }
+
+        throw args.createError(Util.getTextMessageWithFormat("args.note.nousernotes",user.getName()));
+    }
+
+    @Override
+    public List<String> complete(CommandSource src, CommandArgs args, CommandContext context) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Text getUsage(CommandSource src) {
+        return Text.of("<user> <index>");
+    }
+
+    public static class Result {
+        public final User user;
+        public final NoteData noteData;
+
+        public Result(User user, NoteData noteData) {
+            this.user = user;
+            this.noteData = noteData;
+        }
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/WarningArgument.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/WarningArgument.java
@@ -79,7 +79,7 @@ public class WarningArgument extends CommandElement {
 
     @Override
     public Text getUsage(CommandSource src) {
-        return Text.of("<user> <index>");
+        return Text.of("<user> <ID>");
     }
 
     public static class Result {

--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/WarningArgument.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/WarningArgument.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.argumentparsers;
+
+import io.github.nucleuspowered.nucleus.Nucleus;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.api.data.WarnData;
+import io.github.nucleuspowered.nucleus.modules.warn.handlers.WarnHandler;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.ArgumentParseException;
+import org.spongepowered.api.command.args.CommandArgs;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.service.user.UserStorageService;
+import org.spongepowered.api.text.Text;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class WarningArgument extends CommandElement {
+
+    private Nucleus plugin;
+    private WarnHandler handler;
+
+    public WarningArgument(@Nullable Text key, Nucleus plugin, WarnHandler handler) {
+        super(key);
+        this.plugin = plugin;
+        this.handler = handler;
+    }
+
+    @Nullable
+    @Override
+    protected Object parseValue(CommandSource source, CommandArgs args) throws ArgumentParseException {
+        Optional<String> optPlayer = args.nextIfPresent();
+        if (!optPlayer.isPresent()) {
+            throw args.createError(Util.getTextMessageWithFormat("args.warning.nouserarg"));
+        }
+        String player = optPlayer.get();
+
+        Optional<User> optUser = Sponge.getServiceManager().provideUnchecked(UserStorageService.class).get(player);
+        if (!optUser.isPresent()) {
+            throw args.createError(Util.getTextMessageWithFormat("args.warning.nouser", player));
+        }
+        User user = optUser.get();
+
+        Optional<String> optIndex = args.nextIfPresent();
+        if (!optIndex.isPresent()) {
+            throw args.createError(Util.getTextMessageWithFormat("args.warning.noindex", user.getName()));
+        }
+
+        List<WarnData> warnData = handler.getWarnings(user);
+        int index;
+        try {
+            index = Integer.parseInt(optIndex.get()) - 1;
+            if (index >= warnData.size() || index < 0) {
+                throw args.createError(Util.getTextMessageWithFormat("args.warning.nowarndata", optIndex.get(), user.getName()));
+            }
+        } catch (NumberFormatException ex) {
+            throw args.createError(Util.getTextMessageWithFormat("args.warning.indexnotnumber"));
+        }
+
+        if (!warnData.isEmpty()) {
+            return new Result(user, warnData.get(index));
+        }
+
+        throw args.createError(Util.getTextMessageWithFormat("args.warning.nouserwarnings",user.getName()));
+    }
+
+    @Override
+    public List<String> complete(CommandSource src, CommandArgs args, CommandContext context) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Text getUsage(CommandSource src) {
+        return Text.of("<user> <index>");
+    }
+
+    public static class Result {
+        public final User user;
+        public final WarnData warnData;
+
+        public Result(User user, WarnData warnData) {
+            this.user = user;
+            this.warnData = warnData;
+        }
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/datatypes/UserDataNode.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/datatypes/UserDataNode.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.github.nucleuspowered.nucleus.api.data.JailData;
 import io.github.nucleuspowered.nucleus.api.data.MuteData;
+import io.github.nucleuspowered.nucleus.api.data.NoteData;
 import io.github.nucleuspowered.nucleus.api.data.WarnData;
 import io.github.nucleuspowered.nucleus.api.data.mail.MailData;
 import ninja.leaping.configurate.objectmapping.Setting;
@@ -27,6 +28,9 @@ public class UserDataNode {
 
     @Setting("expired-warnings")
     private List<WarnData> expiredWarnings = Lists.newArrayList();
+
+    @Setting("notes")
+    private List<NoteData> notes = Lists.newArrayList();
 
     @Setting
     private boolean socialspy;
@@ -94,12 +98,24 @@ public class UserDataNode {
         return warnings;
     }
 
+    public void setWarnings(List<WarnData> warnings) {
+        this.warnings = warnings;
+    }
+
     public List<WarnData> getExpiredWarnings() {
         return expiredWarnings;
     }
 
-    public void setWarnings(List<WarnData> warnings) {
-        this.warnings = warnings;
+    public void setExpiredWarnings(List<WarnData> expiredWarnings) {
+        this.expiredWarnings = expiredWarnings;
+    }
+
+    public List<NoteData> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<NoteData> notes) {
+        this.notes = notes;
     }
 
     public boolean isSocialspy() {

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/datatypes/UserDataNode.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/datatypes/UserDataNode.java
@@ -26,9 +26,6 @@ public class UserDataNode {
     @Setting("warnings")
     private List<WarnData> warnings = Lists.newArrayList();
 
-    @Setting("expired-warnings")
-    private List<WarnData> expiredWarnings = Lists.newArrayList();
-
     @Setting("notes")
     private List<NoteData> notes = Lists.newArrayList();
 
@@ -100,14 +97,6 @@ public class UserDataNode {
 
     public void setWarnings(List<WarnData> warnings) {
         this.warnings = warnings;
-    }
-
-    public List<WarnData> getExpiredWarnings() {
-        return expiredWarnings;
-    }
-
-    public void setExpiredWarnings(List<WarnData> expiredWarnings) {
-        this.expiredWarnings = expiredWarnings;
     }
 
     public List<NoteData> getNotes() {

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/datatypes/UserDataNode.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/datatypes/UserDataNode.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.github.nucleuspowered.nucleus.api.data.JailData;
 import io.github.nucleuspowered.nucleus.api.data.MuteData;
+import io.github.nucleuspowered.nucleus.api.data.WarnData;
 import io.github.nucleuspowered.nucleus.api.data.mail.MailData;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
@@ -20,6 +21,9 @@ import java.util.UUID;
 public class UserDataNode {
     @Setting
     private MuteData muteData;
+
+    @Setting("warnings")
+    private List<WarnData> warnings = Lists.newArrayList();
 
     @Setting
     private boolean socialspy;
@@ -81,6 +85,14 @@ public class UserDataNode {
 
     public void setMuteData(MuteData muteData) {
         this.muteData = muteData;
+    }
+
+    public List<WarnData> getWarnings() {
+        return warnings;
+    }
+
+    public void setWarnings(List<WarnData> warnings) {
+        this.warnings = warnings;
     }
 
     public boolean isSocialspy() {

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/datatypes/UserDataNode.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/datatypes/UserDataNode.java
@@ -25,6 +25,9 @@ public class UserDataNode {
     @Setting("warnings")
     private List<WarnData> warnings = Lists.newArrayList();
 
+    @Setting("expired-warnings")
+    private List<WarnData> expiredWarnings = Lists.newArrayList();
+
     @Setting
     private boolean socialspy;
 
@@ -89,6 +92,10 @@ public class UserDataNode {
 
     public List<WarnData> getWarnings() {
         return warnings;
+    }
+
+    public List<WarnData> getExpiredWarnings() {
+        return expiredWarnings;
     }
 
     public void setWarnings(List<WarnData> warnings) {

--- a/src/main/java/io/github/nucleuspowered/nucleus/dataservices/UserService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/dataservices/UserService.java
@@ -12,10 +12,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.github.nucleuspowered.nucleus.Nucleus;
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.api.data.JailData;
-import io.github.nucleuspowered.nucleus.api.data.MuteData;
-import io.github.nucleuspowered.nucleus.api.data.NucleusUser;
-import io.github.nucleuspowered.nucleus.api.data.WarpLocation;
+import io.github.nucleuspowered.nucleus.api.data.*;
 import io.github.nucleuspowered.nucleus.api.data.mail.MailData;
 import io.github.nucleuspowered.nucleus.api.exceptions.NoSuchWorldException;
 import io.github.nucleuspowered.nucleus.configurate.datatypes.LocationNode;
@@ -84,6 +81,40 @@ public class UserService extends Service<UserDataNode>
 
     public void setMuteData(MuteData mData) {
         data.setMuteData(mData);
+    }
+
+    public List<WarnData> getWarnings() {
+        return ImmutableList.copyOf(data.getWarnings());
+    }
+
+    public void addWarning(WarnData warning) {
+        List<WarnData> warnings = data.getWarnings();
+        if (warnings == null) {
+            warnings = Lists.newArrayList();
+        }
+
+        warnings.add(warning);
+        data.setWarnings(warnings);
+    }
+
+    public boolean removeWarning(WarnData warning) {
+        List<WarnData> warnings = data.getWarnings();
+        if (warnings.removeIf(x -> x.getEndTimestamp().equals(warning.getEndTimestamp()) &&
+                x.getReason().equals(warning.getReason()) && x.getTimeFromNextLogin().equals(warning.getTimeFromNextLogin()) && x.getWarner().equals(warning.getWarner()))) {
+            data.setWarnings(warnings);
+            return true;
+        }
+
+        return false;
+    }
+
+    public boolean clearWarnings() {
+        if (!data.getWarnings().isEmpty()) {
+            data.setWarnings(Lists.newArrayList());
+            return true;
+        } else {
+            return false;
+        }
     }
 
     public void removeMuteData() {

--- a/src/main/java/io/github/nucleuspowered/nucleus/dataservices/UserService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/dataservices/UserService.java
@@ -83,10 +83,21 @@ public class UserService extends Service<UserDataNode>
         data.setMuteData(mData);
     }
 
+    public void removeMuteData() {
+        data.setMuteData(null);
+    }
+
+    @Override
     public List<WarnData> getWarnings() {
         return ImmutableList.copyOf(data.getWarnings());
     }
 
+    @Override
+    public List<WarnData> getExpiredWarnings() {
+        return ImmutableList.copyOf(data.getExpiredWarnings());
+    }
+
+    @Override
     public void addWarning(WarnData warning) {
         List<WarnData> warnings = data.getWarnings();
         if (warnings == null) {
@@ -97,10 +108,13 @@ public class UserService extends Service<UserDataNode>
         data.setWarnings(warnings);
     }
 
+    @Override
     public boolean removeWarning(WarnData warning) {
         List<WarnData> warnings = data.getWarnings();
         if (warnings.removeIf(x -> x.getEndTimestamp().equals(warning.getEndTimestamp()) &&
-                x.getReason().equals(warning.getReason()) && x.getTimeFromNextLogin().equals(warning.getTimeFromNextLogin()) && x.getWarner().equals(warning.getWarner()))) {
+                x.getReason().equals(warning.getReason()) &&
+                x.getTimeFromNextLogin().equals(warning.getTimeFromNextLogin()) &&
+                x.getWarner().equals(warning.getWarner()))) {
             data.setWarnings(warnings);
             return true;
         }
@@ -108,6 +122,7 @@ public class UserService extends Service<UserDataNode>
         return false;
     }
 
+    @Override
     public boolean clearWarnings() {
         if (!data.getWarnings().isEmpty()) {
             data.setWarnings(Lists.newArrayList());
@@ -115,10 +130,6 @@ public class UserService extends Service<UserDataNode>
         } else {
             return false;
         }
-    }
-
-    public void removeMuteData() {
-        data.setMuteData(null);
     }
 
     public boolean isSocialSpy() {

--- a/src/main/java/io/github/nucleuspowered/nucleus/dataservices/UserService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/dataservices/UserService.java
@@ -132,6 +132,39 @@ public class UserService extends Service<UserDataNode>
         }
     }
 
+    public List<NoteData> getNotes() {
+        return ImmutableList.copyOf(data.getNotes());
+    }
+
+    public void addNote(NoteData note) {
+        List<NoteData> notes = data.getNotes();
+        if (notes == null) {
+            notes = Lists.newArrayList();
+        }
+
+        notes.add(note);
+        data.setNotes(notes);
+    }
+
+    public boolean removeNote(NoteData note) {
+        List<NoteData> notes = data.getNotes();
+        if (notes.removeIf(x -> x.getNoter().equals(note.getNoter()) && x.getNote().equals(note.getNote()))) {
+            data.setNotes(notes);
+            return true;
+        }
+
+        return false;
+    }
+
+    public boolean clearNotes() {
+        if (!data.getNotes().isEmpty()) {
+            data.setNotes(Lists.newArrayList());
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     public boolean isSocialSpy() {
         // Only a spy if they have the permission!
         Optional<CommandPermissionHandler> ps = plugin.getPermissionRegistry().getService(SocialSpyCommand.class);

--- a/src/main/java/io/github/nucleuspowered/nucleus/dataservices/UserService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/dataservices/UserService.java
@@ -93,11 +93,6 @@ public class UserService extends Service<UserDataNode>
     }
 
     @Override
-    public List<WarnData> getExpiredWarnings() {
-        return ImmutableList.copyOf(data.getExpiredWarnings());
-    }
-
-    @Override
     public void addWarning(WarnData warning) {
         List<WarnData> warnings = data.getWarnings();
         if (warnings == null) {

--- a/src/main/java/io/github/nucleuspowered/nucleus/dataservices/UserService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/dataservices/UserService.java
@@ -114,7 +114,8 @@ public class UserService extends Service<UserDataNode>
         if (warnings.removeIf(x -> x.getEndTimestamp().equals(warning.getEndTimestamp()) &&
                 x.getReason().equals(warning.getReason()) &&
                 x.getTimeFromNextLogin().equals(warning.getTimeFromNextLogin()) &&
-                x.getWarner().equals(warning.getWarner()))) {
+                x.getWarner().equals(warning.getWarner()) &&
+                x.getDate().equals(warning.getDate()))) {
             data.setWarnings(warnings);
             return true;
         }

--- a/src/main/java/io/github/nucleuspowered/nucleus/dataservices/UserService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/dataservices/UserService.java
@@ -92,6 +92,10 @@ public class UserService extends Service<UserDataNode>
         return ImmutableList.copyOf(data.getWarnings());
     }
 
+    public void setWarnings(List<WarnData> warnings) {
+        data.setWarnings(warnings);
+    }
+
     @Override
     public void addWarning(WarnData warning) {
         List<WarnData> warnings = data.getWarnings();
@@ -100,6 +104,7 @@ public class UserService extends Service<UserDataNode>
         }
 
         warnings.add(warning);
+        warnings.sort((x, y) -> Boolean.compare(x.isExpired(), y.isExpired()));
         data.setWarnings(warnings);
     }
 
@@ -369,14 +374,14 @@ public class UserService extends Service<UserDataNode>
     }
 
     public boolean removeMail(MailData mailData) {
-         List<MailData> lmd = data.getMailDataList();
-         if (lmd.removeIf(x -> x.getDate().equals(mailData.getDate()) &&
+        List<MailData> lmd = data.getMailDataList();
+        if (lmd.removeIf(x -> x.getDate().equals(mailData.getDate()) &&
                 x.getMessage().equals(mailData.getMessage()) && x.getUuid().equals(mailData.getUuid()))) {
-             data.setMailDataList(lmd);
-             return true;
-         }
+            data.setMailDataList(lmd);
+            return true;
+        }
 
-         return false;
+        return false;
     }
 
     public boolean clearMail() {

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/BanModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/BanModule.java
@@ -4,9 +4,15 @@
  */
 package io.github.nucleuspowered.nucleus.modules.ban;
 
-import io.github.nucleuspowered.nucleus.internal.qsml.module.StandardModule;
+import io.github.nucleuspowered.nucleus.internal.qsml.module.ConfigurableModule;
+import io.github.nucleuspowered.nucleus.modules.ban.config.BanConfigAdapter;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
 
 @ModuleData(id = "ban", name = "Bans")
-public class BanModule extends StandardModule {
+public class BanModule extends ConfigurableModule<BanConfigAdapter> {
+
+    @Override
+    public BanConfigAdapter getAdapter() {
+        return new BanConfigAdapter();
+    }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/BanCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/BanCommand.java
@@ -64,7 +64,7 @@ public class BanCommand extends CommandBase<CommandSource> {
     @Override
     public Map<String, PermissionInformation> permissionSuffixesToRegister() {
         Map<String, PermissionInformation> m = new HashMap<>();
-        m.put("offline", new PermissionInformation(Util.getMessageWithFormat("permission.ban.offline"), SuggestedLevel.ADMIN));
+        m.put("offline", new PermissionInformation(Util.getMessageWithFormat("permission.ban.offline"), SuggestedLevel.MOD));
         return m;
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/BanCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/BanCommand.java
@@ -33,6 +33,7 @@ import org.spongepowered.api.text.serializer.TextSerializers;
 import org.spongepowered.api.util.ban.Ban;
 import org.spongepowered.api.util.ban.BanTypes;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -58,6 +59,13 @@ public class BanCommand extends CommandBase<CommandSource> {
         Map<String, PermissionInformation> ps = Maps.newHashMap();
         ps.put(notifyPermission, new PermissionInformation(Util.getMessageWithFormat("permission.ban.notify"), SuggestedLevel.MOD));
         return ps;
+    }
+
+    @Override
+    public Map<String, PermissionInformation> permissionSuffixesToRegister() {
+        Map<String, PermissionInformation> m = new HashMap<>();
+        m.put("offline", new PermissionInformation(Util.getMessageWithFormat("permission.ban.offline"), SuggestedLevel.ADMIN));
+        return m;
     }
 
     @Override
@@ -116,6 +124,13 @@ public class BanCommand extends CommandBase<CommandSource> {
 
     private CommandResult executeBan(CommandSource src, GameProfile u, String r) {
         BanService service = Sponge.getServiceManager().provideUnchecked(BanService.class);
+
+        UserStorageService uss = Sponge.getServiceManager().provideUnchecked(UserStorageService.class);
+        User user = uss.get(u).get();
+        if (!user.isOnline() && !permissions.testSuffix(src, "offline")) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.ban.offline.noperms"));
+            return CommandResult.empty();
+        }
 
         if (service.isBanned(u)) {
             src.sendMessage(Util.getTextMessageWithFormat("command.ban.alreadyset", u.getName().orElse(Util.getMessageWithFormat("standard.unknown"))));

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/TempBanCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/TempBanCommand.java
@@ -8,6 +8,7 @@ import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.TimespanArgument;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
+import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
@@ -26,6 +27,8 @@ import org.spongepowered.api.util.ban.BanTypes;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.Map;
 
 @RegisterCommand("tempban")
 @Permissions(suggestedLevel = SuggestedLevel.MOD)
@@ -37,6 +40,13 @@ public class TempBanCommand extends CommandBase<CommandSource> {
     private final String user = "user";
     private final String reason = "reason";
     private final String duration = "duration";
+
+    @Override
+    public Map<String, PermissionInformation> permissionSuffixesToRegister() {
+        Map<String, PermissionInformation> m = new HashMap<>();
+        m.put("offline", new PermissionInformation(Util.getMessageWithFormat("permission.tempban.offline"), SuggestedLevel.ADMIN));
+        return m;
+    }
 
     @Override
     public CommandElement[] getArguments() {
@@ -51,6 +61,11 @@ public class TempBanCommand extends CommandBase<CommandSource> {
         User u = args.<User>getOne(user).get();
         Long time = args.<Long>getOne(duration).get();
         String r = args.<String>getOne(reason).orElse(Util.getMessageWithFormat("ban.defaultreason"));
+
+        if (!u.isOnline() && !permissions.testSuffix(src, "offline")) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.tempban.offline.noperms"));
+            return CommandResult.empty();
+        }
 
         BanService service = Sponge.getServiceManager().provideUnchecked(BanService.class);
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/TempBanCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/TempBanCommand.java
@@ -44,7 +44,7 @@ public class TempBanCommand extends CommandBase<CommandSource> {
     @Override
     public Map<String, PermissionInformation> permissionSuffixesToRegister() {
         Map<String, PermissionInformation> m = new HashMap<>();
-        m.put("offline", new PermissionInformation(Util.getMessageWithFormat("permission.tempban.offline"), SuggestedLevel.ADMIN));
+        m.put("offline", new PermissionInformation(Util.getMessageWithFormat("permission.tempban.offline"), SuggestedLevel.MOD));
         return m;
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/config/BanConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/config/BanConfig.java
@@ -1,0 +1,19 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.ban.config;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+@ConfigSerializable
+public class BanConfig {
+
+    @Setting(value = "maximum-tempban-length", comment = "loc:config.tempban.maxtempbanlength")
+    private long maxTempBanLength = 604800;
+
+    public long getMaximumTempBanLength() {
+        return maxTempBanLength;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/config/BanConfigAdapter.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/config/BanConfigAdapter.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.ban.config;
+
+import com.google.common.reflect.TypeToken;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.commented.SimpleCommentedConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+
+public class BanConfigAdapter extends NucleusConfigAdapter<BanConfig> {
+    @Override
+    protected BanConfig getDefaultObject() {
+        return new BanConfig();
+    }
+
+    @Override
+    protected BanConfig convertFromConfigurateNode(ConfigurationNode node) throws ObjectMappingException {
+        return node.getValue(TypeToken.of(BanConfig.class), new BanConfig());
+    }
+
+    @Override
+    protected ConfigurationNode insertIntoConfigurateNode(BanConfig data) throws ObjectMappingException {
+        return SimpleCommentedConfigurationNode.root().setValue(TypeToken.of(BanConfig.class), data);
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/connection/ConnectionModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/connection/ConnectionModule.java
@@ -4,7 +4,15 @@
  */
 package io.github.nucleuspowered.nucleus.modules.connection;
 
+import io.github.nucleuspowered.nucleus.internal.qsml.module.ConfigurableModule;
+import io.github.nucleuspowered.nucleus.modules.connection.config.ConnectionConfigAdapter;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
 
 @ModuleData(id = "connection", name = "Connection")
-public class ConnectionModule { }
+public class ConnectionModule extends ConfigurableModule<ConnectionConfigAdapter> {
+
+    @Override
+    public ConnectionConfigAdapter getAdapter() {
+        return new ConnectionConfigAdapter();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/connection/ConnectionModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/connection/ConnectionModule.java
@@ -1,0 +1,10 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.connection;
+
+import uk.co.drnaylor.quickstart.annotations.ModuleData;
+
+@ModuleData(id = "connection", name = "Connection")
+public class ConnectionModule { }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/connection/config/ConnectionConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/connection/config/ConnectionConfig.java
@@ -1,0 +1,19 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.connection.config;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+@ConfigSerializable
+public class ConnectionConfig {
+
+    @Setting(value = "reserved-slots", comment = "loc:config.connection.reservedslots")
+    private int reservedSlots = -1;
+
+    public int getReservedSlots() {
+        return reservedSlots;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/connection/config/ConnectionConfigAdapter.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/connection/config/ConnectionConfigAdapter.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.connection.config;
+
+import com.google.common.reflect.TypeToken;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.commented.SimpleCommentedConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+
+public class ConnectionConfigAdapter extends NucleusConfigAdapter<ConnectionConfig> {
+    @Override
+    protected ConnectionConfig getDefaultObject() {
+        return new ConnectionConfig();
+    }
+
+    @Override
+    protected ConnectionConfig convertFromConfigurateNode(ConfigurationNode node) throws ObjectMappingException {
+        return node.getValue(TypeToken.of(ConnectionConfig.class), new ConnectionConfig());
+    }
+
+    @Override
+    protected ConfigurationNode insertIntoConfigurateNode(ConnectionConfig data) throws ObjectMappingException {
+        return SimpleCommentedConfigurationNode.root().setValue(TypeToken.of(ConnectionConfig.class), data);
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/connection/listeners/ConnectionListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/connection/listeners/ConnectionListener.java
@@ -5,11 +5,13 @@
 package io.github.nucleuspowered.nucleus.modules.connection.listeners;
 
 import com.google.common.collect.Maps;
+import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.internal.ListenerBase;
 import io.github.nucleuspowered.nucleus.internal.PermissionRegistry;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import io.github.nucleuspowered.nucleus.modules.connection.config.ConnectionConfigAdapter;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.filter.IsCancelled;
@@ -22,6 +24,7 @@ public class ConnectionListener extends ListenerBase {
 
     private final String joinFullServer = PermissionRegistry.PERMISSIONS_PREFIX + "connection.joinfullserver";
 
+    @Inject private ConnectionConfigAdapter cca;
 
     /**
      * At the time the player joins if the server is full, check if they are permitted to join a full server.
@@ -36,6 +39,11 @@ public class ConnectionListener extends ListenerBase {
         }
 
         if (event.getTargetUser().hasPermission(joinFullServer)) {
+            if (cca.getNodeOrDefault().getReservedSlots() != -1
+                    && Sponge.getServer().getOnlinePlayers().size() - Sponge.getServer().getMaxPlayers() >= cca.getNodeOrDefault().getReservedSlots()) {
+                return;
+            }
+
             event.setCancelled(false);
         }
     }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/connection/listeners/ConnectionListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/connection/listeners/ConnectionListener.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.connection.listeners;
+
+import com.google.common.collect.Maps;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.internal.ListenerBase;
+import io.github.nucleuspowered.nucleus.internal.PermissionRegistry;
+import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
+import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.filter.IsCancelled;
+import org.spongepowered.api.event.network.ClientConnectionEvent;
+import org.spongepowered.api.util.Tristate;
+
+import java.util.Map;
+
+public class ConnectionListener extends ListenerBase {
+
+    private final String joinFullServer = PermissionRegistry.PERMISSIONS_PREFIX + "connection.joinfullserver";
+
+
+    /**
+     * At the time the player joins if the server is full, check if they are permitted to join a full server.
+     *
+     * @param event The event.
+     */
+    @Listener
+    @IsCancelled(Tristate.UNDEFINED)
+    public void onPlayerJoin(ClientConnectionEvent.Login event) {
+        if (!(Sponge.getServer().getOnlinePlayers().size() >= Sponge.getServer().getMaxPlayers())) {
+            return;
+        }
+
+        if (event.getTargetUser().hasPermission(joinFullServer)) {
+            event.setCancelled(false);
+        }
+    }
+
+    @Override
+    public Map<String, PermissionInformation> getPermissions() {
+        Map<String, PermissionInformation> mp = Maps.newHashMap();
+        mp.put(joinFullServer, new PermissionInformation(Util.getMessageWithFormat("permission.connection.joinfullserver"), SuggestedLevel.MOD));
+        return mp;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/commands/JailCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/commands/JailCommand.java
@@ -59,7 +59,7 @@ public class JailCommand extends CommandBase<CommandSource> {
     @Override
     public Map<String, PermissionInformation> permissionSuffixesToRegister() {
         Map<String, PermissionInformation> m = new HashMap<>();
-        m.put("offline", new PermissionInformation(Util.getMessageWithFormat("permission.jail.offline"), SuggestedLevel.ADMIN));
+        m.put("offline", new PermissionInformation(Util.getMessageWithFormat("permission.jail.offline"), SuggestedLevel.MOD));
         return m;
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/commands/JailCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/commands/JailCommand.java
@@ -57,6 +57,13 @@ public class JailCommand extends CommandBase<CommandSource> {
     }
 
     @Override
+    public Map<String, PermissionInformation> permissionSuffixesToRegister() {
+        Map<String, PermissionInformation> m = new HashMap<>();
+        m.put("offline", new PermissionInformation(Util.getMessageWithFormat("permission.jail.offline"), SuggestedLevel.ADMIN));
+        return m;
+    }
+
+    @Override
     public CommandElement[] getArguments() {
         return new CommandElement[] {GenericArguments.onlyOne(GenericArguments.user(Text.of(playerKey))),
                 GenericArguments.optional(GenericArguments.onlyOne(new JailArgument(Text.of(jailKey), handler))),
@@ -68,6 +75,11 @@ public class JailCommand extends CommandBase<CommandSource> {
     public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
         // Get the player.
         User pl = args.<User>getOne(playerKey).get();
+        if (!pl.isOnline() && !permissions.testSuffix(src, "offline")) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.jail.offline.noperms"));
+            return CommandResult.empty();
+        }
+
         if (handler.isPlayerJailed(pl)) {
             return onUnjail(src, args, pl);
         } else {

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/mute/commands/MuteCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/mute/commands/MuteCommand.java
@@ -67,7 +67,8 @@ public class MuteCommand extends CommandBase<CommandSource> {
     @Override
     public Map<String, PermissionInformation> permissionSuffixesToRegister() {
         Map<String, PermissionInformation> m = new HashMap<>();
-        m.put("bypass", new PermissionInformation(Util.getMessageWithFormat("permission.mute.bypass"), SuggestedLevel.MOD));
+        m.put("exempt.length", new PermissionInformation(Util.getMessageWithFormat("permission.mute.bypass"), SuggestedLevel.MOD));
+        m.put("exempt.target", new PermissionInformation(Util.getMessageWithFormat("permission.mute.bypass"), SuggestedLevel.MOD));
         return m;
     }
 
@@ -88,6 +89,11 @@ public class MuteCommand extends CommandBase<CommandSource> {
         Optional<MuteData> omd = handler.getPlayerMuteData(user);
         Optional<String> reas = args.getOne(reason);
 
+        if (permissions.testSuffix(user, "exempt.target")) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.mute.exempt", user.getName()));
+            return CommandResult.success();
+        }
+
         // No time, no reason, but is muted, unmute
         if (omd.isPresent() && !time.isPresent() && !reas.isPresent()) {
             // Unmute.
@@ -103,7 +109,7 @@ public class MuteCommand extends CommandBase<CommandSource> {
             ua = ((Player) src).getUniqueId();
         }
 
-        if (time.orElse(Long.MAX_VALUE) > mca.getNodeOrDefault().getMaximumMuteLength() &&  mca.getNodeOrDefault().getMaximumMuteLength() != -1 && !permissions.testSuffix(src, "bypass")) {
+        if (time.orElse(Long.MAX_VALUE) > mca.getNodeOrDefault().getMaximumMuteLength() &&  mca.getNodeOrDefault().getMaximumMuteLength() != -1 && !permissions.testSuffix(src, "exempt.length")) {
             src.sendMessage(Util.getTextMessageWithFormat("command.mute.length.toolong", Util.getTimeStringFromSeconds(mca.getNodeOrDefault().getMaximumMuteLength())));
             return CommandResult.success();
         }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/mute/commands/MuteCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/mute/commands/MuteCommand.java
@@ -52,7 +52,6 @@ public class MuteCommand extends CommandBase<CommandSource> {
     @Inject private MuteHandler handler;
 
     private final String notifyPermission = PermissionRegistry.PERMISSIONS_PREFIX + "mute.notify";
-    private final String bypassMaximumLength = PermissionRegistry.PERMISSIONS_PREFIX + "mute.bypass";
 
     private String playerArgument = "player";
     private String timespanArgument = "time";
@@ -62,7 +61,13 @@ public class MuteCommand extends CommandBase<CommandSource> {
     public Map<String, PermissionInformation> permissionsToRegister() {
         Map<String, PermissionInformation> m = new HashMap<>();
         m.put(notifyPermission, new PermissionInformation(Util.getMessageWithFormat("permission.mute.notify"), SuggestedLevel.MOD));
-        m.put(bypassMaximumLength, new PermissionInformation(Util.getMessageWithFormat("permission.mute.bypass"), SuggestedLevel.MOD));
+        return m;
+    }
+
+    @Override
+    public Map<String, PermissionInformation> permissionSuffixesToRegister() {
+        Map<String, PermissionInformation> m = new HashMap<>();
+        m.put("bypass", new PermissionInformation(Util.getMessageWithFormat("permission.mute.bypass"), SuggestedLevel.MOD));
         return m;
     }
 
@@ -98,7 +103,7 @@ public class MuteCommand extends CommandBase<CommandSource> {
             ua = ((Player) src).getUniqueId();
         }
 
-        if (time.orElse(Long.MAX_VALUE) > mca.getNodeOrDefault().getMaximumMuteLength() &&  mca.getNodeOrDefault().getMaximumMuteLength() != -1 && !src.hasPermission(bypassMaximumLength)) {
+        if (time.orElse(Long.MAX_VALUE) > mca.getNodeOrDefault().getMaximumMuteLength() &&  mca.getNodeOrDefault().getMaximumMuteLength() != -1 && !permissions.testSuffix(src, "bypass")) {
             src.sendMessage(Util.getTextMessageWithFormat("command.mute.length.toolong", Util.getTimeStringFromSeconds(mca.getNodeOrDefault().getMaximumMuteLength())));
             return CommandResult.success();
         }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/mute/config/MuteConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/mute/config/MuteConfig.java
@@ -16,7 +16,14 @@ public class MuteConfig {
     @Setting(value = "blocked-commands", comment = "loc:config.mute.blocked")
     private List<String> blockedCommands = Lists.newArrayList("me", "say");
 
+    @Setting(value = "maximum-mute-length", comment = "loc:config.mute.maxmutelength")
+    private long maxMuteLength = 604800;
+
     public List<String> getBlockedCommands() {
         return blockedCommands;
+    }
+
+    public long getMaximumMuteLength() {
+        return maxMuteLength;
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/note/NoteModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/note/NoteModule.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.note;
+
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.api.service.NucleusNoteService;
+import io.github.nucleuspowered.nucleus.internal.qsml.module.ConfigurableModule;
+import io.github.nucleuspowered.nucleus.modules.note.config.NoteConfigAdapter;
+import io.github.nucleuspowered.nucleus.modules.note.handlers.NoteHandler;
+import org.slf4j.Logger;
+import org.spongepowered.api.Game;
+import uk.co.drnaylor.quickstart.annotations.ModuleData;
+
+
+@ModuleData(id = "note", name = "Note")
+public class NoteModule extends ConfigurableModule<NoteConfigAdapter> {
+
+    @Inject
+    private Game game;
+    @Inject private Logger logger;
+
+    @Override
+    public NoteConfigAdapter getAdapter() {
+        return new NoteConfigAdapter();
+    }
+
+    @Override
+    protected void performPreTasks() throws Exception {
+        super.performPreTasks();
+
+        try {
+            NoteHandler noteHandler = new NoteHandler(nucleus);
+            nucleus.getInjector().injectMembers(noteHandler);
+            game.getServiceManager().setProvider(nucleus, NucleusNoteService.class, noteHandler);
+            serviceManager.registerService(NoteHandler.class, noteHandler);
+        } catch (Exception ex) {
+            logger.warn("Could not load the note module for the reason below.");
+            ex.printStackTrace();
+            throw ex;
+        }
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/note/commands/CheckNotesCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/note/commands/CheckNotesCommand.java
@@ -103,10 +103,8 @@ public class CheckNotesCommand extends CommandBase<CommandSource> {
         //Add the delete button [Delete]
         actions.append(Text.builder().append(Text.of(TextColors.RED, Util.getMessageWithFormat("standard.action.delete")))
                 .onHover(TextActions.showText(Util.getTextMessageWithFormat("command.checknotes.hover.delete")))
-                .onClick(TextActions.executeCallback(commandSource1 -> {
-                    handler.removeNote(user, note);
-                    commandSource1.sendMessage(Util.getTextMessageWithFormat("command.removenote.remove", user.getName()));
-                })).build());
+                .onClick(TextActions.runCommand("/removenote " + user.getName() + " " + id))
+                .build());
 
         //Add a - to separate it from the next action button
         actions.append(Text.of(TextColors.GOLD, " - "));
@@ -114,7 +112,7 @@ public class CheckNotesCommand extends CommandBase<CommandSource> {
         //Add the return button [Return]
         actions.append(Text.builder().append(Text.of(TextColors.GREEN, Util.getMessageWithFormat("standard.action.return")))
                 .onHover(TextActions.showText(Util.getTextMessageWithFormat("command.checknotes.hover.return")))
-                .onClick(TextActions.executeCallback(commandSource1 -> Sponge.getCommandManager().process(commandSource1, "checknotes " + user.getName())))
+                .onClick(TextActions.runCommand("/checknotes " + user.getName()))
                 .build());
 
         //Add a < to end the actions button list

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/note/commands/CheckNotesCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/note/commands/CheckNotesCommand.java
@@ -4,6 +4,7 @@
  */
 package io.github.nucleuspowered.nucleus.modules.note.commands;
 
+import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.NoteData;
@@ -18,8 +19,10 @@ import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.args.CommandElement;
 import org.spongepowered.api.command.args.GenericArguments;
 import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.service.pagination.PaginationService;
 import org.spongepowered.api.service.user.UserStorageService;
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
 
 import java.util.List;
 import java.util.Optional;
@@ -56,6 +59,7 @@ public class CheckNotesCommand extends CommandBase<CommandSource> {
         }
 
         int index = 0;
+        List<Text> messages = Lists.newArrayList();
         for (NoteData note : notes) {
             String name;
             if (note.getNoter().equals(Util.consoleFakeUUID)) {
@@ -65,9 +69,25 @@ public class CheckNotesCommand extends CommandBase<CommandSource> {
                 name = ou.isPresent() ? ou.get().getName() : Util.getMessageWithFormat("standard.unknown");
             }
 
-            src.sendMessage(Util.getTextMessageWithFormat("command.checknotes.note", String.valueOf(index + 1), note.getNote(), name));
+            messages.add(Util.getTextMessageWithFormat("command.checknotes.note", String.valueOf(index + 1), note.getNote(), name));
             index++;
         }
+
+        PaginationService paginationService = Sponge.getGame().getServiceManager().provideUnchecked(PaginationService.class);
+        paginationService.builder()
+                .title(
+                        Text.builder()
+                        .color(TextColors.GOLD)
+                        .append(Text.of(user.getName() + "'s notes"))
+                        .build())
+                .padding(
+                        Text.builder()
+                        .color(TextColors.YELLOW)
+                        .append(Text.of("="))
+                        .build())
+                .contents(messages)
+                .sendTo(src);
+
         return CommandResult.success();
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/note/commands/CheckNotesCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/note/commands/CheckNotesCommand.java
@@ -78,7 +78,7 @@ public class CheckNotesCommand extends CommandBase<CommandSource> {
                 .title(
                         Text.builder()
                         .color(TextColors.GOLD)
-                        .append(Text.of(user.getName() + "'s notes"))
+                        .append(Text.of(user.getName() + Util.getMessageWithFormat("command.checknotes.header")))
                         .build())
                 .padding(
                         Text.builder()

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/note/commands/CheckNotesCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/note/commands/CheckNotesCommand.java
@@ -78,7 +78,7 @@ public class CheckNotesCommand extends CommandBase<CommandSource> {
                 .title(
                         Text.builder()
                         .color(TextColors.GOLD)
-                        .append(Text.of(user.getName() + Util.getMessageWithFormat("command.checknotes.header")))
+                        .append(Text.of(Util.getMessageWithFormat("command.checknotes.header", user.getName())))
                         .build())
                 .padding(
                         Text.builder()

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/note/commands/CheckNotesCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/note/commands/CheckNotesCommand.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.note.commands;
+
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.api.data.NoteData;
+import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
+import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import io.github.nucleuspowered.nucleus.modules.note.handlers.NoteHandler;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.service.user.UserStorageService;
+import org.spongepowered.api.text.Text;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Checks the notes of a player.
+ *
+ * Command Usage: /checknotes user Permission: quickstart.checknotes.base
+ */
+@Permissions(suggestedLevel = SuggestedLevel.MOD)
+@RunAsync
+@NoWarmup
+@NoCooldown
+@NoCost
+@RegisterCommand({"checknotes", "notes"})
+public class CheckNotesCommand extends CommandBase<CommandSource> {
+
+    @Inject private NoteHandler handler;
+    private final String playerKey = "player";
+
+    @Override
+    public CommandElement[] getArguments() {
+        return new CommandElement[] {GenericArguments.onlyOne(GenericArguments.user(Text.of(playerKey)))};
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        User user = args.<User>getOne(playerKey).get();
+
+        List<NoteData> notes = handler.getNotes(user);
+        if (notes.isEmpty()) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.checknotes.none", user.getName()));
+            return CommandResult.success();
+        }
+
+        int index = 0;
+        for (NoteData note : notes) {
+            String name;
+            if (note.getNoter().equals(Util.consoleFakeUUID)) {
+                name = Sponge.getServer().getConsole().getName();
+            } else {
+                Optional<User> ou = Sponge.getServiceManager().provideUnchecked(UserStorageService.class).get(note.getNoter());
+                name = ou.isPresent() ? ou.get().getName() : Util.getMessageWithFormat("standard.unknown");
+            }
+
+            src.sendMessage(Util.getTextMessageWithFormat("command.checknotes.note", String.valueOf(index + 1), note.getNote(), name));
+            index++;
+        }
+        return CommandResult.success();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/note/commands/ClearNotesCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/note/commands/ClearNotesCommand.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.note.commands;
+
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.api.data.NoteData;
+import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
+import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import io.github.nucleuspowered.nucleus.modules.note.handlers.NoteHandler;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.text.Text;
+
+import java.util.List;
+
+@Permissions(suggestedLevel = SuggestedLevel.MOD)
+@RunAsync
+@NoWarmup
+@NoCooldown
+@NoCost
+@RegisterCommand({"clearnotes", "removeallnotes"})
+public class ClearNotesCommand extends CommandBase<CommandSource> {
+
+    @Inject private NoteHandler handler;
+    private final String playerKey = "player";
+
+    @Override
+    public CommandElement[] getArguments() {
+        return new CommandElement[] {GenericArguments.onlyOne(GenericArguments.user(Text.of(playerKey)))};
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        User user = args.<User>getOne(playerKey).get();
+
+        List<NoteData> notes = handler.getNotes(user);
+        if (notes.isEmpty()) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.checknotes.none", user.getName()));
+            return CommandResult.success();
+        }
+
+        if (handler.clearNotes(user)) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.clearnotes.success", user.getName()));
+            return CommandResult.success();
+        }
+
+        src.sendMessage(Util.getTextMessageWithFormat("command.clearnotes.failure", user.getName()));
+        return CommandResult.empty();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/note/commands/NoteCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/note/commands/NoteCommand.java
@@ -25,6 +25,7 @@ import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.channel.MessageChannel;
 import org.spongepowered.api.text.channel.MutableMessageChannel;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -66,7 +67,7 @@ public class NoteCommand extends CommandBase<CommandSource> {
             noter = ((Player) src).getUniqueId();
         }
 
-        NoteData noteData = new NoteData(noter, note);
+        NoteData noteData = new NoteData(Instant.now(), noter, note);
 
         if (noteHandler.addNote(user, noteData)) {
             MutableMessageChannel messageChannel = MessageChannel.permission(notifyPermission).asMutable();

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/note/commands/NoteCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/note/commands/NoteCommand.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.note.commands;
+
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.api.data.NoteData;
+import io.github.nucleuspowered.nucleus.internal.PermissionRegistry;
+import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
+import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
+import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import io.github.nucleuspowered.nucleus.modules.note.config.NoteConfigAdapter;
+import io.github.nucleuspowered.nucleus.modules.note.handlers.NoteHandler;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.channel.MessageChannel;
+import org.spongepowered.api.text.channel.MutableMessageChannel;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Permissions(suggestedLevel = SuggestedLevel.MOD)
+@NoWarmup
+@NoCooldown
+@NoCost
+@RegisterCommand({"note", "addnote"})
+public class NoteCommand extends CommandBase<CommandSource> {
+    public static final String notifyPermission = PermissionRegistry.PERMISSIONS_PREFIX + "note.notify";
+
+    private final String playerKey = "player";
+    private final String noteKey = "note";
+
+    @Inject private NoteHandler noteHandler;
+    @Inject private NoteConfigAdapter nca;
+
+    @Override
+    public Map<String, PermissionInformation> permissionsToRegister() {
+        Map<String, PermissionInformation> m = new HashMap<>();
+        m.put(notifyPermission, new PermissionInformation(Util.getMessageWithFormat("permission.note.notify"), SuggestedLevel.MOD));
+        return m;
+    }
+
+    @Override
+    public CommandElement[] getArguments() {
+        return new CommandElement[] {GenericArguments.onlyOne(GenericArguments.user(Text.of(playerKey))),
+                GenericArguments.onlyOne(GenericArguments.onlyOne(GenericArguments.remainingJoinedStrings(Text.of(noteKey))))};
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        User user = args.<User>getOne(playerKey).get();
+        String note = args.<String>getOne(noteKey).get();
+
+        UUID noter = Util.consoleFakeUUID;
+        if (src instanceof Player) {
+            noter = ((Player) src).getUniqueId();
+        }
+
+        NoteData noteData = new NoteData(noter, note);
+
+        if (noteHandler.addNote(user, noteData)) {
+            MutableMessageChannel messageChannel = MessageChannel.permission(notifyPermission).asMutable();
+            messageChannel.addMember(src);
+
+            messageChannel.send(Util.getTextMessageWithFormat("command.note.success", src.getName(), noteData.getNote(), user.getName()));
+
+            return CommandResult.success();
+        }
+
+        src.sendMessage(Util.getTextMessageWithFormat("command.warn.fail", user.getName()));
+        return CommandResult.empty();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/note/commands/RemoveNoteCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/note/commands/RemoveNoteCommand.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.note.commands;
+
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.api.data.NoteData;
+import io.github.nucleuspowered.nucleus.argumentparsers.NoteArgument;
+import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
+import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import io.github.nucleuspowered.nucleus.modules.note.handlers.NoteHandler;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.text.Text;
+
+import java.util.List;
+
+@Permissions(suggestedLevel = SuggestedLevel.MOD)
+@RunAsync
+@NoWarmup
+@NoCooldown
+@NoCost
+@RegisterCommand({"removenote", "deletenote", "delnote"})
+public class RemoveNoteCommand extends CommandBase<CommandSource> {
+
+    @Inject private NoteHandler handler;
+    private final String noteKey = "note";
+
+    @Override
+    public CommandElement[] getArguments() {
+        return new CommandElement[] {GenericArguments.onlyOne(new NoteArgument(Text.of(noteKey), plugin, handler))};
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        NoteArgument.Result result = args.<NoteArgument.Result>getOne(noteKey).get();
+        User user = result.user;
+
+        List<NoteData> notes = handler.getNotes(user);
+        if (notes.isEmpty()) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.checkwarnings.none", user.getName()));
+            return CommandResult.success();
+        }
+
+        if (handler.removeNote(user, result.noteData)) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.removenote.success", user.getName()));
+            return CommandResult.success();
+        }
+
+        src.sendMessage(Util.getTextMessageWithFormat("command.removenote.failure", user.getName()));
+        return CommandResult.empty();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/note/config/NoteConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/note/config/NoteConfig.java
@@ -1,0 +1,19 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.note.config;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+@ConfigSerializable
+public class NoteConfig {
+
+    @Setting(value = "show-login", comment = "loc:config.note.showonlogin")
+    private boolean showOnLogin = true;
+
+    public boolean isShowOnLogin() {
+        return showOnLogin;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/note/config/NoteConfigAdapter.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/note/config/NoteConfigAdapter.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.note.config;
+
+import com.google.common.reflect.TypeToken;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.commented.SimpleCommentedConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+
+public class NoteConfigAdapter extends NucleusConfigAdapter<NoteConfig> {
+    @Override
+    protected NoteConfig getDefaultObject() {
+        return new NoteConfig();
+    }
+
+    @Override
+    protected NoteConfig convertFromConfigurateNode(ConfigurationNode node) throws ObjectMappingException {
+        return node.getValue(TypeToken.of(NoteConfig.class), new NoteConfig());
+    }
+
+    @Override
+    protected ConfigurationNode insertIntoConfigurateNode(NoteConfig data) throws ObjectMappingException {
+        return SimpleCommentedConfigurationNode.root().setValue(TypeToken.of(NoteConfig.class), data);
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/note/handlers/NoteHandler.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/note/handlers/NoteHandler.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.note.handlers;
+
+import com.google.common.base.Preconditions;
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Nucleus;
+import io.github.nucleuspowered.nucleus.api.data.NoteData;
+import io.github.nucleuspowered.nucleus.api.service.NucleusNoteService;
+import io.github.nucleuspowered.nucleus.dataservices.UserService;
+import io.github.nucleuspowered.nucleus.dataservices.loaders.UserDataManager;
+import org.spongepowered.api.entity.living.player.User;
+
+import java.util.List;
+import java.util.Optional;
+
+public class NoteHandler implements NucleusNoteService {
+
+    private final Nucleus nucleus;
+    @Inject
+    private UserDataManager userDataManager;
+
+    public NoteHandler(Nucleus nucleus) {
+        this.nucleus = nucleus;
+    }
+
+    @Override
+    public List<NoteData> getNotes(User user) {
+        Optional<UserService> userService = userDataManager.get(user);
+        if (userService.isPresent()) {
+            return userService.get().getNotes();
+        }
+        return null;
+    }
+
+    @Override
+    public boolean addNote(User user, NoteData note) {
+        Preconditions.checkNotNull(user);
+        Preconditions.checkNotNull(note);
+
+        Optional<UserService> optUserService = userDataManager.get(user);
+        if (!optUserService.isPresent()) {
+            return false;
+        }
+        UserService userService = optUserService.get();
+
+        userService.addNote(note);
+        return true;
+    }
+
+    @Override
+    public boolean removeNote(User user, NoteData note) {
+        Optional<UserService> userService = userDataManager.get(user);
+        if (userService.isPresent()) {
+            userService.get().removeNote(note);
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean clearNotes(User user) {
+        Optional<UserService> userService = userDataManager.get(user);
+        if (userService.isPresent()) {
+            userService.get().clearNotes();
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/note/handlers/NoteHandler.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/note/handlers/NoteHandler.java
@@ -5,6 +5,7 @@
 package io.github.nucleuspowered.nucleus.modules.note.handlers;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Nucleus;
 import io.github.nucleuspowered.nucleus.api.data.NoteData;
@@ -32,7 +33,7 @@ public class NoteHandler implements NucleusNoteService {
         if (userService.isPresent()) {
             return userService.get().getNotes();
         }
-        return null;
+        return Lists.newArrayList();
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/note/listeners/NoteListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/note/listeners/NoteListener.java
@@ -8,7 +8,6 @@ import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.NoteData;
-import io.github.nucleuspowered.nucleus.dataservices.UserService;
 import io.github.nucleuspowered.nucleus.dataservices.loaders.UserDataManager;
 import io.github.nucleuspowered.nucleus.internal.ListenerBase;
 import io.github.nucleuspowered.nucleus.internal.PermissionRegistry;
@@ -20,12 +19,12 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.network.ClientConnectionEvent;
+import org.spongepowered.api.text.action.TextActions;
 import org.spongepowered.api.text.channel.MessageChannel;
 import org.spongepowered.api.text.channel.MutableMessageChannel;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 public class NoteListener extends ListenerBase {
@@ -53,19 +52,11 @@ public class NoteListener extends ListenerBase {
             List<NoteData> notes = handler.getNotes(player);
             if (notes != null && !notes.isEmpty()) {
                 MutableMessageChannel messageChannel = MessageChannel.permission(showOnLogin).asMutable();
-                messageChannel.send(Util.getTextMessageWithFormat("note.login.notify", player.getName()));
-                int noteNumber = 1;
-                for (NoteData note : notes) {
-                    Optional<UserService> optUserService = userDataManager.get(note.getNoter());
-                    if (!optUserService.isPresent()) {
-                        messageChannel.send(Util.getTextMessageWithFormat("note.login.nonoter", String.valueOf(noteNumber), note.getNote()));
-                        continue;
-                    }
-                    UserService userService = optUserService.get();
+                messageChannel.send(Util.getTextMessageWithFormat("note.login.notify", player.getName()).toBuilder()
+                        .onHover(TextActions.showText(Util.getTextMessageWithFormat("note.login.view", player.getName())))
+                        .onClick(TextActions.runCommand("/checknotes " + player.getName()))
+                        .build());
 
-                    messageChannel.send(Util.getTextMessageWithFormat("note.login.note", String.valueOf(noteNumber), note.getNote(), userService.getUser().getName()));
-                    noteNumber++;
-                }
             }
         }).submit(plugin);
     }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/note/listeners/NoteListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/note/listeners/NoteListener.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.note.listeners;
+
+import com.google.common.collect.Maps;
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.api.data.NoteData;
+import io.github.nucleuspowered.nucleus.internal.ListenerBase;
+import io.github.nucleuspowered.nucleus.internal.PermissionRegistry;
+import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
+import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import io.github.nucleuspowered.nucleus.modules.note.config.NoteConfigAdapter;
+import io.github.nucleuspowered.nucleus.modules.note.handlers.NoteHandler;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.network.ClientConnectionEvent;
+import org.spongepowered.api.text.channel.MessageChannel;
+import org.spongepowered.api.text.channel.MutableMessageChannel;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class NoteListener extends ListenerBase {
+
+    @Inject private NoteHandler handler;
+    @Inject private NoteConfigAdapter nca;
+    private final String showOnLogin = PermissionRegistry.PERMISSIONS_PREFIX + "note.showonlogin";
+
+
+    /**
+     * At the time the player joins, check to see if the player has any notes,
+     * if he does send them to users with the permission nucleus.note.showonlogin
+     *
+     * @param event The event.
+     */
+    @Listener
+    public void onPlayerLogin(final ClientConnectionEvent.Join event) {
+        if (!nca.getNodeOrDefault().isShowOnLogin()) {
+            return;
+        }
+
+        Sponge.getScheduler().createTaskBuilder().async().delay(500, TimeUnit.MILLISECONDS).execute(() -> {
+            Player player = event.getTargetEntity();
+            List<NoteData> notes = handler.getNotes(player);
+            if (notes != null) {
+                MutableMessageChannel messageChannel = MessageChannel.permission(showOnLogin).asMutable();
+                messageChannel.send(Util.getTextMessageWithFormat("note.login.notify", player.getName()));
+                int noteNumber = 1;
+                for (NoteData note : notes) {
+                    messageChannel.send(Util.getTextMessageWithFormat("note.login.note", String.valueOf(noteNumber), note.getNote()));
+                    noteNumber++;
+                }
+            }
+        }).submit(plugin);
+    }
+
+    @Override
+    public Map<String, PermissionInformation> getPermissions() {
+        Map<String, PermissionInformation> mp = Maps.newHashMap();
+        mp.put(showOnLogin, new PermissionInformation(Util.getMessageWithFormat("permission.note.showonlogin"), SuggestedLevel.MOD));
+        return mp;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/note/listeners/NoteListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/note/listeners/NoteListener.java
@@ -8,6 +8,8 @@ import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.NoteData;
+import io.github.nucleuspowered.nucleus.dataservices.UserService;
+import io.github.nucleuspowered.nucleus.dataservices.loaders.UserDataManager;
 import io.github.nucleuspowered.nucleus.internal.ListenerBase;
 import io.github.nucleuspowered.nucleus.internal.PermissionRegistry;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
@@ -23,12 +25,14 @@ import org.spongepowered.api.text.channel.MutableMessageChannel;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 public class NoteListener extends ListenerBase {
 
     @Inject private NoteHandler handler;
     @Inject private NoteConfigAdapter nca;
+    @Inject private UserDataManager userDataManager;
     private final String showOnLogin = PermissionRegistry.PERMISSIONS_PREFIX + "note.showonlogin";
 
 
@@ -52,7 +56,14 @@ public class NoteListener extends ListenerBase {
                 messageChannel.send(Util.getTextMessageWithFormat("note.login.notify", player.getName()));
                 int noteNumber = 1;
                 for (NoteData note : notes) {
-                    messageChannel.send(Util.getTextMessageWithFormat("note.login.note", String.valueOf(noteNumber), note.getNote()));
+                    Optional<UserService> optUserService = userDataManager.get(note.getNoter());
+                    if (!optUserService.isPresent()) {
+                        messageChannel.send(Util.getTextMessageWithFormat("note.login.nonoter", String.valueOf(noteNumber), note.getNote()));
+                        continue;
+                    }
+                    UserService userService = optUserService.get();
+
+                    messageChannel.send(Util.getTextMessageWithFormat("note.login.note", String.valueOf(noteNumber), note.getNote(), userService.getUser().getName()));
                     noteNumber++;
                 }
             }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/note/listeners/NoteListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/note/listeners/NoteListener.java
@@ -47,7 +47,7 @@ public class NoteListener extends ListenerBase {
         Sponge.getScheduler().createTaskBuilder().async().delay(500, TimeUnit.MILLISECONDS).execute(() -> {
             Player player = event.getTargetEntity();
             List<NoteData> notes = handler.getNotes(player);
-            if (notes != null) {
+            if (notes != null && !notes.isEmpty()) {
                 MutableMessageChannel messageChannel = MessageChannel.permission(showOnLogin).asMutable();
                 messageChannel.send(Util.getTextMessageWithFormat("note.login.notify", player.getName()));
                 int noteNumber = 1;

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/WarnModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/WarnModule.java
@@ -34,7 +34,7 @@ public class WarnModule extends ConfigurableModule<WarnConfigAdapter> {
             game.getServiceManager().setProvider(nucleus, NucleusWarnService.class, warnHandler);
             serviceManager.registerService(WarnHandler.class, warnHandler);
         } catch (Exception ex) {
-            logger.warn("Could not load the mute module for the reason below.");
+            logger.warn("Could not load the warn module for the reason below.");
             ex.printStackTrace();
             throw ex;
         }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/WarnModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/WarnModule.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.warn;
+
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.api.service.NucleusWarnService;
+import io.github.nucleuspowered.nucleus.internal.qsml.module.StandardModule;
+import io.github.nucleuspowered.nucleus.modules.warn.handlers.WarnHandler;
+import org.slf4j.Logger;
+import org.spongepowered.api.Game;
+import uk.co.drnaylor.quickstart.annotations.ModuleData;
+
+@ModuleData(id = "warn", name = "Warn")
+public class WarnModule extends StandardModule {
+
+    @Inject private Game game;
+    @Inject private Logger logger;
+
+    @Override
+    protected void performPreTasks() throws Exception {
+        super.performPreTasks();
+
+        try {
+            WarnHandler warnHandler = new WarnHandler(nucleus);
+            nucleus.getInjector().injectMembers(warnHandler);
+            game.getServiceManager().setProvider(nucleus, NucleusWarnService.class, warnHandler);
+            serviceManager.registerService(WarnHandler.class, warnHandler);
+        } catch (Exception ex) {
+            logger.warn("Could not load the mute module for the reason below.");
+            ex.printStackTrace();
+            throw ex;
+        }
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/WarnModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/WarnModule.java
@@ -6,17 +6,23 @@ package io.github.nucleuspowered.nucleus.modules.warn;
 
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.api.service.NucleusWarnService;
-import io.github.nucleuspowered.nucleus.internal.qsml.module.StandardModule;
+import io.github.nucleuspowered.nucleus.internal.qsml.module.ConfigurableModule;
+import io.github.nucleuspowered.nucleus.modules.warn.config.WarnConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.warn.handlers.WarnHandler;
 import org.slf4j.Logger;
 import org.spongepowered.api.Game;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
 
 @ModuleData(id = "warn", name = "Warn")
-public class WarnModule extends StandardModule {
+public class WarnModule extends ConfigurableModule<WarnConfigAdapter> {
 
     @Inject private Game game;
     @Inject private Logger logger;
+
+    @Override
+    public WarnConfigAdapter getAdapter() {
+        return new WarnConfigAdapter();
+    }
 
     @Override
     protected void performPreTasks() throws Exception {

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/CheckWarningsCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/CheckWarningsCommand.java
@@ -73,7 +73,7 @@ public class CheckWarningsCommand extends CommandBase<CommandSource> {
             } else if (warning.getTimeFromNextLogin().isPresent()) {
                 time = Util.getTimeStringFromSeconds(warning.getTimeFromNextLogin().get().getSeconds());
             } else {
-                time = "the rest of time";
+                time = Util.getMessageWithFormat("standard.restoftime");
             }
 
             src.sendMessage(Util.getTextMessageWithFormat("command.checkwarnings.warn", String.valueOf(index + 1), user.getName(), name, time, warning.getReason()));

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/CheckWarningsCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/CheckWarningsCommand.java
@@ -68,17 +68,15 @@ public class CheckWarningsCommand extends CommandBase<CommandSource> {
             }
 
             String time = "";
-            String forString = "";
             if (warning.getEndTimestamp().isPresent()) {
                 time = Util.getTimeStringFromSeconds(Instant.now().until(warning.getEndTimestamp().get(), ChronoUnit.SECONDS));
-                forString = " " + Util.getMessageWithFormat("standard.for") + " ";
             } else if (warning.getTimeFromNextLogin().isPresent()) {
                 time = Util.getTimeStringFromSeconds(warning.getTimeFromNextLogin().get().getSeconds());
-                forString = " " + Util.getMessageWithFormat("standard.for") + " ";
+            } else {
+                time = "the rest of time";
             }
 
-            src.sendMessage(Util.getTextMessageWithFormat("command.checkmute.mute", String.valueOf(index + 1), user.getName(), name, forString, time));
-            src.sendMessage(Util.getTextMessageWithFormat("standard.reason", warning.getReason()));
+            src.sendMessage(Util.getTextMessageWithFormat("command.checkwarnings.warn", String.valueOf(index + 1), user.getName(), name, time, warning.getReason()));
             index++;
         }
         return CommandResult.success();

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/CheckWarningsCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/CheckWarningsCommand.java
@@ -125,10 +125,8 @@ public class CheckWarningsCommand extends CommandBase<CommandSource> {
         //Add the delete button [Delete]
         actions.append(Text.builder().append(Text.of(TextColors.RED, Util.getMessageWithFormat("standard.action.delete")))
                 .onHover(TextActions.showText(Util.getTextMessageWithFormat("command.checkwarnings.hover.delete")))
-                .onClick(TextActions.executeCallback(commandSource1 -> {
-                    handler.removeWarning(user, warning, true);
-                    commandSource1.sendMessage(Util.getTextMessageWithFormat("command.removewarning.remove", user.getName()));
-                })).build());
+                .onClick(TextActions.runCommand("/removewarning --remove" + user.getName() + " " + id))
+                .build());
 
         //Add a - to separate it from the next action button
         actions.append(Text.of(TextColors.GOLD, " - "));
@@ -137,10 +135,8 @@ public class CheckWarningsCommand extends CommandBase<CommandSource> {
         if (!warning.isExpired()) {
             actions.append(Text.builder().append(Text.of(TextColors.YELLOW, Util.getMessageWithFormat("standard.action.expire")))
                     .onHover(TextActions.showText(Util.getTextMessageWithFormat("command.checkwarnings.hover.expire")))
-                    .onClick(TextActions.executeCallback(commandSource1 -> {
-                        handler.removeWarning(user, warning, false);
-                        commandSource1.sendMessage(Util.getTextMessageWithFormat("command.removewarning.expire", user.getName()));
-                    })).build());
+                    .onClick(TextActions.runCommand("/removewarning " + user.getName() + " " + id))
+                    .build());
 
             //Add a - to separate it from the next action button
             actions.append(Text.of(TextColors.GOLD, " - "));
@@ -149,7 +145,7 @@ public class CheckWarningsCommand extends CommandBase<CommandSource> {
         //Add the return button [Return]
         actions.append(Text.builder().append(Text.of(TextColors.GREEN, Util.getMessageWithFormat("standard.action.return")))
                 .onHover(TextActions.showText(Util.getTextMessageWithFormat("command.checkwarnings.hover.return")))
-                .onClick(TextActions.executeCallback(commandSource1 -> Sponge.getCommandManager().process(commandSource1, "checkwarnings " + user.getName())))
+                .onClick(TextActions.runCommand("/checkwarnings " + user.getName()))
                 .build());
 
         //Add a < to end the actions button list

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/CheckWarningsCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/CheckWarningsCommand.java
@@ -56,6 +56,7 @@ public class CheckWarningsCommand extends CommandBase<CommandSource> {
             src.sendMessage(Util.getTextMessageWithFormat("command.checkwarnings.none", user.getName()));
             return CommandResult.success();
         }
+        handler.updateWarnings(user);
 
         int index = 0;
         for (WarnData warning : warnings) {

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/CheckWarningsCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/CheckWarningsCommand.java
@@ -4,7 +4,6 @@
  */
 package io.github.nucleuspowered.nucleus.modules.warn.commands;
 
-import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.WarnData;
@@ -22,12 +21,16 @@ import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.service.pagination.PaginationService;
 import org.spongepowered.api.service.user.UserStorageService;
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.action.TextActions;
 import org.spongepowered.api.text.format.TextColors;
 
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Checks the warnings of a player.
@@ -70,49 +73,118 @@ public class CheckWarningsCommand extends CommandBase<CommandSource> {
         }
         handler.updateWarnings(user);
 
-        int index = 0;
-        List<Text> messages = Lists.newArrayList();
-        for (WarnData warning : warnings) {
-            String name;
-            if (warning.getWarner().equals(Util.consoleFakeUUID)) {
-                name = Sponge.getServer().getConsole().getName();
-            } else {
-                Optional<User> ou = Sponge.getServiceManager().provideUnchecked(UserStorageService.class).get(warning.getWarner());
-                name = ou.isPresent() ? ou.get().getName() : Util.getMessageWithFormat("standard.unknown");
-            }
-
-            String time;
-            if (warning.getEndTimestamp().isPresent()) {
-                time = Util.getTimeStringFromSeconds(Instant.now().until(warning.getEndTimestamp().get(), ChronoUnit.SECONDS));
-            } else if (warning.getTimeFromNextLogin().isPresent()) {
-                time = Util.getTimeStringFromSeconds(warning.getTimeFromNextLogin().get().getSeconds());
-            } else {
-                time = Util.getMessageWithFormat("standard.restoftime");
-            }
-
-            if (warning.isExpired()) {
-                messages.add(Util.getTextMessageWithFormat("command.checkwarnings.expired", String.valueOf(index + 1), user.getName(), name, warning.getReason()));
-            } else {
-                messages.add(Util.getTextMessageWithFormat("command.checkwarnings.warn", String.valueOf(index + 1), user.getName(), name, time, warning.getReason()));
-            }
-            index++;
-        }
+        List<Text> messages = warnings.stream().sorted((a, b) -> a.getDate().compareTo(b.getDate())).map(x -> createMessage(x, user)).collect(Collectors.toList());
+        messages.add(0, Util.getTextMessageWithFormat("command.checkwarnings.info"));
 
         PaginationService paginationService = Sponge.getGame().getServiceManager().provideUnchecked(PaginationService.class);
         paginationService.builder()
                 .title(
                         Text.builder()
-                        .color(TextColors.GOLD)
-                        .append(Text.of(user.getName() + Util.getMessageWithFormat("command.checkwarnings.header")))
-                        .build())
+                                .color(TextColors.GOLD)
+                                .append(Text.of(Util.getMessageWithFormat("command.checkwarnings.header", user.getName())))
+                                .build())
                 .padding(
                         Text.builder()
-                        .color(TextColors.YELLOW)
-                        .append(Text.of("="))
-                        .build())
+                                .color(TextColors.YELLOW)
+                                .append(Text.of("="))
+                                .build())
                 .contents(messages)
                 .sendTo(src);
 
         return CommandResult.success();
+    }
+
+    private Text createMessage(WarnData warning, User user) {
+        String name;
+        if (warning.getWarner().equals(Util.consoleFakeUUID)) {
+            name = Sponge.getServer().getConsole().getName();
+        } else {
+            Optional<User> ou = Sponge.getServiceManager().provideUnchecked(UserStorageService.class).get(warning.getWarner());
+            name = ou.isPresent() ? ou.get().getName() : Util.getMessageWithFormat("standard.unknown");
+        }
+
+        //Get the remaining length of the warning
+        String time;
+        if (warning.getEndTimestamp().isPresent()) {
+            time = Util.getTimeStringFromSeconds(Instant.now().until(warning.getEndTimestamp().get(), ChronoUnit.SECONDS));
+        } else if (warning.getTimeFromNextLogin().isPresent()) {
+            time = Util.getTimeStringFromSeconds(warning.getTimeFromNextLogin().get().getSeconds());
+        } else {
+            time = Util.getMessageWithFormat("standard.restoftime");
+        }
+
+        //Get the ID of the warning, its index in the users List<WarnData>
+        int id = handler.getWarnings(user).indexOf(warning);
+
+        //Action buttons, for a non expired warning this should look like 'Action > [Delete] - [Expire] - [Return] <'
+        Text.Builder actions = Util.getTextMessageWithFormat("command.checkwarnings.action").toBuilder();
+
+        //Add separation between the word 'Action' and action buttons
+        actions.append(Text.of(TextColors.GOLD, " > "));
+
+        //Add the delete button [Delete]
+        actions.append(Text.builder().append(Text.of(TextColors.RED, Util.getMessageWithFormat("standard.action.delete")))
+                .onHover(TextActions.showText(Util.getTextMessageWithFormat("command.checkwarnings.hover.delete")))
+                .onClick(TextActions.executeCallback(commandSource1 -> {
+                    handler.removeWarning(user, warning, true);
+                    commandSource1.sendMessage(Util.getTextMessageWithFormat("command.removewarning.remove", user.getName()));
+                })).build());
+
+        //Add a - to separate it from the next action button
+        actions.append(Text.of(TextColors.GOLD, " - "));
+
+        //Add the expire button if the warning isn't expired [Expire]
+        if (!warning.isExpired()) {
+            actions.append(Text.builder().append(Text.of(TextColors.YELLOW, Util.getMessageWithFormat("standard.action.expire")))
+                    .onHover(TextActions.showText(Util.getTextMessageWithFormat("command.checkwarnings.hover.expire")))
+                    .onClick(TextActions.executeCallback(commandSource1 -> {
+                        handler.removeWarning(user, warning, false);
+                        commandSource1.sendMessage(Util.getTextMessageWithFormat("command.removewarning.expire", user.getName()));
+                    })).build());
+
+            //Add a - to separate it from the next action button
+            actions.append(Text.of(TextColors.GOLD, " - "));
+        }
+
+        //Add the return button [Return]
+        actions.append(Text.builder().append(Text.of(TextColors.GREEN, Util.getMessageWithFormat("standard.action.return")))
+                .onHover(TextActions.showText(Util.getTextMessageWithFormat("command.checkwarnings.hover.return")))
+                .onClick(TextActions.executeCallback(commandSource1 -> Sponge.getCommandManager().process(commandSource1, "checkwarnings " + user.getName())))
+                .build());
+
+        //Add a < to end the actions button list
+        actions.append(Text.of(TextColors.GOLD, " < "));
+
+        //Get and format the date of the warning
+        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("MMM dd, yyyy").withZone(ZoneId.systemDefault());
+        String date = dtf.format(warning.getDate());
+
+        //Create a clickable name providing more information about the warning
+        Text.Builder information = Text.builder(name)
+                .onHover(TextActions.showText(Util.getTextMessageWithFormat("command.checkwarnings.hover.check")))
+                .onClick(TextActions.executeCallback(commandSource -> {
+                    commandSource.sendMessage(Util.getTextMessageWithFormat("command.checkwarnings.id", String.valueOf(id)));
+                    commandSource.sendMessage(Util.getTextMessageWithFormat("command.checkwarnings.date", date));
+                    commandSource.sendMessage(Util.getTextMessageWithFormat("command.checkwarnings.remaining", time));
+                    commandSource.sendMessage(Util.getTextMessageWithFormat("command.checkwarnings.warner", name));
+                    commandSource.sendMessage(Util.getTextMessageWithFormat("command.checkwarnings.warning", warning.getReason()));
+                    commandSource.sendMessage(actions.build());
+                }));
+
+        //Create the warning message
+        Text.Builder message = Text.builder()
+                .append(Text.of(TextColors.GREEN, information.build()))
+                .append(Text.of(": "))
+                .append(Text.of(TextColors.YELLOW, warning.getReason()));
+
+        //Add the remaining length of the warning
+        if (warning.isExpired()) {
+            message.append(Text.of(TextColors.GRAY, " " + Util.getMessageWithFormat("standard.status.expired")));
+        } else {
+            message.append(Text.of(TextColors.GREEN, " " + Util.getMessageWithFormat("standard.for") + " "));
+            message.append(Text.of(TextColors.YELLOW, time));
+        }
+
+        return message.build();
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/CheckWarningsCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/CheckWarningsCommand.java
@@ -4,6 +4,7 @@
  */
 package io.github.nucleuspowered.nucleus.modules.warn.commands;
 
+import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.WarnData;
@@ -18,8 +19,10 @@ import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.args.CommandElement;
 import org.spongepowered.api.command.args.GenericArguments;
 import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.service.pagination.PaginationService;
 import org.spongepowered.api.service.user.UserStorageService;
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -68,6 +71,7 @@ public class CheckWarningsCommand extends CommandBase<CommandSource> {
         handler.updateWarnings(user);
 
         int index = 0;
+        List<Text> messages = Lists.newArrayList();
         for (WarnData warning : warnings) {
             String name;
             if (warning.getWarner().equals(Util.consoleFakeUUID)) {
@@ -87,12 +91,28 @@ public class CheckWarningsCommand extends CommandBase<CommandSource> {
             }
 
             if (warning.isExpired()) {
-                src.sendMessage(Util.getTextMessageWithFormat("command.checkwarnings.expired", String.valueOf(index + 1), user.getName(), name, warning.getReason()));
+                messages.add(Util.getTextMessageWithFormat("command.checkwarnings.expired", String.valueOf(index + 1), user.getName(), name, warning.getReason()));
             } else {
-                src.sendMessage(Util.getTextMessageWithFormat("command.checkwarnings.warn", String.valueOf(index + 1), user.getName(), name, time, warning.getReason()));
+                messages.add(Util.getTextMessageWithFormat("command.checkwarnings.warn", String.valueOf(index + 1), user.getName(), name, time, warning.getReason()));
             }
             index++;
         }
+
+        PaginationService paginationService = Sponge.getGame().getServiceManager().provideUnchecked(PaginationService.class);
+        paginationService.builder()
+                .title(
+                        Text.builder()
+                        .color(TextColors.GOLD)
+                        .append(Text.of(user.getName() + "'s warnings"))
+                        .build())
+                .padding(
+                        Text.builder()
+                        .color(TextColors.YELLOW)
+                        .append(Text.of("="))
+                        .build())
+                .contents(messages)
+                .sendTo(src);
+
         return CommandResult.success();
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/CheckWarningsCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/CheckWarningsCommand.java
@@ -182,7 +182,11 @@ public class CheckWarningsCommand extends CommandBase<CommandSource> {
             message.append(Text.of(TextColors.GRAY, " " + Util.getMessageWithFormat("standard.status.expired")));
         } else {
             message.append(Text.of(TextColors.GREEN, " " + Util.getMessageWithFormat("standard.for") + " "));
-            message.append(Text.of(TextColors.YELLOW, time));
+            if (Character.isLetter(time.charAt(0))) {
+                message.append(Text.of(TextColors.YELLOW, time.substring(0, 1).toLowerCase() + time.substring(1)));
+            } else {
+                message.append(Text.of(TextColors.YELLOW, time));
+            }
         }
 
         return message.build();

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/CheckWarningsCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/CheckWarningsCommand.java
@@ -103,7 +103,7 @@ public class CheckWarningsCommand extends CommandBase<CommandSource> {
                 .title(
                         Text.builder()
                         .color(TextColors.GOLD)
-                        .append(Text.of(user.getName() + "'s warnings"))
+                        .append(Text.of(user.getName() + Util.getMessageWithFormat("command.checkwarnings.header")))
                         .build())
                 .padding(
                         Text.builder()

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/CheckWarningsCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/CheckWarningsCommand.java
@@ -44,8 +44,8 @@ public class CheckWarningsCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandElement[] getArguments() {
-        return new CommandElement[] {GenericArguments.onlyOne(GenericArguments.user(Text.of(playerKey))),
-                GenericArguments.flags().flag("all", "a").flag("expired", "e").buildWith(GenericArguments.none())};
+        return new CommandElement[] {GenericArguments.flags().flag("-all", "a").flag("-expired", "e").buildWith(
+                GenericArguments.onlyOne(GenericArguments.user(Text.of(playerKey))))};
     }
 
     @Override
@@ -53,12 +53,12 @@ public class CheckWarningsCommand extends CommandBase<CommandSource> {
         User user = args.<User>getOne(playerKey).get();
 
         List<WarnData> warnings;
-        if (args.hasAny("all") || args.hasAny("a")) {
+        if (args.hasAny("all")) {
             warnings = handler.getWarnings(user);
-        } else if (args.hasAny("expired") || args.hasAny("e")) {
-            warnings = handler.getWarnings(user, true);
+        } else if (args.hasAny("expired")) {
+            warnings = handler.getWarnings(user, false, true);
         } else {
-            warnings = handler.getWarnings(user, false);
+            warnings = handler.getWarnings(user, true, false);
         }
 
         if (warnings.isEmpty()) {
@@ -77,7 +77,7 @@ public class CheckWarningsCommand extends CommandBase<CommandSource> {
                 name = ou.isPresent() ? ou.get().getName() : Util.getMessageWithFormat("standard.unknown");
             }
 
-            String time = "";
+            String time;
             if (warning.getEndTimestamp().isPresent()) {
                 time = Util.getTimeStringFromSeconds(Instant.now().until(warning.getEndTimestamp().get(), ChronoUnit.SECONDS));
             } else if (warning.getTimeFromNextLogin().isPresent()) {

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/CheckWarningsCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/CheckWarningsCommand.java
@@ -36,7 +36,7 @@ import java.util.Optional;
 @NoWarmup
 @NoCooldown
 @NoCost
-@RegisterCommand({"checkwarnings", "checkwarn"})
+@RegisterCommand({"checkwarnings", "checkwarn", "warnings"})
 public class CheckWarningsCommand extends CommandBase<CommandSource> {
 
     @Inject private WarnHandler handler;

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/CheckWarningsCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/CheckWarningsCommand.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.warn.commands;
+
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.api.data.WarnData;
+import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
+import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import io.github.nucleuspowered.nucleus.modules.warn.handlers.WarnHandler;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.service.user.UserStorageService;
+import org.spongepowered.api.text.Text;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Checks the warnings of a player.
+ *
+ * Command Usage: /checkwarnings user Permission: quickstart.checkwarnings.base
+ */
+@Permissions(suggestedLevel = SuggestedLevel.MOD)
+@RunAsync
+@NoWarmup
+@NoCooldown
+@NoCost
+@RegisterCommand({"checkwarnings", "checkwarn"})
+public class CheckWarningsCommand extends CommandBase<CommandSource> {
+
+    @Inject private WarnHandler handler;
+    private final String playerKey = "player";
+
+    @Override
+    public CommandElement[] getArguments() {
+        return new CommandElement[] {GenericArguments.onlyOne(GenericArguments.user(Text.of(playerKey)))};
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        User user = args.<User>getOne(playerKey).get();
+
+        List<WarnData> warnings = handler.getWarnings(user);
+        if (warnings.isEmpty()) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.checkwarnings.none", user.getName()));
+            return CommandResult.success();
+        }
+
+        int index = 0;
+        for (WarnData warning : warnings) {
+            String name;
+            if (warning.getWarner().equals(Util.consoleFakeUUID)) {
+                name = Sponge.getServer().getConsole().getName();
+            } else {
+                Optional<User> ou = Sponge.getServiceManager().provideUnchecked(UserStorageService.class).get(warning.getWarner());
+                name = ou.isPresent() ? ou.get().getName() : Util.getMessageWithFormat("standard.unknown");
+            }
+
+            String time = "";
+            String forString = "";
+            if (warning.getEndTimestamp().isPresent()) {
+                time = Util.getTimeStringFromSeconds(Instant.now().until(warning.getEndTimestamp().get(), ChronoUnit.SECONDS));
+                forString = " " + Util.getMessageWithFormat("standard.for") + " ";
+            } else if (warning.getTimeFromNextLogin().isPresent()) {
+                time = Util.getTimeStringFromSeconds(warning.getTimeFromNextLogin().get().getSeconds());
+                forString = " " + Util.getMessageWithFormat("standard.for") + " ";
+            }
+
+            src.sendMessage(Util.getTextMessageWithFormat("command.checkmute.mute", String.valueOf(index + 1), user.getName(), name, forString, time));
+            src.sendMessage(Util.getTextMessageWithFormat("standard.reason", warning.getReason()));
+            index++;
+        }
+        return CommandResult.success();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/ClearWarningsCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/ClearWarningsCommand.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.warn.commands;
+
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.api.data.WarnData;
+import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
+import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import io.github.nucleuspowered.nucleus.modules.warn.handlers.WarnHandler;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.text.Text;
+
+import java.util.List;
+
+@Permissions(suggestedLevel = SuggestedLevel.MOD)
+@RunAsync
+@NoWarmup
+@NoCooldown
+@NoCost
+@RegisterCommand({"clearwarnings", "removeallwarnings"})
+public class ClearWarningsCommand extends CommandBase<CommandSource> {
+
+    @Inject private WarnHandler handler;
+    private final String playerKey = "player";
+
+    @Override
+    public CommandElement[] getArguments() {
+        return new CommandElement[] {GenericArguments.onlyOne(GenericArguments.user(Text.of(playerKey)))};
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        User user = args.<User>getOne(playerKey).get();
+
+        List<WarnData> warnings = handler.getWarnings(user);
+        if (warnings.isEmpty()) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.checkwarnings.none", user.getName()));
+            return CommandResult.success();
+        }
+
+        if (handler.clearWarnings(user)) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.clearwarnings.success", user.getName()));
+            return CommandResult.success();
+        }
+
+        src.sendMessage(Util.getTextMessageWithFormat("command.clearwarnings.failure", user.getName()));
+        return CommandResult.empty();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/ClearWarningsCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/ClearWarningsCommand.java
@@ -34,7 +34,8 @@ public class ClearWarningsCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandElement[] getArguments() {
-        return new CommandElement[] {GenericArguments.onlyOne(GenericArguments.user(Text.of(playerKey)))};
+        return new CommandElement[] {GenericArguments.flags().flag("-all", "a").flag("-remove", "r").flag("-expired", "e").buildWith(
+                        GenericArguments.onlyOne(GenericArguments.user(Text.of(playerKey))))};
     }
 
     @Override
@@ -47,8 +48,27 @@ public class ClearWarningsCommand extends CommandBase<CommandSource> {
             return CommandResult.success();
         }
 
-        if (handler.clearWarnings(user)) {
-            src.sendMessage(Util.getTextMessageWithFormat("command.clearwarnings.success", user.getName()));
+        //By default expire all active warnings.
+        //If the flag --all is used then remove all warnings
+        //If the flag --expired is used then remove all expired warnings.
+        //If the flag --remove is used then remove all active warnings.
+        boolean removeActive = false;
+        boolean removeExpired = false;
+        Text message = Util.getTextMessageWithFormat("command.clearwarnings.success", user.getName());
+        if (args.hasAny("all")) {
+            removeActive = true;
+            removeExpired = true;
+            message = Util.getTextMessageWithFormat("command.clearwarnings.all", user.getName());
+        } else if (args.hasAny("remove")) {
+            removeActive = true;
+            message = Util.getTextMessageWithFormat("command.clearwarnings.remove", user.getName());
+        } else if (args.hasAny("expired")) {
+            removeExpired = true;
+            message = Util.getTextMessageWithFormat("command.clearwarnings.expired", user.getName());
+        }
+
+        if (handler.clearWarnings(user, removeActive, removeExpired)) {
+            src.sendMessage(message);
             return CommandResult.success();
         }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/RemoveWarningCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/RemoveWarningCommand.java
@@ -36,13 +36,18 @@ public class RemoveWarningCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandElement[] getArguments() {
-        return new CommandElement[] {GenericArguments.onlyOne(new WarningArgument(Text.of(warningKey), plugin, handler))};
+        return new CommandElement[] {GenericArguments.flags().flag("-remove", "r").buildWith(
+                GenericArguments.onlyOne(new WarningArgument(Text.of(warningKey), plugin, handler)))};
     }
 
     @Override
     public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
         WarningArgument.Result result = args.<WarningArgument.Result>getOne(warningKey).get();
         User user = result.user;
+        boolean removePermanently = false;
+        if (args.hasAny("remove")) {
+            removePermanently = true;
+        }
 
         List<WarnData> warnings = handler.getWarnings(user);
         if (warnings.isEmpty()) {
@@ -50,7 +55,7 @@ public class RemoveWarningCommand extends CommandBase<CommandSource> {
             return CommandResult.success();
         }
 
-        if (handler.removeWarning(user, result.warnData)) {
+        if (handler.removeWarning(user, result.warnData, removePermanently)) {
             src.sendMessage(Util.getTextMessageWithFormat("command.removewarning.success", user.getName()));
             return CommandResult.success();
         }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/RemoveWarningCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/RemoveWarningCommand.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.warn.commands;
+
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.api.data.WarnData;
+import io.github.nucleuspowered.nucleus.argumentparsers.WarningArgument;
+import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
+import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import io.github.nucleuspowered.nucleus.modules.warn.handlers.WarnHandler;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.text.Text;
+
+import java.util.List;
+
+@Permissions(suggestedLevel = SuggestedLevel.MOD)
+@RunAsync
+@NoWarmup
+@NoCooldown
+@NoCost
+@RegisterCommand({"removewarning", "deletewarning", "delwarn"})
+public class RemoveWarningCommand extends CommandBase<CommandSource> {
+
+    @Inject
+    private WarnHandler handler;
+    private final String warningKey = "warning";
+
+    @Override
+    public CommandElement[] getArguments() {
+        return new CommandElement[] {GenericArguments.onlyOne(new WarningArgument(Text.of(warningKey), plugin, handler))};
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        WarningArgument.Result result = args.<WarningArgument.Result>getOne(warningKey).get();
+        User user = result.user;
+
+        List<WarnData> warnings = handler.getWarnings(user);
+        if (warnings.isEmpty()) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.checkwarnings.none", user.getName()));
+            return CommandResult.success();
+        }
+
+        if (handler.removeWarning(user, result.warnData)) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.removewarning.success", user.getName()));
+            return CommandResult.success();
+        }
+
+        src.sendMessage(Util.getTextMessageWithFormat("command.removewarning.failure", user.getName()));
+        return CommandResult.empty();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
@@ -89,10 +89,8 @@ public class WarnCommand extends CommandBase<CommandSource> {
         } else if (optDuration.get() > wca.getNodeOrDefault().getMaximumWarnLength() &&  wca.getNodeOrDefault().getMaximumWarnLength() != -1) {
             src.sendMessage(Util.getTextMessageWithFormat("command.warn.length.toolong", Util.getTimeStringFromSeconds(wca.getNodeOrDefault().getMaximumWarnLength())));
             return CommandResult.success();
-        }
-
         //Check if too short
-        if (optDuration.get() < wca.getNodeOrDefault().getMinimumWarnLength() &&  wca.getNodeOrDefault().getMinimumWarnLength() != -1){
+        } else if (optDuration.get() < wca.getNodeOrDefault().getMinimumWarnLength() &&  wca.getNodeOrDefault().getMinimumWarnLength() != -1){
             src.sendMessage(Util.getTextMessageWithFormat("command.warn.length.tooshort", Util.getTimeStringFromSeconds(wca.getNodeOrDefault().getMinimumWarnLength())));
             return CommandResult.success();
         }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
@@ -85,16 +85,14 @@ public class WarnCommand extends CommandBase<CommandSource> {
 
             if (optDuration.isPresent()) {
                 String time= Util.getTimeStringFromSeconds(optDuration.get());
-                messageChannel.send(Util.getTextMessageWithFormat("command.warn.success.time", user.getName(), src.getName(), time));
-                messageChannel.send(Util.getTextMessageWithFormat("standard.reason", warnData.getReason()));
+                messageChannel.send(Util.getTextMessageWithFormat("command.warn.success.time", user.getName(), src.getName(), time, warnData.getReason()));
 
                 if (user.isOnline()) {
                     user.getPlayer().get().sendMessage(Util.getTextMessageWithFormat("warn.playernotify.time", warnData.getReason(), time));
                 }
             } else {
                 String time= Util.getTimeStringFromSeconds(optDuration.get());
-                messageChannel.send(Util.getTextMessageWithFormat("command.warn.success.time", user.getName(), src.getName(), time));
-                messageChannel.send(Util.getTextMessageWithFormat("standard.reason", warnData.getReason()));
+                messageChannel.send(Util.getTextMessageWithFormat("command.warn.success.time", user.getName(), src.getName(), time, warnData.getReason()));
 
                 if (user.isOnline()) {
                     user.getPlayer().get().sendMessage(Util.getTextMessageWithFormat("mute.playernotify.standard", warnData.getReason()));

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
@@ -153,7 +153,7 @@ public class WarnCommand extends CommandBase<CommandSource> {
                 warnHandler.clearWarnings(user, false, false);
 
                 //Get and run the action command
-                String command = chatUtil.getPlayerMessageFromTemplate(wca.getNodeOrDefault().getActionCommand(), src, true).toPlain();
+                String command = wca.getNodeOrDefault().getActionCommand().replaceAll("\\{\\{name\\}\\}", user.getName());
                 Sponge.getCommandManager().process(Sponge.getServer().getConsole(), command);
                 return CommandResult.success();
             }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
@@ -68,6 +68,11 @@ public class WarnCommand extends CommandBase<CommandSource> {
         Optional<Long> optDuration = args.getOne(durationKey);
         String reason = args.<String>getOne(reasonKey).get();
 
+        //Set default duration if no duration given
+        if (wca.getNodeOrDefault().getDefaultLength() != -1 && !optDuration.isPresent()) {
+            optDuration = Optional.of(wca.getNodeOrDefault().getDefaultLength());
+        }
+
         UUID warner = Util.consoleFakeUUID;
         if (src instanceof Player) {
             warner = ((Player) src).getUniqueId();
@@ -101,7 +106,7 @@ public class WarnCommand extends CommandBase<CommandSource> {
 
             if (optDuration.isPresent()) {
                 String time= Util.getTimeStringFromSeconds(optDuration.get());
-                messageChannel.send(Util.getTextMessageWithFormat("command.warn.success.time", user.getName(), src.getName(), time, warnData.getReason()));
+                messageChannel.send(Util.getTextMessageWithFormat("command.warn.success.time", user.getName(), src.getName(), warnData.getReason(), time));
 
                 if (user.isOnline()) {
                     user.getPlayer().get().sendMessage(Util.getTextMessageWithFormat("warn.playernotify.time", warnData.getReason(), time));

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
@@ -48,12 +48,9 @@ public class WarnCommand extends CommandBase<CommandSource> {
     private final String durationKey = "duration";
     private final String reasonKey = "reason";
 
-    @Inject
-    private WarnHandler warnHandler;
-    @Inject
-    private WarnConfigAdapter wca;
-    @Inject
-    private ChatUtil chatUtil;
+    @Inject private WarnHandler warnHandler;
+    @Inject private WarnConfigAdapter wca;
+    @Inject private ChatUtil chatUtil;
 
     @Override
     public Map<String, PermissionInformation> permissionSuffixesToRegister() {

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
@@ -29,6 +29,7 @@ import org.spongepowered.api.text.channel.MessageChannel;
 import org.spongepowered.api.text.channel.MutableMessageChannel;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -99,9 +100,9 @@ public class WarnCommand extends CommandBase<CommandSource> {
 
         WarnData warnData;
         if (optDuration.isPresent()) {
-            warnData = new WarnData(warner, reason, Duration.ofSeconds(optDuration.get()));
+            warnData = new WarnData(Instant.now(), warner, reason, Duration.ofSeconds(optDuration.get()));
         } else {
-            warnData = new WarnData(warner, reason);
+            warnData = new WarnData(Instant.now(), warner, reason);
         }
 
         //Check if too long (No duration provided, it is infinite)

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
@@ -35,7 +35,7 @@ import java.util.UUID;
 @NoWarmup
 @NoCooldown
 @NoCost
-@RegisterCommand({"warn", "warning", "warnings"})
+@RegisterCommand({"warn", "warning"})
 public class WarnCommand extends CommandBase<CommandSource> {
 
     public static final String notifyPermission = PermissionRegistry.PERMISSIONS_PREFIX + "warn.notify";

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
@@ -94,7 +94,7 @@ public class WarnCommand extends CommandBase<CommandSource> {
                 messageChannel.send(Util.getTextMessageWithFormat("command.warn.success.norm", user.getName(), src.getName(), warnData.getReason()));
 
                 if (user.isOnline()) {
-                    user.getPlayer().get().sendMessage(Util.getTextMessageWithFormat("mute.playernotify.standard", warnData.getReason()));
+                    user.getPlayer().get().sendMessage(Util.getTextMessageWithFormat("warn.playernotify.standard", warnData.getReason()));
                 }
             }
             return CommandResult.success();

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
@@ -91,8 +91,7 @@ public class WarnCommand extends CommandBase<CommandSource> {
                     user.getPlayer().get().sendMessage(Util.getTextMessageWithFormat("warn.playernotify.time", warnData.getReason(), time));
                 }
             } else {
-                String time= Util.getTimeStringFromSeconds(optDuration.get());
-                messageChannel.send(Util.getTextMessageWithFormat("command.warn.success.time", user.getName(), src.getName(), time, warnData.getReason()));
+                messageChannel.send(Util.getTextMessageWithFormat("command.warn.success.norm", user.getName(), src.getName(), warnData.getReason()));
 
                 if (user.isOnline()) {
                     user.getPlayer().get().sendMessage(Util.getTextMessageWithFormat("mute.playernotify.standard", warnData.getReason()));

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
@@ -36,7 +36,7 @@ import java.util.UUID;
 @NoWarmup
 @NoCooldown
 @NoCost
-@RegisterCommand({"warn", "warning"})
+@RegisterCommand({"warn", "warning", "addwarning"})
 public class WarnCommand extends CommandBase<CommandSource> {
 
     public static final String notifyPermission = PermissionRegistry.PERMISSIONS_PREFIX + "warn.notify";

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
@@ -57,16 +57,15 @@ public class WarnCommand extends CommandBase<CommandSource> {
     public CommandElement[] getArguments() {
         return new CommandElement[] {GenericArguments.onlyOne(GenericArguments.user(Text.of(playerKey))),
                 GenericArguments.onlyOne(GenericArguments.optionalWeak(new TimespanArgument(Text.of(durationKey)))),
-                GenericArguments.optional(GenericArguments.onlyOne(GenericArguments.remainingJoinedStrings(Text.of(reasonKey))))};
+                GenericArguments.onlyOne(GenericArguments.onlyOne(GenericArguments.remainingJoinedStrings(Text.of(reasonKey))))};
     }
 
     @Override
     public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
         User user = args.<User>getOne(playerKey).get();
         Optional<Long> optDuration = args.getOne(durationKey);
-        Optional<String> optReason = args.getOne(reasonKey);
+        String reason = args.<String>getOne(reasonKey).get();
 
-        String reason = optReason.orElse(Util.getMessageWithFormat("command.warn.defaultreason"));
         UUID warner = Util.consoleFakeUUID;
         if (src instanceof Player) {
             warner = ((Player) src).getUniqueId();

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/commands/WarnCommand.java
@@ -1,0 +1,109 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.warn.commands;
+
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.api.data.WarnData;
+import io.github.nucleuspowered.nucleus.argumentparsers.TimespanArgument;
+import io.github.nucleuspowered.nucleus.internal.PermissionRegistry;
+import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
+import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
+import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import io.github.nucleuspowered.nucleus.modules.warn.handlers.WarnHandler;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.channel.MessageChannel;
+import org.spongepowered.api.text.channel.MutableMessageChannel;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@Permissions(suggestedLevel = SuggestedLevel.MOD)
+@NoWarmup
+@NoCooldown
+@NoCost
+@RegisterCommand({"warn", "warning", "warnings"})
+public class WarnCommand extends CommandBase<CommandSource> {
+
+    public static final String notifyPermission = PermissionRegistry.PERMISSIONS_PREFIX + "warn.notify";
+
+    private final String playerKey = "player";
+    private final String durationKey = "duration";
+    private final String reasonKey = "reason";
+
+    @Inject private WarnHandler warnHandler;
+
+    @Override
+    public Map<String, PermissionInformation> permissionsToRegister() {
+        Map<String, PermissionInformation> m = new HashMap<>();
+        m.put(notifyPermission, new PermissionInformation(Util.getMessageWithFormat("permission.warn.notify"), SuggestedLevel.MOD));
+        return m;
+    }
+
+    @Override
+    public CommandElement[] getArguments() {
+        return new CommandElement[] {GenericArguments.onlyOne(GenericArguments.user(Text.of(playerKey))),
+                GenericArguments.onlyOne(GenericArguments.optionalWeak(new TimespanArgument(Text.of(durationKey)))),
+                GenericArguments.optional(GenericArguments.onlyOne(GenericArguments.remainingJoinedStrings(Text.of(reasonKey))))};
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        User user = args.<User>getOne(playerKey).get();
+        Optional<Long> optDuration = args.getOne(durationKey);
+        Optional<String> optReason = args.getOne(reasonKey);
+
+        String reason = optReason.orElse(Util.getMessageWithFormat("command.warn.defaultreason"));
+        UUID warner = Util.consoleFakeUUID;
+        if (src instanceof Player) {
+            warner = ((Player) src).getUniqueId();
+        }
+
+        WarnData warnData;
+        if (optDuration.isPresent()) {
+            warnData = new WarnData(warner, reason, Duration.ofSeconds(optDuration.get()));
+        } else {
+            warnData = new WarnData(warner, reason);
+        }
+
+        if (warnHandler.addWarning(user, warnData)) {
+            MutableMessageChannel messageChannel = MessageChannel.permission(notifyPermission).asMutable();
+            messageChannel.addMember(src);
+
+            if (optDuration.isPresent()) {
+                String time= Util.getTimeStringFromSeconds(optDuration.get());
+                messageChannel.send(Util.getTextMessageWithFormat("command.warn.success.time", user.getName(), src.getName(), time));
+                messageChannel.send(Util.getTextMessageWithFormat("standard.reason", warnData.getReason()));
+
+                if (user.isOnline()) {
+                    user.getPlayer().get().sendMessage(Util.getTextMessageWithFormat("warn.playernotify.time", warnData.getReason(), time));
+                }
+            } else {
+                String time= Util.getTimeStringFromSeconds(optDuration.get());
+                messageChannel.send(Util.getTextMessageWithFormat("command.warn.success.time", user.getName(), src.getName(), time));
+                messageChannel.send(Util.getTextMessageWithFormat("standard.reason", warnData.getReason()));
+
+                if (user.isOnline()) {
+                    user.getPlayer().get().sendMessage(Util.getTextMessageWithFormat("mute.playernotify.standard", warnData.getReason()));
+                }
+            }
+            return CommandResult.success();
+        }
+
+        src.sendMessage(Util.getTextMessageWithFormat("command.warn.fail", user.getName()));
+        return CommandResult.empty();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/config/WarnConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/config/WarnConfig.java
@@ -13,6 +13,9 @@ public class WarnConfig {
     @Setting(value = "show-login", comment = "loc:config.warn.showonlogin")
     private boolean showOnLogin = true;
 
+    @Setting(value = "expire-warnings", comment = "loc:config.warn.expire")
+    private boolean expireWarnings = true;
+
     @Setting(value = "minimum-warn-length", comment = "loc:config.warn.minwarnlength")
     private long minWarnLength = -1;
 
@@ -21,6 +24,10 @@ public class WarnConfig {
 
     public boolean isShowOnLogin() {
         return showOnLogin;
+    }
+
+    public boolean isExpireWarnings() {
+        return expireWarnings;
     }
 
     public long getMinimumWarnLength() {

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/config/WarnConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/config/WarnConfig.java
@@ -13,7 +13,21 @@ public class WarnConfig {
     @Setting(value = "show-login", comment = "loc:config.warn.showonlogin")
     private boolean showOnLogin = true;
 
+    @Setting(value = "minimum-warn-length", comment = "loc:config.warn.minwarnlength")
+    private long minWarnLength = -1;
+
+    @Setting(value = "maximum-warn-length", comment = "loc:config.warn.maxwarnlength")
+    private long maxWarnLength = -1;
+
     public boolean isShowOnLogin() {
         return showOnLogin;
+    }
+
+    public long getMinimumWarnLength() {
+        return minWarnLength;
+    }
+
+    public long getMaximumWarnLength() {
+        return maxWarnLength;
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/config/WarnConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/config/WarnConfig.java
@@ -22,6 +22,9 @@ public class WarnConfig {
     @Setting(value = "maximum-warn-length", comment = "loc:config.warn.maxwarnlength")
     private long maxWarnLength = -1;
 
+    @Setting(value = "default-length", comment = "loc:config.warn.defaultlength")
+    private long defaultLength = -1;
+
     public boolean isShowOnLogin() {
         return showOnLogin;
     }
@@ -36,5 +39,9 @@ public class WarnConfig {
 
     public long getMaximumWarnLength() {
         return maxWarnLength;
+    }
+
+    public long getDefaultLength() {
+        return defaultLength;
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/config/WarnConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/config/WarnConfig.java
@@ -25,6 +25,12 @@ public class WarnConfig {
     @Setting(value = "default-length", comment = "loc:config.warn.defaultlength")
     private long defaultLength = -1;
 
+    @Setting(value = "warnings-before-action", comment = "loc:config.warn.warningsbeforeaction")
+    private int warningsBeforeAction = -1;
+
+    @Setting(value = "action-command", comment = "loc:config.warn.actioncommand")
+    private String actionCommand = "tempban {{name}} 1d Exceeding the active warning threshold";
+
     public boolean isShowOnLogin() {
         return showOnLogin;
     }
@@ -43,5 +49,13 @@ public class WarnConfig {
 
     public long getDefaultLength() {
         return defaultLength;
+    }
+
+    public int getWarningsBeforeAction() {
+        return warningsBeforeAction;
+    }
+
+    public String getActionCommand() {
+        return actionCommand;
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/config/WarnConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/config/WarnConfig.java
@@ -1,0 +1,19 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.warn.config;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+@ConfigSerializable
+public class WarnConfig {
+
+    @Setting(value = "show-login", comment = "loc:config.warn.showonlogin")
+    private boolean showOnLogin = true;
+
+    public boolean isShowOnLogin() {
+        return showOnLogin;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/config/WarnConfigAdapter.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/config/WarnConfigAdapter.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.warn.config;
+
+import com.google.common.reflect.TypeToken;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.commented.SimpleCommentedConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+
+public class WarnConfigAdapter extends NucleusConfigAdapter<WarnConfig> {
+    @Override
+    protected WarnConfig getDefaultObject() {
+        return new WarnConfig();
+    }
+
+    @Override
+    protected WarnConfig convertFromConfigurateNode(ConfigurationNode node) throws ObjectMappingException {
+        return node.getValue(TypeToken.of(WarnConfig.class), new WarnConfig());
+    }
+
+    @Override
+    protected ConfigurationNode insertIntoConfigurateNode(WarnConfig data) throws ObjectMappingException {
+        return SimpleCommentedConfigurationNode.root().setValue(TypeToken.of(WarnConfig.class), data);
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/handlers/WarnHandler.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/handlers/WarnHandler.java
@@ -75,4 +75,21 @@ public class WarnHandler implements NucleusWarnService {
 
         return false;
     }
+
+    @Override
+    public boolean updateWarnings(User user) {
+        Optional<UserService> userService = userDataManager.get(user);
+        if (!userService.isPresent()) {
+            return false;
+        }
+
+        for (WarnData warning : getWarnings(user)) {
+            warning.nextLoginToTimestamp();
+
+            if (warning.getEndTimestamp().isPresent() && warning.getEndTimestamp().get().isBefore(Instant.now())) {
+                removeWarning(user, warning);
+            }
+        }
+        return true;
+    }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/handlers/WarnHandler.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/handlers/WarnHandler.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.warn.handlers;
+
+import com.google.common.base.Preconditions;
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Nucleus;
+import io.github.nucleuspowered.nucleus.api.data.WarnData;
+import io.github.nucleuspowered.nucleus.api.service.NucleusWarnService;
+import io.github.nucleuspowered.nucleus.dataservices.UserService;
+import io.github.nucleuspowered.nucleus.dataservices.loaders.UserDataManager;
+import org.spongepowered.api.entity.living.player.User;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+public class WarnHandler implements NucleusWarnService {
+
+    private final Nucleus nucleus;
+    @Inject private UserDataManager userDataManager;
+
+    public WarnHandler(Nucleus nucleus) {
+        this.nucleus = nucleus;
+    }
+
+    @Override
+    public List<WarnData> getWarnings(User user) {
+        Optional<UserService> userService = userDataManager.get(user);
+        if (userService.isPresent()) {
+            return userService.get().getWarnings();
+        }
+        return null;
+    }
+
+    @Override
+    public boolean addWarning(User user, WarnData warning) {
+        Preconditions.checkNotNull(user);
+        Preconditions.checkNotNull(warning);
+
+        Optional<UserService> optUserService = userDataManager.get(user);
+        if (!optUserService.isPresent()) {
+            return false;
+        }
+
+        UserService userService = optUserService.get();
+        if (user.isOnline() && warning.getTimeFromNextLogin().isPresent() && !warning.getEndTimestamp().isPresent()) {
+            warning = new WarnData(warning.getWarner(), warning.getReason(), Instant.now().plus(warning.getTimeFromNextLogin().get()));
+        }
+
+        userService.addWarning(warning);
+        return true;
+    }
+
+    @Override
+    public boolean removeWarning(User user, WarnData warning) {
+        Optional<UserService> userService = userDataManager.get(user);
+        if (userService.isPresent()) {
+            userService.get().removeWarning(warning);
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean clearWarnings(User user) {
+        Optional<UserService> userService = userDataManager.get(user);
+        if (userService.isPresent()) {
+            userService.get().clearWarnings();
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/handlers/WarnHandler.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/handlers/WarnHandler.java
@@ -63,7 +63,7 @@ public class WarnHandler implements NucleusWarnService {
 
         UserService userService = optUserService.get();
         if (user.isOnline() && warning.getTimeFromNextLogin().isPresent() && !warning.getEndTimestamp().isPresent()) {
-            warning = new WarnData(warning.getWarner(), warning.getReason(), Instant.now().plus(warning.getTimeFromNextLogin().get()));
+            warning = new WarnData(Instant.now(), warning.getWarner(), warning.getReason(), Instant.now().plus(warning.getTimeFromNextLogin().get()));
         }
 
         userService.addWarning(warning);
@@ -81,7 +81,7 @@ public class WarnHandler implements NucleusWarnService {
         if (userService.isPresent()) {
             userService.get().removeWarning(warning);
             if (wca.getNodeOrDefault().isExpireWarnings() && !warning.isExpired() && !permanent) {
-                userService.get().addWarning(new WarnData(warning.getWarner(), warning.getReason(), true));
+                userService.get().addWarning(new WarnData(warning.getDate(), warning.getWarner(), warning.getReason(), true));
             }
             return true;
         }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/listeners/WarnListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/listeners/WarnListener.java
@@ -37,6 +37,9 @@ public class WarnListener extends ListenerBase {
             List<WarnData> warnings = handler.getWarnings(player);
             if (warnings != null) {
                 for (WarnData warning : warnings) {
+                    if (warning.isExpired()) {
+                        return;
+                    }
                     warning.nextLoginToTimestamp();
 
                     if (warning.getEndTimestamp().isPresent() && warning.getEndTimestamp().get().isBefore(Instant.now())) {

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/listeners/WarnListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/listeners/WarnListener.java
@@ -8,6 +8,7 @@ import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.WarnData;
 import io.github.nucleuspowered.nucleus.internal.ListenerBase;
+import io.github.nucleuspowered.nucleus.modules.warn.config.WarnConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.warn.handlers.WarnHandler;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.Player;
@@ -21,8 +22,8 @@ import java.util.concurrent.TimeUnit;
 
 public class WarnListener extends ListenerBase {
 
-    @Inject
-    private WarnHandler handler;
+    @Inject private WarnHandler handler;
+    @Inject private WarnConfigAdapter wca;
 
     /**
      * At the time the player joins, check to see if the player has been warned.
@@ -41,11 +42,13 @@ public class WarnListener extends ListenerBase {
                     if (warning.getEndTimestamp().isPresent() && warning.getEndTimestamp().get().isBefore(Instant.now())) {
                         handler.removeWarning(player, warning);
                     } else {
-                        if (warning.getEndTimestamp().isPresent()) {
-                            player.sendMessage(Util.getTextMessageWithFormat("warn.playernotify.time", warning.getReason(),
-                                    Util.getTimeStringFromSeconds(Instant.now().until(warning.getEndTimestamp().get(), ChronoUnit.SECONDS))));
-                        } else {
-                            player.sendMessage(Util.getTextMessageWithFormat("warn.playernotify.standard", warning.getReason()));
+                        if (wca.getNodeOrDefault().isShowOnLogin()) {
+                            if (warning.getEndTimestamp().isPresent()) {
+                                player.sendMessage(Util.getTextMessageWithFormat("warn.playernotify.time", warning.getReason(),
+                                        Util.getTimeStringFromSeconds(Instant.now().until(warning.getEndTimestamp().get(), ChronoUnit.SECONDS))));
+                            } else {
+                                player.sendMessage(Util.getTextMessageWithFormat("warn.playernotify.standard", warning.getReason()));
+                            }
                         }
                     }
                 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/listeners/WarnListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/listeners/WarnListener.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.warn.listeners;
+
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.api.data.WarnData;
+import io.github.nucleuspowered.nucleus.internal.ListenerBase;
+import io.github.nucleuspowered.nucleus.modules.warn.handlers.WarnHandler;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.network.ClientConnectionEvent;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class WarnListener extends ListenerBase {
+
+    @Inject
+    private WarnHandler handler;
+
+    /**
+     * At the time the player joins, check to see if the player has been warned.
+     *
+     * @param event The event.
+     */
+    @Listener
+    public void onPlayerLogin(final ClientConnectionEvent.Join event) {
+        Sponge.getScheduler().createTaskBuilder().async().delay(500, TimeUnit.MILLISECONDS).execute(() -> {
+            Player player = event.getTargetEntity();
+            List<WarnData> warnings = handler.getWarnings(player);
+            if (warnings != null) {
+                for (WarnData warning : warnings) {
+                    warning.nextLoginToTimestamp();
+
+                    if (warning.getEndTimestamp().isPresent() && warning.getEndTimestamp().get().isBefore(Instant.now())) {
+                        handler.removeWarning(player, warning);
+                    } else {
+                        if (warning.getEndTimestamp().isPresent()) {
+                            player.sendMessage(Util.getTextMessageWithFormat("warn.playernotify.time", warning.getReason(),
+                                    Util.getTimeStringFromSeconds(Instant.now().until(warning.getEndTimestamp().get(), ChronoUnit.SECONDS))));
+                        } else {
+                            player.sendMessage(Util.getTextMessageWithFormat("warn.playernotify.standard", warning.getReason()));
+                        }
+                    }
+                }
+            }
+        }).submit(plugin);
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/listeners/WarnListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/listeners/WarnListener.java
@@ -38,7 +38,7 @@ public class WarnListener extends ListenerBase {
             if (warnings != null) {
                 for (WarnData warning : warnings) {
                     if (warning.isExpired()) {
-                        return;
+                        continue;
                     }
                     warning.nextLoginToTimestamp();
 

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -295,6 +295,7 @@ command.mute.success.norm=&e{0} &ahas been muted by &e{1}.
 command.mute.defaultreason=&eYou have been muted!
 command.mute.fail=&cUnable to mute &e{0}&c.
 command.mute.length.toolong=&cThe duration for that mute is too long! The maximum duration is &4{0}.
+command.mute.exempt=&cThe user &4{0} &cis exempt from being muted.
 command.unmute.success=&e{0} &ahas been unmuted by &e{1}.
 
 command.warn.success.time=&e{0} &ahas been warned by &e{1} &afor reason &e{2}&a, the warning will expire in &e{3}.
@@ -926,7 +927,8 @@ permission.homes.unlimited=Allows the user to have an unlimited number of homes.
 permission.sudo.exempt=Exempts the user from being a target of the /sudo command.
 
 permission.warn.exempt.target=Exempts the user from being a target of the /warn command.
-permission.warn.exempt.length=Exempts the user from being restricted by the minimum and maximum durations for the /warn command.
+permission.warn.exempt.length=Allows the user to bypass the maximum and minimum warning lengths.
+permission.mute.exempt.target=Exempts the user from being a target of the /mute command.
 permission.mute.exempt.length=Allows the user to bypass the maximum mute length.
 permission.tempban.exempt.target=Exempts the user from being a target of the /tempban command.
 permission.tempban.exempt.length=Allows the user to bypass the maximum tempban length.

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -195,6 +195,13 @@ args.warning.noindex=&cSpecify the warning index, check the index in &4/warnings
 args.warning.nouserwarnings=&cThe user &4{0} &cdoes not have any warnings.
 args.warning.indexnotnumber=&cThe warning index must be a number.
 
+args.note.nouserarg=&cA user to remove notes from must be specified.
+args.note.nouser=&cThe user &4{0} &cdoes not exist.
+args.note.nonotedata=&cThe note &4{0} &cdoes not exist, check again in &4/notes {1}.
+args.note.noindex=&cSpecify the note index, check the index in &4/notes {0}.
+args.note.nousernotes=&cThe user &4{0} &cdoes not have any notes.
+args.note.indexnotnumber=&cThe note index must be a number.
+
 args.playerconsole.noexist=&cThat player does not exist. Use "-" for the console.
 
 args.warps.noexist=&cThat warp does not exist.
@@ -302,8 +309,14 @@ command.checknotes.note=&e{0}. &a{1}, added by &e{2}
 command.clearwarnings.success=&aWarnings for &e{0} &ahave been cleared.
 command.clearwarnings.failure=&aWarnings for &e{0} &acould not be cleared.
 
+command.clearnotes.success=&aNotes for &e{0} &ahave been cleared.
+command.clearnotes.failure=&aNotes for &e{0} &acould not be cleared.
+
 command.removewarning.success=&aWarning for &e{0} &ahas been cleared.
 command.removewarning.failure=&aWarning for &e{0} &acould not be cleared.
+
+command.removenote.success=&aNote for &e{0} &ahas been cleared.
+command.removenote.failure=&aNote for &e{0} &acould not be cleared.
 
 command.warps.start=&aWarping to &e{0}&a.
 command.warps.nosafe=&cCould not warp to a safe location nearby. To force a warp, use the "-f" flag.

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -266,7 +266,6 @@ command.unmute.success=&e{0} &ahas been unmuted by &e{1}.
 
 command.warn.success.time=&e{0} &ahas been warned by &e{1} &afor reason &e{2}&a, the warning will expire in &e{3}.
 command.warn.success.norm=&e{0} &ahas been warned by &e{1} &afor reason &e{2}.
-command.warn.defaultreason=&eYou have been warned!
 command.warn.fail=&cUnable to warn &e{0}&c.
 
 command.kick.defaultreason=&eYou have been kicked!

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -943,6 +943,8 @@ permission.spawn.exempt.login=If granted, and the configuration is set to send p
 
 permission.vanish.other=If granted, grants ability to vanish other players.
 
+permission.connection.joinfullserver=Allows the user to join the server even if full.
+
 # Command descriptions.
 description.time.desc=Gets the time for the specified world.
 description.time.set.desc=Sets the time for the specified world.

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -280,6 +280,9 @@ command.checkmute.mute=&e{0} &awas muted by &e{1}&a{2}&e{3}.
 command.checkwarnings.none=&e{0} &ahas no warnings.
 command.checkwarnings.warn=&a{0}. &e{1} &awas warned by &e{2} &afor &e{3} &afor reason &e{4}.
 
+command.clearwarnings.success=&e{0}'s &awarnings cleared successfully.
+command.clearwarnings.failure=&e{0}'s &awarnings could not be cleared.
+
 command.warps.start=&aWarping to &e{0}&a.
 command.warps.nosafe=&cCould not warp to a safe location nearby. To force a warp, use the "-f" flag.
 command.warps.invalidname=&cWarps can only be alphanumeric, and must begin with a letter.

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -11,9 +11,9 @@ standard.hours=hours
 standard.days=days
 
 standard.inamoment=moment
-standard.restoftime=the rest of time
+standard.restoftime=The rest of time
 
-standard.for= for
+standard.for=for
 standard.reason=Reason: {0}
 
 standard.accept=Accept
@@ -48,6 +48,12 @@ standard.muted=muted
 
 standard.time.am={0}:{2} am ({1}:{2}h)
 standard.time.pm={0}:{2} pm ({1}:{2}h)
+
+standard.action.delete=[Delete]
+standard.action.expire=[Expire]
+standard.action.return=[Return]
+
+standard.status.expired=(Expired)
 
 nucleus.module.disabled.forceload=The plugin {0} ({1}) has requested that the module {2} be disabled, but it''s set to force load, so it''s being loaded anyway.
 nucleus.module.disabled.forceloadtwo=Be aware: this might cause conflicts with the {0} and so things might not work perfectly.
@@ -310,13 +316,23 @@ command.checkmute.none=&e{0} &ais not muted.
 command.checkmute.mute=&e{0} &awas muted by &e{1}&a{2}&e{3}.
 
 command.checkwarnings.none=&e{0} &ahas no warnings.
-command.checkwarnings.warn=&a{0}. &e{1} &awas warned by &e{2} &afor &e{3} &afor reason &e{4}.
-command.checkwarnings.expired=&a{0}. &e{1} &awas warned by &e{2} &afor reason &e{3}, &athis warning has expired.
-command.checkwarnings.header=''s warnings
+command.checkwarnings.info=&2Click on the warner''s name for more information about a warning!
+command.checkwarnings.hover.check=&aClick here to view more details about this warning.
+command.checkwarnings.hover.delete=&cClick here to delete this warning.
+command.checkwarnings.hover.expire=&eClick here to expire this warning.
+command.checkwarnings.hover.return=&aClick here to return to this users list of warnings.
+command.checkwarnings.id=&6ID: &e{0}
+command.checkwarnings.date=&6Date: &e{0}
+command.checkwarnings.remaining=&6Time remaining: &e{0}
+command.checkwarnings.warner=&6Warner: &e{0}
+command.checkwarnings.warning=&6Warning: &e{0}
+command.checkwarnings.action=&6Action
+
+command.checkwarnings.header={0}''s warnings
 
 command.checknotes.none=&e{0} &ahas no notes.
 command.checknotes.note=&e{0}. &a{1}, added by &e{2}
-command.checknotes.header=''s notes
+command.checknotes.header={0}''s notes
 
 command.clearwarnings.all=&aAll warnings for &e{0} &ahave been cleared.
 command.clearwarnings.expired=&aAll expired warnings for &e{0} &ahave been cleared.
@@ -327,7 +343,9 @@ command.clearwarnings.failure=&aWarnings for &e{0} &acould not be cleared.
 command.clearnotes.success=&aNotes for &e{0} &ahave been cleared.
 command.clearnotes.failure=&aNotes for &e{0} &acould not be cleared.
 
-command.removewarning.success=&aWarning for &e{0} &ahas been cleared.
+command.removewarning.success=&aWarning for &e{0} &ahas been cleared successfully.
+command.removewarning.remove=&aWarning for &e{0} &ahas been removed successfully.
+command.removewarning.expire=&aWarning for &e{0} &ahas been expired successfully.
 command.removewarning.failure=&aWarning for &e{0} &acould not be cleared.
 
 command.removenote.success=&aNote for &e{0} &ahas been cleared.

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -168,6 +168,7 @@ config.warn.showonlogin=If true, players will be shown all their warnings when t
 config.warn.expire=If true, a record of players warnings will be kept as 'expired warnings'. If false, they will not.
 config.warn.minwarnlength=The minimum length a warning will last before expiring (In seconds), set to -1 for no minimum.
 config.warn.maxwarnlength=The maximum length a warning may last for (In seconds), set to -1 for no maximum.
+config.warn.defaultlength=The default length a warning is set to if no length is provided (In seconds), set to -1 for no maximum.
 
 config.note.showonlogin=If true, users with the permission nucleus.note.showonlogin will be shown a users notes when they login. If false, they will not.
 

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -439,6 +439,7 @@ command.feed.error=&cThe feeding could not be completed.
 command.jail.unjail.success=&e{0} &ahas been unjailed.
 command.jail.unjail.fail=&cCould not unjail &e{0}&c.
 
+command.jail.offline.noperms=&cYou do not have permission to jail offline players.
 command.jail.jail.nojail=&cYou must specify a jail!
 command.jail.reason=You have been jailed!
 
@@ -520,7 +521,9 @@ command.seen.loggedoff=&bLast online:&f
 command.ban.alreadyset=&e{0} &chas already been banned.
 command.ban.applied=&e{0} &awas banned by &e{1}&a.
 command.ban.profileerror=&cUnable to get the profile for {0} from Mojang.
+command.ban.offline.noperms=&cYou do not have permission to ban offline players.
 command.tempban.applied=&e{0} &awas banned temporarily for &e{1}&a by &e{2}&a.
+command.tempban.offline.noperms=&cYou do not have permission to tempban offline players.
 command.checkban.notset=&e{0} &ais not banned.
 command.checkban.banned=&e{0} &awas banned by &e{1}&a{2}&e{3}&a.
 command.unban.success=&e{0} &awas unbanned by &e{1}.
@@ -843,6 +846,10 @@ permission.jail.notify=Notifies the user about jails when they occur.
 permission.kick.notify=Notifies the user about kicks when they occur.
 permission.warn.notify=Notifies the user about warnings when they occur.
 permission.note.notify=Notifies the user about notes when they occur.
+
+permission.tempban.offline=Allows the user to temp ban offline users.
+permission.ban.offline=Allows the user to ban offline users.
+permission.jail.offline=Allows the user to jail offline users.
 
 permission.nick.others=Allows the user to change other''s nicknames.
 permission.nick.colour=Allows the user to colour their nickname.

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -296,6 +296,9 @@ command.checkmute.mute=&e{0} &awas muted by &e{1}&a{2}&e{3}.
 command.checkwarnings.none=&e{0} &ahas no warnings.
 command.checkwarnings.warn=&a{0}. &e{1} &awas warned by &e{2} &afor &e{3} &afor reason &e{4}.
 
+command.checknotes.none=&e{0} &ahas no notes.
+command.checknotes.note=&e{0}. &a{1}, added by &e{2}
+
 command.clearwarnings.success=&aWarnings for &e{0} &ahave been cleared.
 command.clearwarnings.failure=&aWarnings for &e{0} &acould not be cleared.
 

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -165,6 +165,7 @@ config.commandlogger.list=A comma separated list of commands in the blacklist or
 config.mute.blocked=Commands to block when muted. This is in addition to chat and /m already being blocked.
 
 config.warn.showonlogin=If true, players will be shown all their warnings when they login. If false, they will not.
+config.warn.expire=If true, a record of players warnings will be kept as 'expired warnings'. If false, they will not.
 config.warn.minwarnlength=The minimum length a warning will last before expiring (In seconds), set to -1 for no minimum.
 config.warn.maxwarnlength=The maximum length a warning may last for (In seconds), set to -1 for no maximum.
 
@@ -302,6 +303,7 @@ command.checkmute.mute=&e{0} &awas muted by &e{1}&a{2}&e{3}.
 
 command.checkwarnings.none=&e{0} &ahas no warnings.
 command.checkwarnings.warn=&a{0}. &e{1} &awas warned by &e{2} &afor &e{3} &afor reason &e{4}.
+command.checkwarnings.expired=&a{0}. &e{1} &awas warned by &e{2} &afor reason &e{3}, &athis warning has expired.
 
 command.checknotes.none=&e{0} &ahas no notes.
 command.checknotes.note=&e{0}. &a{1}, added by &e{2}

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -11,6 +11,7 @@ standard.hours=hours
 standard.days=days
 
 standard.inamoment=moment
+standard.restoftime=the rest of time
 
 standard.for= for
 standard.reason=Reason: {0}

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -97,6 +97,8 @@ config.chat.template.suffix='Sets the suffix to a message. {{prefix}} - prefix (
 config.chat.default-template=The default chat template if no group templates apply.
 config.chat.group-templates=Group templates override the default chat template based on the users group. Note that the group name is case sensitive.
 
+config.connection.reservedslots=The maximum number of reserved slots that can be used, set to -1 for unlimited.
+
 config.afk.time=The amount of time, in seconds, of inactivity before the player will be marked as AFK. Set to 0 to disable, or use the permission "nucleus.afk.exempt.toggle".
 config.afk.timetokick=The amount of time, in seconds, of inactivity before the player will be kicked. Set to 0 to disable, or use the permission "nucleus.afk.exempt.kick".
 config.afk.whenvanished=If true, the server will announce when players go AFK, even when vanished. If false, only non-vanished players can go AFK.

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -183,6 +183,13 @@ args.home.nohome=&cThe home "{0}" does not exist.
 args.homeother.notenough=&cA player and a home must be specified.
 args.homeother.nouser=&cThe user {0} does not exist.
 
+args.warning.nouserarg=&cA user to remove warnings from must be specified.
+args.warning.nouser=&cThe user &4{0} &cdoes not exist.
+args.warning.nowarndata=&cThe warning &4{0} &cdoes not exist, check again in &4/warnings {1}.
+args.warning.noindex=&cSpecify the warning index, check the index in &4/warnings {0}.
+args.warning.nouserwarnings=&cThe user &4{0} &cdoes not have any warnings.
+args.warning.indexnotnumber=&cThe warning index must be a number.
+
 args.playerconsole.noexist=&cThat player does not exist. Use "-" for the console.
 
 args.warps.noexist=&cThat warp does not exist.
@@ -279,8 +286,11 @@ command.checkmute.mute=&e{0} &awas muted by &e{1}&a{2}&e{3}.
 command.checkwarnings.none=&e{0} &ahas no warnings.
 command.checkwarnings.warn=&a{0}. &e{1} &awas warned by &e{2} &afor &e{3} &afor reason &e{4}.
 
-command.clearwarnings.success=&e{0}'s &awarnings cleared successfully.
-command.clearwarnings.failure=&e{0}'s &awarnings could not be cleared.
+command.clearwarnings.success=&aWarnings for &e{0} &ahave been cleared.
+command.clearwarnings.failure=&aWarnings for &e{0} &acould not be cleared.
+
+command.removewarning.success=&aWarning for &e{0} &ahas been cleared.
+command.removewarning.failure=&aWarning for &e{0} &acould not be cleared.
 
 command.warps.start=&aWarping to &e{0}&a.
 command.warps.nosafe=&cCould not warp to a safe location nearby. To force a warp, use the "-f" flag.

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -264,8 +264,8 @@ command.mute.defaultreason=&eYou have been muted!
 command.mute.fail=&cUnable to mute &e{0}&c.
 command.unmute.success=&e{0} &ahas been unmuted by &e{1}.
 
-command.warn.success.time=&e{0} &ahas been warned by &e{1}&a, the warning will expire in &e{2}.
-command.warn.success.norm=&e{0} &ahas been warned by &e{1}.
+command.warn.success.time=&e{0} &ahas been warned by &e{1} &afor reason &e{2}&a, the warning will expire in &e{3}.
+command.warn.success.norm=&e{0} &ahas been warned by &e{1} &afor reason &e{2}.
 command.warn.defaultreason=&eYou have been warned!
 command.warn.fail=&cUnable to warn &e{0}&c.
 
@@ -278,7 +278,7 @@ command.checkmute.none=&e{0} &ais not muted.
 command.checkmute.mute=&e{0} &awas muted by &e{1}&a{2}&e{3}.
 
 command.checkwarnings.none=&e{0} &ahas no warnings.
-command.checkwarnings.warn=&a{0}. &e{1} &awas warned by &e{2}&a{3}&e{4}.
+command.checkwarnings.warn=&a{0}. &e{1} &awas warned by &e{2} &afor &e{3} &afor reason &e{4}.
 
 command.warps.start=&aWarping to &e{0}&a.
 command.warps.nosafe=&cCould not warp to a safe location nearby. To force a warp, use the "-f" flag.

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -169,7 +169,7 @@ config.tempban.maxtempbanlength=The maximum length a temporary ban may last for 
 
 config.warn.actioncommand=The command to execute when a player has a specific number of warnings.
 config.warn.showonlogin=If true, players will be shown all their warnings when they login. If false, they will not.
-config.warn.expire=If true, a record of players warnings will be kept as 'expired warnings'. If false, they will not.
+config.warn.expire=If true, a record of players warnings will be kept as ''expired warnings''. If false, they will not.
 config.warn.minwarnlength=The minimum length a warning will last before expiring (In seconds), set to -1 for no minimum.
 config.warn.maxwarnlength=The maximum length a warning may last for (In seconds), set to -1 for no maximum.
 config.warn.defaultlength=The default length a warning is set to if no length is provided (In seconds), set to -1 for no maximum.
@@ -312,9 +312,11 @@ command.checkmute.mute=&e{0} &awas muted by &e{1}&a{2}&e{3}.
 command.checkwarnings.none=&e{0} &ahas no warnings.
 command.checkwarnings.warn=&a{0}. &e{1} &awas warned by &e{2} &afor &e{3} &afor reason &e{4}.
 command.checkwarnings.expired=&a{0}. &e{1} &awas warned by &e{2} &afor reason &e{3}, &athis warning has expired.
+command.checkwarnings.header=''s warnings
 
 command.checknotes.none=&e{0} &ahas no notes.
 command.checknotes.note=&e{0}. &a{1}, added by &e{2}
+command.checknotes.header=''s notes
 
 command.clearwarnings.all=&aAll warnings for &e{0} &ahave been cleared.
 command.clearwarnings.expired=&aAll expired warnings for &e{0} &ahave been cleared.
@@ -554,6 +556,7 @@ command.ban.offline.noperms=&cYou do not have permission to ban offline players.
 command.tempban.applied=&e{0} &awas banned temporarily for &e{1}&a by &e{2}&a.
 command.tempban.offline.noperms=&cYou do not have permission to tempban offline players.
 command.tempban.length.toolong=&cThe duration for that tempban is too long! The maximum duration is &4{0}.
+command.tempban.exempt=&cThe user &4{0} &cis exempt from being temporarily banned.
 command.checkban.notset=&e{0} &ais not banned.
 command.checkban.banned=&e{0} &awas banned by &e{1}&a{2}&e{3}&a.
 command.unban.success=&e{0} &awas unbanned by &e{1}.
@@ -876,10 +879,6 @@ permission.kick.notify=Notifies the user about kicks when they occur.
 permission.warn.notify=Notifies the user about warnings when they occur.
 permission.note.notify=Notifies the user about notes when they occur.
 
-permission.mute.bypass=Allows the user to bypass the maximum mute length.
-permission.tempban.bypass=Allows the user to bypass the maximum tempban length.
-permission.warn.bypass=Allows the user to bypass the maximum warn length.
-
 permission.tempban.offline=Allows the user to temp ban offline users.
 permission.ban.offline=Allows the user to ban offline users.
 permission.jail.offline=Allows the user to jail offline users.
@@ -907,7 +906,12 @@ permission.others=Allows the user to target other players using the command "{0}
 permission.homes.unlimited=Allows the user to have an unlimited number of homes.
 
 permission.sudo.exempt=Exempts the user from being a target of the /sudo command.
-permission.warn.exempt=Exempts the user from being a target of the /warn command.
+
+permission.warn.exempt.target=Exempts the user from being a target of the /warn command.
+permission.warn.exempt.length=Exempts the user from being restricted by the minimum and maximum durations for the /warn command.
+permission.mute.exempt.length=Allows the user to bypass the maximum mute length.
+permission.tempban.exempt.target=Exempts the user from being a target of the /tempban command.
+permission.tempban.exempt.length=Allows the user to bypass the maximum tempban length.
 
 permission.kickall.whitelist=Allows the user to turn the whitelist on when kicking all players.
 

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -308,7 +308,10 @@ command.checkwarnings.expired=&a{0}. &e{1} &awas warned by &e{2} &afor reason &e
 command.checknotes.none=&e{0} &ahas no notes.
 command.checknotes.note=&e{0}. &a{1}, added by &e{2}
 
-command.clearwarnings.success=&aWarnings for &e{0} &ahave been cleared.
+command.clearwarnings.all=&aAll warnings for &e{0} &ahave been cleared.
+command.clearwarnings.expired=&aAll expired warnings for &e{0} &ahave been cleared.
+command.clearwarnings.remove=&aAll active warnings for &e{0} &ahave been cleared.
+command.clearwarnings.success=&aAll active warnings for &e{0} &ahave been expired.
 command.clearwarnings.failure=&aWarnings for &e{0} &acould not be cleared.
 
 command.clearnotes.success=&aNotes for &e{0} &ahave been cleared.

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -164,6 +164,9 @@ config.commandlogger.list=A comma separated list of commands in the blacklist or
 
 config.mute.blocked=Commands to block when muted. This is in addition to chat and /m already being blocked.
 
+config.mute.maxmutelength=The maximum length a mute may last for (In seconds) unless the user handing the mute has a bypass permission, set to -1 for no maximum.
+config.tempban.maxtempbanlength=The maximum length a temporary ban may last for (In seconds) unless the user handing the mute has a bypass permission, set to -1 for no maximum.
+
 config.warn.showonlogin=If true, players will be shown all their warnings when they login. If false, they will not.
 config.warn.expire=If true, a record of players warnings will be kept as 'expired warnings'. If false, they will not.
 config.warn.minwarnlength=The minimum length a warning will last before expiring (In seconds), set to -1 for no minimum.
@@ -283,6 +286,7 @@ command.mute.success.time=&e{0} &ahas been muted by &e{1} &afor &e{2}.
 command.mute.success.norm=&e{0} &ahas been muted by &e{1}.
 command.mute.defaultreason=&eYou have been muted!
 command.mute.fail=&cUnable to mute &e{0}&c.
+command.mute.length.toolong=&cThe duration for that mute is too long! The maximum duration is &4{0}.
 command.unmute.success=&e{0} &ahas been unmuted by &e{1}.
 
 command.warn.success.time=&e{0} &ahas been warned by &e{1} &afor reason &e{2}&a, the warning will expire in &e{3}.
@@ -546,6 +550,7 @@ command.ban.profileerror=&cUnable to get the profile for {0} from Mojang.
 command.ban.offline.noperms=&cYou do not have permission to ban offline players.
 command.tempban.applied=&e{0} &awas banned temporarily for &e{1}&a by &e{2}&a.
 command.tempban.offline.noperms=&cYou do not have permission to tempban offline players.
+command.tempban.length.toolong=&cThe duration for that tempban is too long! The maximum duration is &4{0}.
 command.checkban.notset=&e{0} &ais not banned.
 command.checkban.banned=&e{0} &awas banned by &e{1}&a{2}&e{3}&a.
 command.unban.success=&e{0} &awas unbanned by &e{1}.
@@ -868,6 +873,10 @@ permission.jail.notify=Notifies the user about jails when they occur.
 permission.kick.notify=Notifies the user about kicks when they occur.
 permission.warn.notify=Notifies the user about warnings when they occur.
 permission.note.notify=Notifies the user about notes when they occur.
+
+permission.mute.bypass=Allows the user to bypass the maximum mute length.
+permission.tempban.bypass=Allows the user to bypass the maximum tempban length.
+permission.warn.bypass=Allows the user to bypass the maximum warn length.
 
 permission.tempban.offline=Allows the user to temp ban offline users.
 permission.ban.offline=Allows the user to ban offline users.

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -262,6 +262,11 @@ command.mute.defaultreason=&eYou have been muted!
 command.mute.fail=&cUnable to mute &e{0}&c.
 command.unmute.success=&e{0} &ahas been unmuted by &e{1}.
 
+command.warn.success.time=&e{0} &ahas been warned by &e{1}&a, the warning will expire in &e{2}.
+command.warn.success.norm=&e{0} &ahas been warned by &e{1}.
+command.warn.defaultreason=&eYou have been warned!
+command.warn.fail=&cUnable to warn &e{0}&c.
+
 command.kick.defaultreason=&eYou have been kicked!
 command.kick.message={0} &awas kicked by &e{1}.
 command.kickall.message=&aAll players were kicked.
@@ -269,6 +274,9 @@ command.kickall.whitelist=&aThe whitelist was enabled.
 
 command.checkmute.none=&e{0} &ais not muted.
 command.checkmute.mute=&e{0} &awas muted by &e{1}&a{2}&e{3}.
+
+command.checkwarnings.none=&e{0} &ahas no warnings.
+command.checkwarnings.warn=&a{0}. &e{1} &awas warned by &e{2}&a{3}&e{4}.
 
 command.warps.start=&aWarping to &e{0}&a.
 command.warps.nosafe=&cCould not warp to a safe location nearby. To force a warp, use the "-f" flag.
@@ -729,6 +737,10 @@ ban.defaultreason=The BanHammer has spoken!
 mute.playernotify.standard=&cYou are muted and cannot speak.
 mute.playernotify.time=&cYou are muted and cannot speak for &e{0}&c.
 
+# Warn
+warn.playernotify.standard=&4Warning: &c{0}
+warn.playernotify.time=&4Warning: &c{0}, this warning will expire in &e{1}.
+
 # jail
 jail.playernotify.standard=&cYou are jailed and cannot interact.
 jail.playernotify.time=&cYou are jailed and cannot interact for &e{0}&c.
@@ -800,6 +812,7 @@ permission.mute.notify=Notifies the user about bans when they occur.
 permission.ban.notify=Notifies the user about mutes when they occur.
 permission.jail.notify=Notifies the user about jails when they occur.
 permission.kick.notify=Notifies the user about kicks when they occur.
+permission.warn.notify=Notifies the user about warnings when they occur.
 
 permission.nick.others=Allows the user to change other''s nicknames.
 permission.nick.colour=Allows the user to colour their nickname.

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -165,6 +165,8 @@ config.commandlogger.list=A comma separated list of commands in the blacklist or
 config.mute.blocked=Commands to block when muted. This is in addition to chat and /m already being blocked.
 
 config.warn.showonlogin=If true, players will be shown all their warnings when they login. If false, they will not.
+config.warn.minwarnlength=The minimum length a warning will last before expiring (In seconds), set to -1 for no minimum.
+config.warn.maxwarnlength=The maximum length a warning may last for (In seconds), set to -1 for no maximum.
 
 config.teleport.quiet=If true, by default, a target player will not be informed that they have been /teleport ed to. Override using "-q false"
 
@@ -275,6 +277,8 @@ command.unmute.success=&e{0} &ahas been unmuted by &e{1}.
 command.warn.success.time=&e{0} &ahas been warned by &e{1} &afor reason &e{2}&a, the warning will expire in &e{3}.
 command.warn.success.norm=&e{0} &ahas been warned by &e{1} &afor reason &e{2}.
 command.warn.fail=&cUnable to warn &e{0}&c.
+command.warn.length.toolong=&cThe duration for that warning is too long! The maximum duration is &4{0}.
+command.warn.length.tooshort=&cThe duration for that warning is too short! The minimum duration is &4{0}.
 
 command.kick.defaultreason=&eYou have been kicked!
 command.kick.message={0} &awas kicked by &e{1}.

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -768,6 +768,7 @@ warn.playernotify.time=&4Warning: &c{0}, this warning will expire in &e{1}.
 # Note
 note.login.notify=&aThe user &e{0} &ahas the following notes:
 note.login.note=&e{0}. &a{1}, added by &e{2}
+note.login.nonoter=&e{0}. &a{1}, added by &eunknown.
 
 # jail
 jail.playernotify.standard=&cYou are jailed and cannot interact.

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -163,6 +163,8 @@ config.commandlogger.list=A comma separated list of commands in the blacklist or
 
 config.mute.blocked=Commands to block when muted. This is in addition to chat and /m already being blocked.
 
+config.warn.showonlogin=If true, players will be shown all their warnings when they login. If false, they will not.
+
 config.teleport.quiet=If true, by default, a target player will not be informed that they have been /teleport ed to. Override using "-q false"
 
 config.spawn.onlogin=If true, players will be sent to the default world spawn on login, unless they are sent to the first login spawn, or they have the "nucleus.spawn.exempt.onjoin" permission.

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -796,9 +796,8 @@ warn.playernotify.standard=&4Warning: &c{0}
 warn.playernotify.time=&4Warning: &c{0}, this warning will expire in &e{1}.
 
 # Note
-note.login.notify=&aThe user &e{0} &ahas the following notes:
-note.login.note=&e{0}. &a{1}, added by &e{2}
-note.login.nonoter=&e{0}. &a{1}, added by &eunknown.
+note.login.notify=&aThe user &e{0} &ahas some notes. To view them &e&lClick Here!
+note.login.view=&aClick to view notes for &e{0}.
 
 # jail
 jail.playernotify.standard=&cYou are jailed and cannot interact.

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -203,17 +203,17 @@ args.homeother.nouser=&cThe user {0} does not exist.
 
 args.warning.nouserarg=&cA user to remove warnings from must be specified.
 args.warning.nouser=&cThe user &4{0} &cdoes not exist.
-args.warning.nowarndata=&cThe warning &4{0} &cdoes not exist, check again in &4/warnings {1}.
-args.warning.noindex=&cSpecify the warning index, check the index in &4/warnings {0}.
+args.warning.nowarndata=&cThe warning ID &4{0} &cdoes not exist, check again in &4/warnings {1}.
+args.warning.noindex=&cSpecify the warning ID, check the ID in &4/warnings {0}.
 args.warning.nouserwarnings=&cThe user &4{0} &cdoes not have any warnings.
-args.warning.indexnotnumber=&cThe warning index must be a number.
+args.warning.indexnotnumber=&cThe warning ID must be a number.
 
 args.note.nouserarg=&cA user to remove notes from must be specified.
 args.note.nouser=&cThe user &4{0} &cdoes not exist.
-args.note.nonotedata=&cThe note &4{0} &cdoes not exist, check again in &4/notes {1}.
-args.note.noindex=&cSpecify the note index, check the index in &4/notes {0}.
+args.note.nonotedata=&cThe note ID &4{0} &cdoes not exist, check again in &4/notes {1}.
+args.note.noindex=&cSpecify the note ID, check the ID in &4/notes {0}.
 args.note.nousernotes=&cThe user &4{0} &cdoes not have any notes.
-args.note.indexnotnumber=&cThe note index must be a number.
+args.note.indexnotnumber=&cThe note ID must be a number.
 
 args.playerconsole.noexist=&cThat player does not exist. Use "-" for the console.
 
@@ -317,23 +317,30 @@ command.checkmute.none=&e{0} &ais not muted.
 command.checkmute.mute=&e{0} &awas muted by &e{1}&a{2}&e{3}.
 
 command.checkwarnings.none=&e{0} &ahas no warnings.
-command.checkwarnings.info=&2Click on the warner''s name for more information about a warning!
+command.checkwarnings.info=&2Click on the warner''s name for more information!
+command.checkwarnings.header={0}''s warnings
 command.checkwarnings.hover.check=&aClick here to view more details about this warning.
 command.checkwarnings.hover.delete=&cClick here to delete this warning.
 command.checkwarnings.hover.expire=&eClick here to expire this warning.
 command.checkwarnings.hover.return=&aClick here to return to this users list of warnings.
 command.checkwarnings.id=&6ID: &e{0}
-command.checkwarnings.date=&6Date: &e{0}
+command.checkwarnings.date=&6Date warned: &e{0}
 command.checkwarnings.remaining=&6Time remaining: &e{0}
-command.checkwarnings.warner=&6Warner: &e{0}
+command.checkwarnings.warner=&6Warned by: &e{0}
 command.checkwarnings.warning=&6Warning: &e{0}
 command.checkwarnings.action=&6Action
 
-command.checkwarnings.header={0}''s warnings
-
 command.checknotes.none=&e{0} &ahas no notes.
-command.checknotes.note=&e{0}. &a{1}, added by &e{2}
+command.checknotes.info=&2Click on the noter''s name for more information!
 command.checknotes.header={0}''s notes
+command.checknotes.hover.check=&aClick here to view more details about this note.
+command.checknotes.hover.delete=&cClick here to delete this note.
+command.checknotes.hover.return=&aClick here to return to this users list of notes.
+command.checknotes.id=&6ID: &e{0}
+command.checknotes.date=&6Date noted: &e{0}
+command.checknotes.noter=&6Noted by: &e{0}
+command.checknotes.note=&6Note: &e{0}
+command.checknotes.action=&6Action
 
 command.clearwarnings.all=&aAll warnings for &e{0} &ahave been cleared.
 command.clearwarnings.expired=&aAll expired warnings for &e{0} &ahave been cleared.
@@ -350,6 +357,7 @@ command.removewarning.expire=&aWarning for &e{0} &ahas been expired successfully
 command.removewarning.failure=&aWarning for &e{0} &acould not be cleared.
 
 command.removenote.success=&aNote for &e{0} &ahas been cleared.
+command.removenote.remove=&aNote for &e{0} &ahas been removed successfully.
 command.removenote.failure=&aNote for &e{0} &acould not be cleared.
 
 command.warps.start=&aWarping to &e{0}&a.

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -167,11 +167,13 @@ config.mute.blocked=Commands to block when muted. This is in addition to chat an
 config.mute.maxmutelength=The maximum length a mute may last for (In seconds) unless the user handing the mute has a bypass permission, set to -1 for no maximum.
 config.tempban.maxtempbanlength=The maximum length a temporary ban may last for (In seconds) unless the user handing the mute has a bypass permission, set to -1 for no maximum.
 
+config.warn.actioncommand=The command to execute when a player has a specific number of warnings.
 config.warn.showonlogin=If true, players will be shown all their warnings when they login. If false, they will not.
 config.warn.expire=If true, a record of players warnings will be kept as 'expired warnings'. If false, they will not.
 config.warn.minwarnlength=The minimum length a warning will last before expiring (In seconds), set to -1 for no minimum.
 config.warn.maxwarnlength=The maximum length a warning may last for (In seconds), set to -1 for no maximum.
 config.warn.defaultlength=The default length a warning is set to if no length is provided (In seconds), set to -1 for no maximum.
+config.warn.warningsbeforeaction=The number of active warnings a player must accumulate before the action command is executed, set to -1 to disable.
 
 config.note.showonlogin=If true, users with the permission nucleus.note.showonlogin will be shown a users notes when they login. If false, they will not.
 
@@ -294,6 +296,7 @@ command.warn.success.norm=&e{0} &ahas been warned by &e{1} &afor reason &e{2}.
 command.warn.fail=&cUnable to warn &e{0}&c.
 command.warn.length.toolong=&cThe duration for that warning is too long! The maximum duration is &4{0}.
 command.warn.length.tooshort=&cThe duration for that warning is too short! The minimum duration is &4{0}.
+command.warn.exempt=&cThe user &4{0} &cis exempt from being warned.
 
 command.note.fail=&cUnable to add a note to &e{0}&c.
 command.note.success=&e{0} &ahas added the note &e{1} &ato the user &e{2}.
@@ -904,6 +907,7 @@ permission.others=Allows the user to target other players using the command "{0}
 permission.homes.unlimited=Allows the user to have an unlimited number of homes.
 
 permission.sudo.exempt=Exempts the user from being a target of the /sudo command.
+permission.warn.exempt=Exempts the user from being a target of the /warn command.
 
 permission.kickall.whitelist=Allows the user to turn the whitelist on when kicking all players.
 

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -168,6 +168,8 @@ config.warn.showonlogin=If true, players will be shown all their warnings when t
 config.warn.minwarnlength=The minimum length a warning will last before expiring (In seconds), set to -1 for no minimum.
 config.warn.maxwarnlength=The maximum length a warning may last for (In seconds), set to -1 for no maximum.
 
+config.note.showonlogin=If true, users with the permission nucleus.note.showonlogin will be shown a users notes when they login. If false, they will not.
+
 config.teleport.quiet=If true, by default, a target player will not be informed that they have been /teleport ed to. Override using "-q false"
 
 config.spawn.onlogin=If true, players will be sent to the default world spawn on login, unless they are sent to the first login spawn, or they have the "nucleus.spawn.exempt.onjoin" permission.
@@ -279,6 +281,9 @@ command.warn.success.norm=&e{0} &ahas been warned by &e{1} &afor reason &e{2}.
 command.warn.fail=&cUnable to warn &e{0}&c.
 command.warn.length.toolong=&cThe duration for that warning is too long! The maximum duration is &4{0}.
 command.warn.length.tooshort=&cThe duration for that warning is too short! The minimum duration is &4{0}.
+
+command.note.fail=&cUnable to add a note to &e{0}&c.
+command.note.success=&e{0} &ahas added the note &e{1} &ato the user &e{2}.
 
 command.kick.defaultreason=&eYou have been kicked!
 command.kick.message={0} &awas kicked by &e{1}.
@@ -760,6 +765,10 @@ mute.playernotify.time=&cYou are muted and cannot speak for &e{0}&c.
 warn.playernotify.standard=&4Warning: &c{0}
 warn.playernotify.time=&4Warning: &c{0}, this warning will expire in &e{1}.
 
+# Note
+note.login.notify=&aThe user &e{0} &ahas the following notes:
+note.login.note=&e{0}. &a{1}, added by &e{2}
+
 # jail
 jail.playernotify.standard=&cYou are jailed and cannot interact.
 jail.playernotify.time=&cYou are jailed and cannot interact for &e{0}&c.
@@ -832,6 +841,7 @@ permission.ban.notify=Notifies the user about mutes when they occur.
 permission.jail.notify=Notifies the user about jails when they occur.
 permission.kick.notify=Notifies the user about kicks when they occur.
 permission.warn.notify=Notifies the user about warnings when they occur.
+permission.note.notify=Notifies the user about notes when they occur.
 
 permission.nick.others=Allows the user to change other''s nicknames.
 permission.nick.colour=Allows the user to colour their nickname.
@@ -872,6 +882,8 @@ permission.message.magic=Allows user to use magic characters into messages.
 permission.message.urls=Allows user to type clickable URLs into messages.
 
 permission.blacklist.bypass=Allows user to bypass the restriction on blacklisted items.
+
+permission.note.showonlogin=Allows user to see other users notes when they login.
 
 permission.sign.formatting=Allows user to use text formatting on signs.
 


### PR DESCRIPTION
Addition of warn and note module, also adding features pointed out in #262 and #261 

- [x] Warn Module
    - [x] Ability to add warnings
        - [x] Configurable minimum length
        - [x] Configurable maximum length
        - [x] Configurable default length
    - [x] Ability to remove warnings
    - [x] Ability to clear all warnings
    - [x] Ability to check warnings
    - [x] Expired warnings
        - [x] Expire normal warnings when the end timestamp is reached
        - [x] Ability to check expired warnings
        - [x] Ability to remove expired warnings
        - [x] Ability to clear expired warnings
    - [x] Execute a configurable command when a user has reached a configurable number of active warnings
- [x] Note Module
    - [x] Ability to add notes
    - [x] Ability to remove notes
    - [x] Ability to clear all notes
    - [x] Ability to check notes
- [x] Offline command permission nodes
    - [x] Jail
    - [x] Ban
    - [x] Temp ban
- [x] Add maximum mute time
- [x] Add maximum temp ban time
- [x] Allow certain users to join full server
