### PR TITLE
Add ability to use nicknames as the argument as some commands.

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/HomeArgument.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/HomeArgument.java
@@ -4,7 +4,6 @@
  */
 package io.github.nucleuspowered.nucleus.argumentparsers;
 
-import com.google.common.collect.Lists;
 import io.github.nucleuspowered.nucleus.Nucleus;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.LocationData;
@@ -69,18 +68,21 @@ public class HomeArgument extends CommandElement {
         }
 
         User u = (User) src;
+        try {
+            return complete(u, args.peek());
+        } catch (ArgumentParseException e) {
+            return complete(u, "");
+        }
+    }
+
+    protected List<String> complete(User src, String homeName) {
         Set<String> s;
         try {
-            s = plugin.getUserDataManager().get(u).get().getHomes().keySet();
+            s = plugin.getUserDataManager().get(src).get().getHomes().keySet();
         } catch (Exception e) {
             return null;
         }
 
-        try {
-            String n = args.peek();
-            return s.stream().filter(x -> n.toLowerCase().startsWith(x.toLowerCase())).collect(Collectors.toList());
-        } catch (ArgumentParseException e) {
-            return Lists.newArrayList(s);
-        }
+        return s.stream().filter(x -> homeName.toLowerCase().startsWith(x.toLowerCase())).collect(Collectors.toList());
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/HomeOtherArgument.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/HomeOtherArgument.java
@@ -8,13 +8,11 @@ import io.github.nucleuspowered.nucleus.Nucleus;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.LocationData;
 import io.github.nucleuspowered.nucleus.modules.core.config.CoreConfigAdapter;
-import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.ArgumentParseException;
 import org.spongepowered.api.command.args.CommandArgs;
 import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.entity.living.player.User;
-import org.spongepowered.api.service.user.UserStorageService;
 import org.spongepowered.api.text.Text;
 
 import javax.annotation.Nullable;
@@ -24,8 +22,11 @@ import java.util.Optional;
 
 public class HomeOtherArgument extends HomeArgument {
 
+    private final NicknameArgument nickArg;
+
     public HomeOtherArgument(@Nullable Text key, Nucleus plugin, CoreConfigAdapter cca) {
         super(key, plugin, cca);
+        nickArg = new NicknameArgument(key, plugin.getUserDataManager(), NicknameArgument.UnderlyingType.USER);
     }
 
     @Nullable
@@ -38,18 +39,44 @@ public class HomeOtherArgument extends HomeArgument {
             throw args.createError(Util.getTextMessageWithFormat("args.homeother.notenough"));
         }
 
-        Optional<User> ouser = Sponge.getServiceManager().provideUnchecked(UserStorageService.class).get(player);
-        if (!ouser.isPresent()) {
+        // We know it's an instance of a user.
+        User user;
+        try {
+             user = (User) nickArg.parseValue(source, args);
+        } catch (Exception e) {
             throw args.createError(Util.getTextMessageWithFormat("args.homeother.nouser", player));
         }
 
-        User user = ouser.get();
         LocationData location = this.getHome(user, ohome.get(), args);
         return new HomeData(user, location);
     }
 
     @Override
     public List<String> complete(CommandSource src, CommandArgs args, CommandContext context) {
+        Object saveState = null;
+        try {
+            saveState = args.getState();
+
+            // Do we have two args?
+            String arg1 = args.next();
+            Optional<String> arg2 = args.nextIfPresent();
+            if (arg2.isPresent()) {
+                // Get the user
+                User user = (User)this.nickArg.parseInternal(arg1, args);
+                return this.complete(user, arg2.get());
+            } else {
+                args.setState(saveState);
+                return nickArg.complete(src, args, context);
+            }
+
+        } catch (Exception e) {
+            //
+        } finally {
+            if (saveState != null) {
+                args.setState(saveState);
+            }
+        }
+
         return Collections.emptyList();
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/NicknameArgument.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/NicknameArgument.java
@@ -1,0 +1,141 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.argumentparsers;
+
+import com.google.common.base.Preconditions;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.dataservices.UserService;
+import io.github.nucleuspowered.nucleus.dataservices.loaders.UserDataManager;
+import io.github.nucleuspowered.nucleus.functionalinterfaces.ThrownBiFunction;
+import io.github.nucleuspowered.nucleus.functionalinterfaces.TriFunction;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.ArgumentParseException;
+import org.spongepowered.api.command.args.CommandArgs;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.service.user.UserStorageService;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.serializer.TextSerializers;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class NicknameArgument extends CommandElement {
+
+    private final UserDataManager userDataManager;
+    private final ThrownBiFunction<String, CommandArgs, Object, ArgumentParseException> parser;
+    private final TriFunction<String, CommandArgs, CommandContext, List<String>> completer;
+
+    public NicknameArgument(@Nullable Text key, @Nonnull UserDataManager userDataManager, UnderlyingType type) {
+        super(key);
+
+        Preconditions.checkNotNull(userDataManager);
+        this.userDataManager = userDataManager;
+
+        if (type == UnderlyingType.USER) {
+            parser = (s, a) -> {
+                try {
+                    UserStorageService uss = Sponge.getServiceManager().provideUnchecked(UserStorageService.class);
+                    List<User> users = uss.match(s).stream().map(uss::get).filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList());
+                    if (!users.isEmpty()) {
+                        return users;
+                    }
+                } catch (Exception e) {
+                    //
+                }
+
+                throw a.createError(Util.getTextMessageWithFormat("args.user.nouser", s));
+            };
+
+            completer = (s, a, c) -> Sponge.getServiceManager().provideUnchecked(UserStorageService.class).match(s).stream().filter(x -> x.getName().isPresent())
+                    .map(x -> x.getName().get()).collect(Collectors.toList());
+        } else {
+            PlayerConsoleArgument pca = new PlayerConsoleArgument(key, type == UnderlyingType.PLAYER_CONSOLE);
+            parser = pca::parseInternal;
+            completer = pca::completeInternal;
+        }
+    }
+
+    @Nullable
+    @Override
+    protected Object parseValue(CommandSource source, CommandArgs args) throws ArgumentParseException {
+        String name = args.next().toLowerCase();
+        return parseInternal(name, args);
+    }
+
+    Object parseInternal(String name, CommandArgs args) throws ArgumentParseException {
+        boolean playerOnly = name.startsWith("p:");
+
+        final String fName;
+        if (playerOnly) {
+            fName = name.split(":", 2)[1];
+        } else {
+            fName = name;
+        }
+
+        try {
+            return parser.accept(fName, args);
+        } catch (ArgumentParseException e) {
+            if (playerOnly) {
+                // Rethrow;
+                throw e;
+            }
+        }
+
+        // Now check user names
+        List<UserService> players = userDataManager.getOnlineUsersInternal().stream()
+                .filter(x -> x.getUser().isOnline() && x.getNicknameAsString().isPresent() &&
+                TextSerializers.FORMATTING_CODE.stripCodes(x.getNicknameAsString().get()).toLowerCase().startsWith(fName))
+                .sorted((x, y) -> x.getNicknameAsString().get().compareTo(y.getNicknameAsString().get()))
+                .collect(Collectors.toList());
+
+        if (players.isEmpty()) {
+            throw args.createError(Util.getTextMessageWithFormat("args.playerconsole.noexist"));
+        }
+
+        // We know they are online.
+        return players.stream().map(x -> x.getUser().getPlayer().get()).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<String> complete(CommandSource src, CommandArgs args, CommandContext context) {
+        String name;
+        try {
+            name = args.peek().toLowerCase();
+        } catch (ArgumentParseException e) {
+            name = "";
+        }
+
+        boolean playerOnly = name.startsWith("p:");
+        final String fName;
+        if (playerOnly) {
+            fName = name.split(":", 2)[1];
+        } else {
+            fName = name;
+        }
+
+        List<String> original = completer.accept(fName, args, context);
+        if (playerOnly) {
+            return original.stream().map(x -> "p:" + x).collect(Collectors.toList());
+        } else {
+            original.addAll(userDataManager.getOnlineUsersInternal().stream()
+                    .filter(x -> x.getUser().isOnline() && x.getNicknameAsString().isPresent() &&
+                            TextSerializers.FORMATTING_CODE.stripCodes(x.getNicknameAsString().get()).toLowerCase().startsWith(fName))
+                    .map(x -> TextSerializers.FORMATTING_CODE.stripCodes(x.getNicknameAsString().get())).collect(Collectors.toList()));
+            return original;
+        }
+    }
+
+    public enum UnderlyingType {
+        PLAYER,
+        PLAYER_CONSOLE,
+        USER
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/functionalinterfaces/ThrownBiFunction.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/functionalinterfaces/ThrownBiFunction.java
@@ -1,0 +1,19 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.functionalinterfaces;
+
+/**
+ * A function that accepts two arguments and returns a result, but can also throw a checked exception.
+ *
+ * @param <A> The first argument type.
+ * @param <B> The second argument type.
+ * @param <R> The type of the result.
+ * @param <T> The type of {@link Exception} that could be thrown.
+ */
+@FunctionalInterface
+public interface ThrownBiFunction<A, B, R, T extends Exception> {
+
+    R accept(A a, B b) throws T;
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/functionalinterfaces/TriFunction.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/functionalinterfaces/TriFunction.java
@@ -1,0 +1,19 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.functionalinterfaces;
+
+/**
+ * A function that accepts three arguments and returns a result.
+ *
+ * @param <A> The first argument type.
+ * @param <B> The second argument type.
+ * @param <C> The third argument type.
+ * @param <R> The type of the result.
+ */
+@FunctionalInterface
+public interface TriFunction<A, B, C, R> {
+
+    R accept(A a, B b, C c);
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/commands/FlyCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/commands/FlyCommand.java
@@ -6,6 +6,7 @@ package io.github.nucleuspowered.nucleus.modules.fly.commands;
 
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
 import io.github.nucleuspowered.nucleus.dataservices.UserService;
 import io.github.nucleuspowered.nucleus.dataservices.loaders.UserDataManager;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
@@ -44,7 +45,8 @@ public class FlyCommand extends CommandBase<CommandSource> {
     @Override
     public CommandElement[] getArguments() {
         return new CommandElement[] {
-                GenericArguments.optionalWeak(GenericArguments.onlyOne(GenericArguments.requiringPermission(GenericArguments.player(Text.of(player)),
+                GenericArguments.optionalWeak(GenericArguments.onlyOne(GenericArguments.requiringPermission(
+                        new NicknameArgument(Text.of(player), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER),
                         permissions.getPermissionWithSuffix("others")))),
                 GenericArguments.optional(GenericArguments.onlyOne(GenericArguments.bool(Text.of(toggle))))
         };

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/fun/commands/HatCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/fun/commands/HatCommand.java
@@ -5,6 +5,7 @@
 package io.github.nucleuspowered.nucleus.modules.fun.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
@@ -43,7 +44,8 @@ public class HatCommand extends CommandBase<Player> {
     public CommandElement[] getArguments() {
         return new CommandElement[] {
                 GenericArguments.optional(GenericArguments.requiringPermission(
-                        GenericArguments.onlyOne(GenericArguments.player(Text.of(player))), permissions.getPermissionWithSuffix("others")))
+                        GenericArguments.onlyOne(new NicknameArgument(Text.of(player), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER)),
+                        permissions.getPermissionWithSuffix("others")))
         };
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/fun/commands/IgniteCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/fun/commands/IgniteCommand.java
@@ -5,6 +5,7 @@
 package io.github.nucleuspowered.nucleus.modules.fun.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
@@ -43,7 +44,8 @@ public class IgniteCommand extends CommandBase<CommandSource> {
     public CommandElement[] getArguments() {
         return new CommandElement[]{
                 GenericArguments.optionalWeak(GenericArguments.requiringPermission(
-                        GenericArguments.onlyOne(GenericArguments.player(Text.of(player))), permissions.getPermissionWithSuffix("others"))),
+                        GenericArguments.onlyOne(new NicknameArgument(Text.of(player), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER)),
+                        permissions.getPermissionWithSuffix("others"))),
                 GenericArguments.onlyOne(GenericArguments.integer(Text.of(ticks)))
         };
     }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/fun/commands/LightningCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/fun/commands/LightningCommand.java
@@ -6,6 +6,7 @@ package io.github.nucleuspowered.nucleus.modules.fun.commands;
 
 import io.github.nucleuspowered.nucleus.NameUtil;
 import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
@@ -50,7 +51,9 @@ public class LightningCommand extends CommandBase<CommandSource> {
     public CommandElement[] getArguments() {
         return new CommandElement[]{
                 GenericArguments.optional(GenericArguments.requiringPermission(
-                        GenericArguments.onlyOne(GenericArguments.player(Text.of(player))), permissions.getPermissionWithSuffix("others")))
+                        GenericArguments.onlyOne(
+                                new NicknameArgument(Text.of(player), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER)
+                        ), permissions.getPermissionWithSuffix("others")))
         };
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/home/commands/ListHomeCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/home/commands/ListHomeCommand.java
@@ -6,6 +6,7 @@ package io.github.nucleuspowered.nucleus.modules.home.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.data.LocationData;
+import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
@@ -53,7 +54,9 @@ public class ListHomeCommand extends CommandBase<CommandSource> {
     @Override
     public CommandElement[] getArguments() {
         return new CommandElement[] {GenericArguments.optional(GenericArguments.onlyOne(
-                GenericArguments.requiringPermission(GenericArguments.user(Text.of(player)), permissions.getPermissionWithSuffix("others"))))};
+                GenericArguments.requiringPermission(
+                        new NicknameArgument(Text.of(player), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.USER),
+                        permissions.getPermissionWithSuffix("others"))))};
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/mail/commands/MailOtherCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/mail/commands/MailOtherCommand.java
@@ -6,6 +6,7 @@ package io.github.nucleuspowered.nucleus.modules.mail.commands;
 
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.argumentparsers.MailFilterArgument;
+import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
 import io.github.nucleuspowered.nucleus.modules.mail.handlers.MailHandler;
@@ -39,7 +40,7 @@ public class MailOtherCommand extends CommandBase<CommandSource> {
     @Override
     public CommandElement[] getArguments() {
         return new CommandElement[] {
-            GenericArguments.user(Text.of(userKey)),
+            new NicknameArgument(Text.of(userKey), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.USER),
             GenericArguments.optional(GenericArguments.allOf(new MailFilterArgument(Text.of(MailReadBase.filters), handler)))};
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/mail/commands/SendMailCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/mail/commands/SendMailCommand.java
@@ -6,6 +6,7 @@ package io.github.nucleuspowered.nucleus.modules.mail.commands;
 
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
 import io.github.nucleuspowered.nucleus.internal.CommandPermissionHandler;
 import io.github.nucleuspowered.nucleus.internal.PermissionRegistry;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
@@ -39,7 +40,7 @@ public class SendMailCommand extends CommandBase<CommandSource> {
     @Override
     public CommandElement[] getArguments() {
         return new CommandElement[] {
-            GenericArguments.onlyOne(GenericArguments.user(Text.of(player))),
+            GenericArguments.onlyOne(new NicknameArgument(Text.of(player), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.USER)),
             GenericArguments.onlyOne(GenericArguments.remainingJoinedStrings(Text.of(message)))
         };
     }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/message/commands/MessageCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/message/commands/MessageCommand.java
@@ -6,7 +6,7 @@ package io.github.nucleuspowered.nucleus.modules.message.commands;
 
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
-import io.github.nucleuspowered.nucleus.argumentparsers.PlayerConsoleArgument;
+import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
 import io.github.nucleuspowered.nucleus.internal.annotations.NotifyIfAFK;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
@@ -65,7 +65,7 @@ public class MessageCommand extends CommandBase<CommandSource> {
     @Override
     public CommandElement[] getArguments() {
         return new CommandElement[] {
-                new PlayerConsoleArgument(Text.of(to)),
+                new NicknameArgument(Text.of(to), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER_CONSOLE),
                 GenericArguments.onlyOne(GenericArguments.remainingJoinedStrings(Text.of(message)))
         };
     }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/mob/commands/SpawnMobCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/mob/commands/SpawnMobCommand.java
@@ -7,6 +7,7 @@ package io.github.nucleuspowered.nucleus.modules.mob.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.ImprovedCatalogTypeArgument;
+import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
 import io.github.nucleuspowered.nucleus.argumentparsers.PositiveIntegerArgument;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
@@ -49,7 +50,8 @@ public class SpawnMobCommand extends CommandBase<CommandSource> {
     @Override
     public CommandElement[] getArguments() {
         return new CommandElement[] {
-                GenericArguments.optionalWeak(GenericArguments.requiringPermission(GenericArguments.player(Text.of(playerKey)),
+                GenericArguments.optionalWeak(GenericArguments.requiringPermission(
+                        new NicknameArgument(Text.of(playerKey), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER),
                         permissions.getPermissionWithSuffix("others"))),
                 new ImprovedCatalogTypeArgument(Text.of(mobTypeKey), CatalogTypes.ENTITY_TYPE),
                 GenericArguments.optional(new PositiveIntegerArgument(Text.of(amountKey)), 1)

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/playerinfo/commands/SeenCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/playerinfo/commands/SeenCommand.java
@@ -7,6 +7,7 @@ package io.github.nucleuspowered.nucleus.modules.playerinfo.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.NameUtil;
 import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
 import io.github.nucleuspowered.nucleus.dataservices.UserService;
 import io.github.nucleuspowered.nucleus.dataservices.loaders.UserDataManager;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
@@ -61,7 +62,9 @@ public class SeenCommand extends CommandBase<CommandSource> {
 
     @Override
     public CommandElement[] getArguments() {
-        return new CommandElement[] {GenericArguments.onlyOne(GenericArguments.user(Text.of(playerKey)))};
+        return new CommandElement[] {
+            GenericArguments.onlyOne(new NicknameArgument(Text.of(playerKey), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.USER))
+        };
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportAskCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportAskCommand.java
@@ -5,6 +5,7 @@
 package io.github.nucleuspowered.nucleus.modules.teleport.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
@@ -47,7 +48,7 @@ public class TeleportAskCommand extends CommandBase<Player> {
     @Override
     public CommandElement[] getArguments() {
         return new CommandElement[] {
-                GenericArguments.onlyOne(GenericArguments.player(Text.of(playerKey))),
+                GenericArguments.onlyOne(new NicknameArgument(Text.of(playerKey), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER)),
                 GenericArguments.flags().permissionFlag(permissions.getPermissionWithSuffix("force"), "f").buildWith(GenericArguments.none())
         };
     }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportAskHereCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportAskHereCommand.java
@@ -5,6 +5,7 @@
 package io.github.nucleuspowered.nucleus.modules.teleport.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
@@ -46,7 +47,7 @@ public class TeleportAskHereCommand extends CommandBase<Player> {
     @Override
     public CommandElement[] getArguments() {
         return new CommandElement[] {
-            GenericArguments.onlyOne(GenericArguments.player(Text.of(playerKey))),
+            GenericArguments.onlyOne(new NicknameArgument(Text.of(playerKey), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER)),
             GenericArguments.flags().permissionFlag(permissions.getPermissionWithSuffix("force"), "f").buildWith(GenericArguments.none())
         };
     }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportCommand.java
@@ -6,6 +6,7 @@ package io.github.nucleuspowered.nucleus.modules.teleport.commands;
 
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
 import io.github.nucleuspowered.nucleus.argumentparsers.NoCostArgument;
 import io.github.nucleuspowered.nucleus.argumentparsers.NoWarmupArgument;
 import io.github.nucleuspowered.nucleus.argumentparsers.TwoPlayersArgument;
@@ -66,7 +67,7 @@ public class TeleportCommand extends CommandBase<CommandSource> {
                                 permissions.getPermissionWithSuffix("others")),
 
                 // <player>
-                GenericArguments.onlyOne(GenericArguments.player(Text.of(playerKey))))};
+                GenericArguments.onlyOne(new NicknameArgument(Text.of(playerKey), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER)))};
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportHereCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportHereCommand.java
@@ -5,6 +5,7 @@
 package io.github.nucleuspowered.nucleus.modules.teleport.commands;
 
 import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
@@ -37,7 +38,7 @@ public class TeleportHereCommand extends CommandBase<Player> {
 
     @Override
     public CommandElement[] getArguments() {
-        return new CommandElement[] {GenericArguments.onlyOne(GenericArguments.player(Text.of(playerKey)))};
+        return new CommandElement[] {GenericArguments.onlyOne(new NicknameArgument(Text.of(playerKey), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER))};
     }
 
     @Override


### PR DESCRIPTION
Resolves #265

Commands that currently benefit from this:

* fly
* mail send
* mail other
* msg
* spawnmob
* seen
* tp and related commands
* hat
* ignite
* lightning
* list homes
* delete other homes