### PR TITLE
/rtp improvements

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/rtp/commands/RandomTeleportCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/rtp/commands/RandomTeleportCommand.java
@@ -13,16 +13,19 @@ import io.github.nucleuspowered.nucleus.internal.CostCancellableTask;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
-import io.github.nucleuspowered.nucleus.internal.services.WarmupManager;
+import io.github.nucleuspowered.nucleus.modules.rtp.config.RTPConfig;
 import io.github.nucleuspowered.nucleus.modules.rtp.config.RTPConfigAdapter;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.data.property.block.PassableProperty;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.scheduler.Task;
 import org.spongepowered.api.util.PositionOutOfBoundsException;
+import org.spongepowered.api.util.blockray.BlockRay;
+import org.spongepowered.api.util.blockray.BlockRayHit;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.TeleportHelper;
 import org.spongepowered.api.world.World;
@@ -31,16 +34,18 @@ import org.spongepowered.api.world.WorldBorder;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.Predicate;
 
 @Permissions
 @RegisterCommand({"rtp", "randomteleport", "rteleport"})
 public class RandomTeleportCommand extends CommandBase<Player> {
 
     private Set<BlockType> prohibitedTypes = null;
+    private final int maxHeight = 255;
+    private final Vector3d maxHeightVector = new Vector3d(Double.MIN_VALUE, maxHeight + 1, Double.MIN_VALUE);
 
     private final Random random = new Random();
     @Inject private RTPConfigAdapter rca;
-    @Inject private WarmupManager wm;
 
     @Override
     public CommandResult executeCommand(final Player src, CommandContext args) throws Exception {
@@ -50,13 +55,14 @@ public class RandomTeleportCommand extends CommandBase<Player> {
         // World border
         WorldBorder wb = currentWorld.getWorldBorder();
 
-        int diameter = Math.min(Math.abs(rca.getNodeOrDefault().getRadius() * 2), (int)wb.getDiameter());
+        RTPConfig rc = rca.getNodeOrDefault();
+        int diameter = Math.min(Math.abs(rc.getRadius() * 2), (int)wb.getDiameter());
         Vector3d centre = wb.getCenter();
 
-        int count = Math.max(rca.getNodeOrDefault().getNoOfAttempts(), 1);
+        int count = Math.max(rc.getNoOfAttempts(), 1);
         src.sendMessage(Util.getTextMessageWithFormat("command.rtp.searching"));
 
-        Sponge.getScheduler().createTaskBuilder().execute(new RTPTask(plugin, count, diameter, centre, getCost(src, args), src, currentWorld)).submit(plugin);
+        Sponge.getScheduler().createTaskBuilder().execute(new RTPTask(plugin, count, diameter, centre, getCost(src, args), src, currentWorld, rc.isMustSeeSky())).submit(plugin);
         return CommandResult.success();
     }
 
@@ -75,14 +81,16 @@ public class RandomTeleportCommand extends CommandBase<Player> {
         private final Vector3d centre;
         private final TeleportHelper th = Sponge.getGame().getTeleportHelper();
         private final World currentWorld;
+        private final boolean onSurface;
 
-        private RTPTask(Nucleus plugin, int count, int diameter, Vector3d centre, double cost, Player src, World currentWorld) {
+        private RTPTask(Nucleus plugin, int count, int diameter, Vector3d centre, double cost, Player src, World currentWorld, boolean onSurface) {
             super(plugin, src, cost);
             this.count = count;
             this.maxCount = count;
             this.diameter = diameter;
             this.centre = centre;
             this.currentWorld = currentWorld;
+            this.onSurface = onSurface;
         }
 
         @Override
@@ -99,17 +107,19 @@ public class RandomTeleportCommand extends CommandBase<Player> {
             int x = RandomTeleportCommand.this.random.nextInt(diameter) - diameter/2;
             int z = RandomTeleportCommand.this.random.nextInt(diameter) - diameter/2;
 
-            // TODO: Is this available as a constant somewhere?
-            int y = random.nextInt(256);
+            // We remove 10 to avoid getting a location too high up for the safe location teleporter to handle.
+            int y = random.nextInt(maxHeight - 10);
 
             // To get within the world border, add the centre on.
             final Location<World> test = new Location<>(currentWorld, new Vector3d(x + centre.getX(), y, z + centre.getZ()));
             Optional<Location<World>> oSafeLocation = th.getSafeLocation(test, 10, 5);
 
             // getSafeLocation might have put us out of the world border. Best to check.
+            // We also check to see that it's not in water or lava, and if enabled, we see if the player would end up on the surface.
             try {
-                if (oSafeLocation.isPresent() && isSafe(oSafeLocation.get()) && Util.isLocationInWorldBorder(oSafeLocation.get())) {
-                    Location<World> tpTarget = oSafeLocation.get();
+                if (oSafeLocation.isPresent() && isSafe(oSafeLocation.get()) && Util.isLocationInWorldBorder(oSafeLocation.get()) && (!onSurface || isOnSurface(oSafeLocation.get()))) {
+                    Location<World> tpTarget = oSafeLocation.get().add(0, 1, 0);
+
                     plugin.getLogger().debug(String.format("RTP of %s, found location %s, %s, %s", player.getName(),
                             String.valueOf(tpTarget.getBlockX()),
                             String.valueOf(tpTarget.getBlockY()),
@@ -158,10 +168,42 @@ public class RandomTeleportCommand extends CommandBase<Player> {
             return prohibitedTypes;
         }
 
+        private boolean isOnSurface(Location<World> location) {
+            SurfaceCheckPredicate predicate = new SurfaceCheckPredicate();
+            Optional<BlockRayHit<World>> blockRayHitOptional = BlockRay.from(location).to(location.getPosition().max(maxHeightVector))
+                    .filter(predicate).end();
+
+            // If we have no hit, then this is the top of the world and we should allow it.
+            return !blockRayHitOptional.isPresent();
+        }
+
         @Override
         public void onCancel() {
             super.onCancel();
             RandomTeleportCommand.this.removeCooldown(player.getUniqueId());
+        }
+
+        private class SurfaceCheckPredicate implements Predicate<BlockRayHit<World>> {
+
+            private int count = 0;
+
+            @Override
+            public boolean test(BlockRayHit<World> l) {
+                BlockType type = l.getLocation().getBlockType();
+
+                // If passable - treat it as seeing the sky.
+                if (Boolean.TRUE.equals(type.getProperty(PassableProperty.class).orElse(new PassableProperty(false)).getValue())) {
+                    return true;
+                }
+
+                // If leaves, treat it as on the surface.
+                if (count++ > 1 && type.equals(BlockTypes.LEAVES) || type.equals(BlockTypes.LEAVES2)) {
+                    return true;
+                }
+
+                // Nope, we're not on the surface
+                return false;
+            }
         }
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/rtp/config/RTPConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/rtp/config/RTPConfig.java
@@ -16,11 +16,18 @@ public class RTPConfig {
     @Setting(value = "radius", comment = "loc:config.rtp.radius")
     private int radius = 30000;
 
+    @Setting(value = "surface-only", comment = "loc:config.rtp.surface")
+    private boolean mustSeeSky = false;
+
     public int getNoOfAttempts() {
         return noOfAttempts;
     }
 
     public int getRadius() {
         return radius;
+    }
+
+    public boolean isMustSeeSky() {
+        return mustSeeSky;
     }
 }

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -208,6 +208,7 @@ config.fly.stateonquit=If true, if a player is flying when they disconnect, this
 
 config.rtp.attempts=The number of times to try to find a safe teleport spot when using /rtp before failing. Setting this too low may cause a high rate of failiures.
 config.rtp.radius=The radius from the centre of the world/world border where /rtp can warp to. This will not override the world border radius.
+config.rtp.surface=If true, /rtp will only try to teleport players to the surface, and not into caves.
 
 config.core.warmup.info=If true, cancel a user''s warmup on...
 config.core.warmup.move=movement


### PR DESCRIPTION
Fixes #310 

* Prevents `/rtp` from teleporting the player into water or lava.
* Add config option to restrict `/rtp` to teleporting players to the surface.
