### PR TITLE
Add support for @p, @a and @r selectors.

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/SelectorWrapperArgument.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/SelectorWrapperArgument.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.argumentparsers;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.argumentparsers.selectors.*;
+import io.github.nucleuspowered.nucleus.internal.CommandPermissionHandler;
+import io.github.nucleuspowered.nucleus.internal.interfaces.SelectorParser;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.ArgumentParseException;
+import org.spongepowered.api.command.args.CommandArgs;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.text.Text;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public class SelectorWrapperArgument extends CommandElement {
+
+    public final static Collection<SelectorParser<?>> SINGLE_PLAYER_SELECTORS;
+
+    public final static Collection<SelectorParser<?>> MULTIPLE_PLAYER_SELECTORS;
+
+    public final static Collection<SelectorParser<?>> ALL_SELECTORS;
+
+    static {
+        SINGLE_PLAYER_SELECTORS = ImmutableList.of(
+                NearestPlayer.INSTANCE, NearestPlayerFromSpecifiedLocation.INSTANCE, RandomPlayer.INSTANCE, RandomPlayerFromWorld.INSTANCE
+        );
+
+        MULTIPLE_PLAYER_SELECTORS = ImmutableList.of(
+                AllPlayers.INSTANCE, AllPlayersFromWorld.INSTANCE
+        );
+
+        ALL_SELECTORS = ImmutableList.<SelectorParser<?>>builder()
+                .addAll(SINGLE_PLAYER_SELECTORS)
+                .addAll(MULTIPLE_PLAYER_SELECTORS)
+                .build();
+    }
+
+    private final CommandElement wrappedElement;
+    private final CommandPermissionHandler permissionHandler;
+    private final Collection<SelectorParser<?>> selectors;
+
+    public SelectorWrapperArgument(@Nonnull CommandElement wrappedElement, CommandPermissionHandler permissionHandler, SelectorParser<?>... selectors) {
+        this(wrappedElement, permissionHandler, Lists.newArrayList(selectors));
+    }
+
+    public SelectorWrapperArgument(@Nonnull CommandElement wrappedElement, CommandPermissionHandler permissionHandler, Collection<SelectorParser<?>> selectors) {
+        super(wrappedElement.getKey());
+
+        Preconditions.checkArgument(selectors != null && !selectors.isEmpty());
+        this.wrappedElement = wrappedElement;
+        this.selectors = selectors;
+        this.permissionHandler = permissionHandler;
+    }
+
+    @Nullable
+    @Override
+    protected Object parseValue(CommandSource source, CommandArgs args) throws ArgumentParseException {
+        if (!permissionHandler.testSelectors(source)) {
+            throw args.createError(Util.getTextMessageWithFormat("args.selector.nopermissions"));
+        }
+
+        String selectorRaw = args.next();
+        String selector = selectorRaw.substring(1).toLowerCase();
+        Optional<SelectorParser<?>> parserOptional = selectors.stream().filter(x -> x.selector().matcher(selector).matches()).findFirst();
+        if (parserOptional.isPresent()) {
+            return parserOptional.get().get(selector, source, args);
+        }
+
+        throw args.createError(Util.getTextMessageWithFormat("args.selector.noexist", selectorRaw));
+    }
+
+    @Override
+    public void parse(CommandSource source, CommandArgs args, CommandContext context) throws ArgumentParseException {
+        if (args.peek().startsWith("@")) {
+            // MC names cannot have "@" in them, so there is no need to send it to the wrapped argument anyway.
+            super.parse(source, args, context);
+        } else {
+            wrappedElement.parse(source, args, context);
+        }
+    }
+
+    @Override
+    public List<String> complete(CommandSource src, CommandArgs args, CommandContext context) {
+        return wrappedElement.complete(src, args, context);
+    }
+
+    @Override
+    public Text getUsage(CommandSource src) {
+        return wrappedElement.getUsage(src);
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/selectors/AllPlayers.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/selectors/AllPlayers.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.argumentparsers.selectors;
+
+import io.github.nucleuspowered.nucleus.internal.interfaces.SelectorParser;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.ArgumentParseException;
+import org.spongepowered.api.command.args.CommandArgs;
+import org.spongepowered.api.entity.living.player.Player;
+
+import java.util.Collection;
+import java.util.regex.Pattern;
+
+/**
+ * Selector to get all players
+ */
+public class AllPlayers implements SelectorParser<Collection<Player>> {
+
+    public static final AllPlayers INSTANCE = new AllPlayers();
+    private final Pattern pattern = Pattern.compile("^a$");
+
+    private AllPlayers() {}
+
+    @Override
+    public Pattern selector() {
+        return pattern;
+    }
+
+    @Override
+    public Collection<Player> get(String selector, CommandSource source, CommandArgs args) throws ArgumentParseException {
+        return Sponge.getServer().getOnlinePlayers();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/selectors/AllPlayersFromWorld.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/selectors/AllPlayersFromWorld.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.argumentparsers.selectors;
+
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.internal.interfaces.SelectorParser;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.ArgumentParseException;
+import org.spongepowered.api.command.args.CommandArgs;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.world.World;
+
+import java.util.Collection;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Selector to get all players on a given world
+ */
+public class AllPlayersFromWorld implements SelectorParser<Collection<Player>> {
+
+    public static final AllPlayersFromWorld INSTANCE = new AllPlayersFromWorld();
+    private final Pattern pattern = Pattern.compile("^a\\[([\\w-]+)\\]$");
+
+    private AllPlayersFromWorld() {}
+
+    @Override
+    public Pattern selector() {
+        return pattern;
+    }
+
+    @Override
+    public Collection<Player> get(String rawSelector, CommandSource source, CommandArgs args) throws ArgumentParseException {
+        // Get the regex groups.
+        Matcher m = pattern.matcher(rawSelector);
+        m.matches();
+        String world = m.group(1);
+
+        World spongeWorld = Sponge.getServer().getWorld(world).orElseThrow(() -> args.createError(Util.getTextMessageWithFormat("args.selector.noworld", world)));
+
+        return Sponge.getServer().getOnlinePlayers().stream().filter(x -> x.getLocation().getExtent().getUniqueId().equals(spongeWorld.getUniqueId())).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/selectors/NearestPlayer.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/selectors/NearestPlayer.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.argumentparsers.selectors;
+
+import com.flowpowered.math.vector.Vector3d;
+import com.google.common.collect.Lists;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.internal.interfaces.SelectorParser;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.ArgumentParseException;
+import org.spongepowered.api.command.args.CommandArgs;
+import org.spongepowered.api.command.source.LocatedSource;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.util.Tuple;
+import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.World;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Obtains the nearest player to the locatable object.
+ */
+public class NearestPlayer implements SelectorParser<Player> {
+
+    public final static NearestPlayer INSTANCE = new NearestPlayer();
+
+    private final Pattern selector = Pattern.compile("^p$", Pattern.CASE_INSENSITIVE);
+
+    private NearestPlayer() {}
+
+    @Override
+    public Pattern selector() {
+        return selector;
+    }
+
+    @Override
+    public Player get(String selector, CommandSource source, CommandArgs args) throws ArgumentParseException {
+        if (!(source instanceof LocatedSource)) {
+            throw args.createError(Util.getTextMessageWithFormat("args.selector.nolocation"));
+        }
+
+        LocatedSource locatedSource = (LocatedSource)source;
+
+        // We don't want the executing player.
+        List<Player> playerCollection = Lists.newArrayList(Sponge.getServer().getOnlinePlayers());
+        if (locatedSource instanceof Player) {
+            playerCollection.remove(locatedSource);
+        }
+
+        // Remove players "out of this world", then sort players by distance from current location.
+        return getNearestPlayerFromLocation(playerCollection, locatedSource.getLocation(), args);
+    }
+
+    static Player getNearestPlayerFromLocation(Collection<Player> playerCollection, Location<World> locationInWorld, CommandArgs args) throws ArgumentParseException {
+        Vector3d currentLocation = locationInWorld.getPosition();
+        return playerCollection.parallelStream()
+                .filter(x -> x.getWorld().getUniqueId().equals(locationInWorld.getExtent().getUniqueId()))
+                .map(x -> new Tuple<>(x, x.getLocation().getPosition().distanceSquared(currentLocation)))
+                .min((x, y) -> x.getSecond().compareTo(y.getSecond()))
+                .orElseThrow(() -> args.createError(Util.getTextMessageWithFormat("args.selector.notarget")))
+                .getFirst();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/selectors/NearestPlayerFromSpecifiedLocation.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/selectors/NearestPlayerFromSpecifiedLocation.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.argumentparsers.selectors;
+
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.internal.interfaces.SelectorParser;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.ArgumentParseException;
+import org.spongepowered.api.command.args.CommandArgs;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.World;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Obtains the nearest player to the specified location.
+ */
+public class NearestPlayerFromSpecifiedLocation implements SelectorParser<Player> {
+
+    public final static NearestPlayerFromSpecifiedLocation INSTANCE = new NearestPlayerFromSpecifiedLocation();
+
+    private final Pattern selector = Pattern.compile("^p\\[([\\w-]+),(-?\\d+),(\\d{1,3}),(-?\\d+)\\]$", Pattern.CASE_INSENSITIVE);
+
+    private NearestPlayerFromSpecifiedLocation() {}
+
+    @Override
+    public Pattern selector() {
+        return selector;
+    }
+
+    @Override
+    public Player get(String rawSelector, CommandSource source, CommandArgs args) throws ArgumentParseException {
+        // Get the regex groups.
+        Matcher m = selector.matcher(rawSelector);
+        m.matches();
+        String world = m.group(1);
+        int x = Integer.parseInt(m.group(2));
+        int y = Integer.parseInt(m.group(3));
+        int z = Integer.parseInt(m.group(4));
+
+        World spongeWorld = Sponge.getServer().getWorld(world).orElseThrow(() -> args.createError(Util.getTextMessageWithFormat("args.selector.noworld", world)));
+
+        // Remove players "out of this world", then sort players by distance from current location.
+        return NearestPlayer.getNearestPlayerFromLocation(Sponge.getServer().getOnlinePlayers(), new Location<>(spongeWorld, x, y, z), args);
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/selectors/RandomPlayer.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/selectors/RandomPlayer.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.argumentparsers.selectors;
+
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.internal.interfaces.SelectorParser;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.ArgumentParseException;
+import org.spongepowered.api.command.args.CommandArgs;
+import org.spongepowered.api.entity.living.player.Player;
+
+import java.util.List;
+import java.util.Random;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Selector to get all players
+ */
+public class RandomPlayer implements SelectorParser<Player> {
+
+    public static final RandomPlayer INSTANCE = new RandomPlayer();
+    private final Pattern pattern = Pattern.compile("^r$");
+    private final Random random = new Random();
+
+    private RandomPlayer() {}
+
+    @Override
+    public Pattern selector() {
+        return pattern;
+    }
+
+    @Override
+    public Player get(String selector, CommandSource source, CommandArgs args) throws ArgumentParseException {
+        List<Player> players = Sponge.getServer().getOnlinePlayers().stream()
+                .filter(x -> !(source instanceof Player) || ((Player) source).getUniqueId().equals(x.getUniqueId()))
+                .sorted((x, y) -> x.getName().compareTo(y.getName())).collect(Collectors.toList());
+        if (players.isEmpty()) {
+            throw args.createError(Util.getTextMessageWithFormat("args.selector.notarget"));
+        }
+
+        return players.get(random.nextInt(players.size()));
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/selectors/RandomPlayerFromWorld.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/selectors/RandomPlayerFromWorld.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.argumentparsers.selectors;
+
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.internal.interfaces.SelectorParser;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.ArgumentParseException;
+import org.spongepowered.api.command.args.CommandArgs;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.world.World;
+
+import java.util.List;
+import java.util.Random;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Selector to get all players
+ */
+public class RandomPlayerFromWorld implements SelectorParser<Player> {
+
+    public static final RandomPlayerFromWorld INSTANCE = new RandomPlayerFromWorld();
+    private final Pattern pattern = Pattern.compile("^r\\[[\\w-]+\\]$");
+    private final Random random = new Random();
+
+    private RandomPlayerFromWorld() {}
+
+    @Override
+    public Pattern selector() {
+        return pattern;
+    }
+
+    @Override
+    public Player get(String selector, CommandSource source, CommandArgs args) throws ArgumentParseException {
+        // Get the regex groups.
+        Matcher m = pattern.matcher(selector);
+        m.matches();
+        String world = m.group(1);
+
+        World spongeWorld = Sponge.getServer().getWorld(world).orElseThrow(() -> args.createError(Util.getTextMessageWithFormat("args.selector.noworld", world)));
+
+        List<Player> players = Sponge.getServer().getOnlinePlayers().stream().filter(x -> x.getWorld().getUniqueId().equals(spongeWorld.getUniqueId()))
+                .filter(x -> !(source instanceof Player) || ((Player) source).getUniqueId().equals(x.getUniqueId()))
+                .sorted((x, y) -> x.getName().compareTo(y.getName())).collect(Collectors.toList());
+        if (players.isEmpty()) {
+            throw args.createError(Util.getTextMessageWithFormat("args.selector.notarget"));
+        }
+
+        return players.get(random.nextInt(players.size()));
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/CommandPermissionHandler.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/CommandPermissionHandler.java
@@ -25,6 +25,7 @@ public class CommandPermissionHandler {
     private final String warmup;
     private final String cooldown;
     private final String cost;
+    private final String selectors;
 
     private final boolean justReturnTrue;
 
@@ -38,6 +39,7 @@ public class CommandPermissionHandler {
             warmup = "";
             cooldown = "";
             cost = "";
+            selectors = "";
             return;
         }
 
@@ -62,6 +64,11 @@ public class CommandPermissionHandler {
                 @Override
                 public String sub() {
                     return "";
+                }
+
+                @Override
+                public boolean supportsSelectors() {
+                    return false;
                 }
 
                 @Override
@@ -95,6 +102,7 @@ public class CommandPermissionHandler {
         prefix = sb.toString();
 
         base = prefix + "base";
+        selectors = prefix + "selectors";
 
         // Get command name.
         String command = cb.getAliases()[0];
@@ -104,6 +112,10 @@ public class CommandPermissionHandler {
         }
 
         mssl.put(base, new PermissionInformation(Util.getMessageWithFormat("permission.base", command), c.suggestedLevel()));
+
+        if (c.supportsSelectors()) {
+            mssl.put(base, new PermissionInformation(Util.getMessageWithFormat("permission.selector", command), c.suggestedLevel()));
+        }
 
         warmup = prefix + "exempt.warmup";
         cooldown = prefix + "exempt.cooldown";
@@ -133,19 +145,23 @@ public class CommandPermissionHandler {
     }
 
     public boolean testBase(Subject src) {
-        return justReturnTrue || src.hasPermission(base);
+        return test(src, base);
     }
 
     public boolean testWarmupExempt(Subject src) {
-        return justReturnTrue || src.hasPermission(warmup);
+        return test(src, warmup);
     }
 
     public boolean testCooldownExempt(Subject src) {
-        return justReturnTrue || src.hasPermission(cooldown);
+        return test(src, cooldown);
     }
 
     public boolean testCostExempt(Subject src) {
-        return justReturnTrue || src.hasPermission(cost);
+        return test(src, cost);
+    }
+
+    public boolean testSelectors(Subject src) {
+        return test(src, selectors);
     }
 
     public void registerPermssionSuffix(String suffix, PermissionInformation pi) {
@@ -157,7 +173,7 @@ public class CommandPermissionHandler {
     }
 
     public boolean testSuffix(Subject src, String suffix) {
-        return justReturnTrue || src.hasPermission(prefix + suffix);
+        return test(src, prefix + suffix);
     }
 
     public String getPermissionWithSuffix(String suffix) {
@@ -168,4 +184,7 @@ public class CommandPermissionHandler {
         return ImmutableMap.copyOf(mssl);
     }
 
+    private boolean test(Subject src, String permission) {
+        return justReturnTrue || src.hasPermission(permission);
+    }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/annotations/Permissions.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/annotations/Permissions.java
@@ -48,6 +48,13 @@ public @interface Permissions {
     String sub() default "";
 
     /**
+     * If {@code true}, specifies that selector permissions should be generated. Purely for documentation.
+     *
+     * @return {@code true} if so.
+     */
+    boolean supportsSelectors() default false;
+
+    /**
      * The suggested permission level.
      *
      * @return The {@link SuggestedLevel}

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/command/AbstractCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/command/AbstractCommand.java
@@ -518,6 +518,19 @@ public abstract class AbstractCommand<T extends CommandSource> implements Comman
         return Sponge.getServer().getDefaultWorld().get();
     }
 
+    /**
+     * Gets a {@link User} from the specified argument, or if one does not exist, attempts to use the
+     * player currently running the command, if there is one.
+     *
+     * @param clazz The {@link Class} of the object we're expecting, which might be a {@link User} or {@link Player}
+     * @param src The {@link CommandSource} running the command.
+     * @param argument The name of the argument to check.
+     * @param args The {@link CommandContext} that would contain the arguement result.
+     * @param <U> The type of object we're looking for
+     *
+     * @return An {@link Optional} that might contain a user. This will typically only be {@link Optional#empty()} if
+     *         the command was executed on the console.
+     */
     protected <U extends User> Optional<U> getUser(Class<U> clazz, CommandSource src, String argument, CommandContext args) {
         Optional<U> opl = args.getOne(argument);
         U pl;

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/interfaces/SelectorParser.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/interfaces/SelectorParser.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.internal.interfaces;
+
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.ArgumentParseException;
+import org.spongepowered.api.command.args.CommandArgs;
+
+import java.util.regex.Pattern;
+
+/**
+ * This interface represents a parser for selectors.
+ *
+ * @param <T> The type of result that will be returned.
+ */
+public interface SelectorParser<T> {
+
+    /**
+     * The {@link Pattern} that the selector will match, without the "@" symbol
+     *
+     * @return The selector regular expression
+     */
+    Pattern selector();
+
+    /**
+     * Gets the result based on the selector input.
+     * @param selector The raw input for the selector, without the @ symbol
+     * @param source The {@link CommandSource}
+     * @param args The {@link CommandArgs}, for exception handling.
+     * @return The result
+     * @throws ArgumentParseException If the selector could not find a target.
+     */
+    T get(String selector, CommandSource source, CommandArgs args) throws ArgumentParseException;
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/commands/FlyCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/commands/FlyCommand.java
@@ -7,6 +7,7 @@ package io.github.nucleuspowered.nucleus.modules.fly.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
+import io.github.nucleuspowered.nucleus.argumentparsers.SelectorWrapperArgument;
 import io.github.nucleuspowered.nucleus.dataservices.UserService;
 import io.github.nucleuspowered.nucleus.dataservices.loaders.UserDataManager;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
@@ -46,7 +47,10 @@ public class FlyCommand extends CommandBase<CommandSource> {
     public CommandElement[] getArguments() {
         return new CommandElement[] {
                 GenericArguments.optionalWeak(GenericArguments.onlyOne(GenericArguments.requiringPermission(
-                        new NicknameArgument(Text.of(player), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER),
+                        new SelectorWrapperArgument(
+                            new NicknameArgument(Text.of(player), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER),
+                            permissions,
+                            SelectorWrapperArgument.SINGLE_PLAYER_SELECTORS),
                         permissions.getPermissionWithSuffix("others")))),
                 GenericArguments.optional(GenericArguments.onlyOne(GenericArguments.bool(Text.of(toggle))))
         };

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/fun/commands/HatCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/fun/commands/HatCommand.java
@@ -6,6 +6,7 @@ package io.github.nucleuspowered.nucleus.modules.fun.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
+import io.github.nucleuspowered.nucleus.argumentparsers.SelectorWrapperArgument;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
@@ -28,7 +29,7 @@ import java.util.Optional;
 @NoCooldown
 @NoWarmup
 @NoCost
-@Permissions
+@Permissions(supportsSelectors = true)
 public class HatCommand extends CommandBase<Player> {
 
     private final String player = "player";
@@ -44,7 +45,10 @@ public class HatCommand extends CommandBase<Player> {
     public CommandElement[] getArguments() {
         return new CommandElement[] {
                 GenericArguments.optional(GenericArguments.requiringPermission(
-                        GenericArguments.onlyOne(new NicknameArgument(Text.of(player), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER)),
+                        GenericArguments.onlyOne(new SelectorWrapperArgument(
+                                new NicknameArgument(Text.of(player), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER),
+                                permissions, SelectorWrapperArgument.SINGLE_PLAYER_SELECTORS)
+                            ),
                         permissions.getPermissionWithSuffix("others")))
         };
     }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/fun/commands/IgniteCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/fun/commands/IgniteCommand.java
@@ -6,6 +6,7 @@ package io.github.nucleuspowered.nucleus.modules.fun.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
+import io.github.nucleuspowered.nucleus.argumentparsers.SelectorWrapperArgument;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
@@ -26,7 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-@Permissions
+@Permissions(supportsSelectors = true)
 @RegisterCommand({"ignite", "burn"})
 public class IgniteCommand extends CommandBase<CommandSource> {
 
@@ -43,9 +44,15 @@ public class IgniteCommand extends CommandBase<CommandSource> {
     @Override
     public CommandElement[] getArguments() {
         return new CommandElement[]{
-                GenericArguments.optionalWeak(GenericArguments.requiringPermission(
-                        GenericArguments.onlyOne(new NicknameArgument(Text.of(player), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER)),
-                        permissions.getPermissionWithSuffix("others"))),
+                GenericArguments.optionalWeak(
+                    GenericArguments.requiringPermission(
+                        GenericArguments.onlyOne(
+                                new SelectorWrapperArgument(
+                                    new NicknameArgument(Text.of(player), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER),
+                                    permissions,
+                                    SelectorWrapperArgument.SINGLE_PLAYER_SELECTORS)),
+                        permissions.getPermissionWithSuffix("others")
+                )),
                 GenericArguments.onlyOne(GenericArguments.integer(Text.of(ticks)))
         };
     }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/fun/commands/LightningCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/fun/commands/LightningCommand.java
@@ -7,6 +7,7 @@ package io.github.nucleuspowered.nucleus.modules.fun.commands;
 import io.github.nucleuspowered.nucleus.NameUtil;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
+import io.github.nucleuspowered.nucleus.argumentparsers.SelectorWrapperArgument;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
@@ -30,11 +31,12 @@ import org.spongepowered.api.util.blockray.BlockRayHit;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-@Permissions
+@Permissions(supportsSelectors = true)
 @RegisterCommand({"lightning", "smite", "thor"})
 public class LightningCommand extends CommandBase<CommandSource> {
 
@@ -50,24 +52,29 @@ public class LightningCommand extends CommandBase<CommandSource> {
     @Override
     public CommandElement[] getArguments() {
         return new CommandElement[]{
-                GenericArguments.optional(GenericArguments.requiringPermission(
-                        GenericArguments.onlyOne(
-                                new NicknameArgument(Text.of(player), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER)
-                        ), permissions.getPermissionWithSuffix("others")))
+                GenericArguments.optional(
+                    GenericArguments.requiringPermission(
+                            new SelectorWrapperArgument(
+                                new NicknameArgument(Text.of(player), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER, false),
+                                permissions,
+                                SelectorWrapperArgument.ALL_SELECTORS)
+                        , permissions.getPermissionWithSuffix("others")))
         };
     }
 
     @Override
     public CommandResult executeCommand(final CommandSource src, CommandContext args) throws Exception {
-        Optional<Player> opl = this.getUser(Player.class, src, player, args);
-        if (!opl.isPresent()) {
-            return CommandResult.empty();
-        }
-
-        Player pl = opl.get();
+        Collection<Player> playerCollection = args.getAll(player);
 
         // No argument, let's not smite the player.
-        if (!args.getOne(player).isPresent()) {
+        if (playerCollection.isEmpty()) {
+            if (!(src instanceof Player)) {
+                src.sendMessage(Util.getTextMessageWithFormat("command.playeronly"));
+                return CommandResult.empty();
+            }
+
+            Player pl = (Player)src;
+
             // 100 is a good limit here.
             BlockRay<World> playerBlockRay = BlockRay.from(pl).blockLimit(100).filter(BlockRay.continueAfterFilter(BlockRay.onlyAirFilter(), 1)).build();
             Optional<BlockRayHit<World>> obh = playerBlockRay.end();
@@ -79,13 +86,19 @@ public class LightningCommand extends CommandBase<CommandSource> {
                 lightningLocation = pl.getLocation().add(0, 3, 0);
             }
 
-            return this.spawnLightning(lightningLocation, src, "command.lightning.success.normal");
+            return this.spawnLightning(lightningLocation, src, null, "command.lightning.error");
         }
 
-        return this.spawnLightning(pl.getLocation(), src, "command.lightning.success.other", NameUtil.getSerialisedName(pl));
+        int successCount = 0;
+        for (Player pl : playerCollection) {
+            CommandResult cr = this.spawnLightning(pl.getLocation(), src, "command.lightning.success.other", "command.lightning.errorplayer", NameUtil.getSerialisedName(pl));
+            successCount += cr.getSuccessCount().orElse(0);
+        }
+
+        return CommandResult.builder().successCount(successCount).build();
     }
 
-    private CommandResult spawnLightning(Location<World> location, CommandSource src, String successKey, String... replacements) {
+    private CommandResult spawnLightning(Location<World> location, CommandSource src, String successKey, String errorKey, String... replacements) {
         World world = location.getExtent();
         Optional<Entity> bolt = world.createEntity(EntityTypes.LIGHTNING, location.getPosition());
 
@@ -93,11 +106,14 @@ public class LightningCommand extends CommandBase<CommandSource> {
                 NamedCause.owner(SpawnCause.builder().type(SpawnTypes.PLUGIN).build()),
                 NamedCause.source(src));
         if (bolt.isPresent() && world.spawnEntity(bolt.get(), cause)) {
-            src.sendMessage(Util.getTextMessageWithFormat(successKey, replacements));
+            if (successKey != null) {
+                src.sendMessage(Util.getTextMessageWithFormat(successKey, replacements));
+            }
+
             return CommandResult.success();
         }
 
-        src.sendMessage(Util.getTextMessageWithFormat("command.lightning.error"));
+        src.sendMessage(Util.getTextMessageWithFormat(errorKey, replacements));
         return CommandResult.empty();
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/message/commands/MessageCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/message/commands/MessageCommand.java
@@ -7,6 +7,7 @@ package io.github.nucleuspowered.nucleus.modules.message.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
+import io.github.nucleuspowered.nucleus.argumentparsers.SelectorWrapperArgument;
 import io.github.nucleuspowered.nucleus.internal.annotations.NotifyIfAFK;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
@@ -28,7 +29,7 @@ import java.util.Map;
 /**
  * Messages a player.
  */
-@Permissions(suggestedLevel = SuggestedLevel.USER)
+@Permissions(suggestedLevel = SuggestedLevel.USER, supportsSelectors = true)
 @RunAsync
 @RegisterCommand({ "message", "m", "msg", "whisper", "w", "tell", "t" })
 @NotifyIfAFK(MessageCommand.to)
@@ -65,8 +66,11 @@ public class MessageCommand extends CommandBase<CommandSource> {
     @Override
     public CommandElement[] getArguments() {
         return new CommandElement[] {
+            new SelectorWrapperArgument(
                 new NicknameArgument(Text.of(to), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER_CONSOLE),
-                GenericArguments.onlyOne(GenericArguments.remainingJoinedStrings(Text.of(message)))
+                permissions,
+                SelectorWrapperArgument.SINGLE_PLAYER_SELECTORS),
+            GenericArguments.onlyOne(GenericArguments.remainingJoinedStrings(Text.of(message)))
         };
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/mob/commands/SpawnMobCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/mob/commands/SpawnMobCommand.java
@@ -9,6 +9,7 @@ import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.ImprovedCatalogTypeArgument;
 import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
 import io.github.nucleuspowered.nucleus.argumentparsers.PositiveIntegerArgument;
+import io.github.nucleuspowered.nucleus.argumentparsers.SelectorWrapperArgument;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
@@ -37,7 +38,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-@Permissions
+@Permissions(supportsSelectors = true)
 @RegisterCommand({"spawnmob", "spawnentity"})
 public class SpawnMobCommand extends CommandBase<CommandSource> {
 
@@ -50,8 +51,12 @@ public class SpawnMobCommand extends CommandBase<CommandSource> {
     @Override
     public CommandElement[] getArguments() {
         return new CommandElement[] {
-                GenericArguments.optionalWeak(GenericArguments.requiringPermission(
-                        new NicknameArgument(Text.of(playerKey), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER),
+                GenericArguments.optionalWeak(
+                    GenericArguments.requiringPermission(
+                        new SelectorWrapperArgument(
+                            new NicknameArgument(Text.of(playerKey), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER),
+                            permissions,
+                            SelectorWrapperArgument.SINGLE_PLAYER_SELECTORS),
                         permissions.getPermissionWithSuffix("others"))),
                 new ImprovedCatalogTypeArgument(Text.of(mobTypeKey), CatalogTypes.ENTITY_TYPE),
                 GenericArguments.optional(new PositiveIntegerArgument(Text.of(amountKey)), 1)

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportAskCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportAskCommand.java
@@ -6,6 +6,7 @@ package io.github.nucleuspowered.nucleus.modules.teleport.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
+import io.github.nucleuspowered.nucleus.argumentparsers.SelectorWrapperArgument;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
@@ -27,7 +28,7 @@ import java.util.Map;
 /**
  * Sends a request to a player to teleport to them, using click handlers.
  */
-@Permissions(root = "teleport", suggestedLevel = SuggestedLevel.USER)
+@Permissions(root = "teleport", suggestedLevel = SuggestedLevel.USER, supportsSelectors = true)
 @NoWarmup(generateConfigEntry = true)
 @RegisterCommand({"tpa", "teleportask"})
 @RunAsync
@@ -48,7 +49,12 @@ public class TeleportAskCommand extends CommandBase<Player> {
     @Override
     public CommandElement[] getArguments() {
         return new CommandElement[] {
-                GenericArguments.onlyOne(new NicknameArgument(Text.of(playerKey), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER)),
+                GenericArguments.onlyOne(
+                    new SelectorWrapperArgument(
+                        new NicknameArgument(Text.of(playerKey), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER),
+                        permissions,
+                        SelectorWrapperArgument.SINGLE_PLAYER_SELECTORS)
+                ),
                 GenericArguments.flags().permissionFlag(permissions.getPermissionWithSuffix("force"), "f").buildWith(GenericArguments.none())
         };
     }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportAskHereCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportAskHereCommand.java
@@ -6,6 +6,7 @@ package io.github.nucleuspowered.nucleus.modules.teleport.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
+import io.github.nucleuspowered.nucleus.argumentparsers.SelectorWrapperArgument;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
@@ -26,7 +27,7 @@ import java.util.Map;
 
 import static io.github.nucleuspowered.nucleus.modules.teleport.commands.TeleportAskHereCommand.playerKey;
 
-@Permissions(root = "teleport", suggestedLevel = SuggestedLevel.MOD)
+@Permissions(root = "teleport", suggestedLevel = SuggestedLevel.MOD, supportsSelectors = true)
 @RunAsync
 @NoWarmup(generateConfigEntry = true)
 @RegisterCommand({"tpahere", "tpaskhere", "teleportaskhere"})
@@ -47,7 +48,12 @@ public class TeleportAskHereCommand extends CommandBase<Player> {
     @Override
     public CommandElement[] getArguments() {
         return new CommandElement[] {
-            GenericArguments.onlyOne(new NicknameArgument(Text.of(playerKey), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER)),
+            GenericArguments.onlyOne(
+                new SelectorWrapperArgument(
+                    new NicknameArgument(Text.of(playerKey), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER),
+                    permissions,
+                    SelectorWrapperArgument.SINGLE_PLAYER_SELECTORS)
+            ),
             GenericArguments.flags().permissionFlag(permissions.getPermissionWithSuffix("force"), "f").buildWith(GenericArguments.none())
         };
     }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportCommand.java
@@ -63,6 +63,7 @@ public class TeleportCommand extends CommandBase<CommandSource> {
                 // Either we get two arguments, or we get one.
                 GenericArguments.firstParsing(
                         // <player> <player>
+                        // TODO: Hook up with selectors
                         GenericArguments.requiringPermission(new NoCostArgument(new NoWarmupArgument(new TwoPlayersArgument(Text.of(playerFromKey), Text.of(playerKey)))),
                                 permissions.getPermissionWithSuffix("others")),
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportHereCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportHereCommand.java
@@ -6,6 +6,7 @@ package io.github.nucleuspowered.nucleus.modules.teleport.commands;
 
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
+import io.github.nucleuspowered.nucleus.argumentparsers.SelectorWrapperArgument;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
@@ -23,7 +24,7 @@ import org.spongepowered.api.text.Text;
  * for abuse for non-admin players trying to pull players. No cost or warmups
  * will be applied. /tpahere should be used instead in these circumstances.
  */
-@Permissions(root = "teleport", suggestedLevel = SuggestedLevel.ADMIN)
+@Permissions(root = "teleport", suggestedLevel = SuggestedLevel.ADMIN, supportsSelectors = true)
 @NoWarmup
 @NoCooldown
 @NoCost
@@ -38,7 +39,14 @@ public class TeleportHereCommand extends CommandBase<Player> {
 
     @Override
     public CommandElement[] getArguments() {
-        return new CommandElement[] {GenericArguments.onlyOne(new NicknameArgument(Text.of(playerKey), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER))};
+        return new CommandElement[] {
+            GenericArguments.onlyOne(
+                new SelectorWrapperArgument(
+                    new NicknameArgument(Text.of(playerKey), plugin.getUserDataManager(), NicknameArgument.UnderlyingType.PLAYER),
+                    permissions,
+                    SelectorWrapperArgument.SINGLE_PLAYER_SELECTORS)
+                )
+        };
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportPositionCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportPositionCommand.java
@@ -7,6 +7,7 @@ package io.github.nucleuspowered.nucleus.modules.teleport.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.argumentparsers.BoundedIntegerArgument;
+import io.github.nucleuspowered.nucleus.argumentparsers.SelectorWrapperArgument;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
 import io.github.nucleuspowered.nucleus.modules.back.handlers.BackHandler;
@@ -22,7 +23,7 @@ import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.storage.WorldProperties;
 
-@Permissions(root = "teleport")
+@Permissions(root = "teleport", supportsSelectors = true)
 @NoWarmup
 @NoCooldown
 @NoCost
@@ -40,7 +41,7 @@ public class TeleportPositionCommand extends CommandBase<CommandSource> {
     @Override
     public CommandElement[] getArguments() {
         return new CommandElement[] {
-                GenericArguments.onlyOne(GenericArguments.playerOrSource(Text.of(key))),
+                GenericArguments.onlyOne(new SelectorWrapperArgument(GenericArguments.playerOrSource(Text.of(key)), permissions, SelectorWrapperArgument.SINGLE_PLAYER_SELECTORS)),
                 GenericArguments.onlyOne(GenericArguments.optional(GenericArguments.world(Text.of(location)))),
                 GenericArguments.onlyOne(new BoundedIntegerArgument(Text.of(x), Integer.MIN_VALUE, Integer.MAX_VALUE)),
                 GenericArguments.onlyOne(new BoundedIntegerArgument(Text.of(y), 0, 255)),

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -296,6 +296,12 @@ args.info.noinfo=&cThere is no info page with the name "{0}".
 
 args.difficulty.notfound=&cThe difficulty {0} does not exist.
 
+args.selector.nopermissions=&cYou do not have permissions use selectors.
+args.selector.noexist=&cThe selector &e{0} &cis not available for this command.
+args.selector.nolocation=&cYou must have a location on the server to use this selector.
+args.selector.notarget=&cThere were no valid targets chosen by this selector.
+args.selector.noworld=&cThe world &e{0} &cdoes not exist.
+
 commandlog.message={0} ran the command: /{1} {2}
 
 # Commands
@@ -491,9 +497,9 @@ command.god.error=&cCould not set invulnerability status.
 command.hat.success=&aSet hat of &r{0}&a/ to {1}.
 command.hat.error.handempty=&cYou must be holding an item to use this command.
 
-command.lightning.success.normal=&aLightning strike created.
-command.lightning.success.other=&aStruck &r{0}&a with lightning.
-command.lightning.error=&cLightning strike could not be created.
+command.lightning.success.other=&r{0}&a was smited.
+command.lightning.error=&cCould not create lightning strike.
+command.lightning.errorplayer=&cCould not smite &r{0}&c.
 
 command.ignite.success=&aSet player {0} on fire for {1} ticks.
 command.ignite.error=&cAn error occurred while setting player {0} on fire.
@@ -937,6 +943,7 @@ permission.base=Allows the user to run the command /{0}
 permission.exempt.warmup=Allows the user to bypass the warmup for /{0}
 permission.exempt.cooldown=Allows the user to bypass the cooldown for /{0}
 permission.exempt.cost=Allows the user to bypass the cost for /{0}
+permission.selector=Allows the user to use selectors for the command /{0}
 
 permission.afk.exempt.kick=Prevents the user from being kicked for being AFK for too long.
 permission.afk.exempt.toggle=Prevents the user from going AFK.


### PR DESCRIPTION
Selectors require the `nucleus.<command-name>.selector` permission - which will be different for each command.

The following selectors, some of which are Nucleus specific, are available:

* `@p` - nearest player to command executor, not including command executor
* `@p[world,x,y,z]` - nearest player to co-ordinates, including command executor
* `@r` - random player, not including executor
* `@r[world]` - random player on specified world, not including executor
* `@a` - all players
* `@a[world]` - all players on world.

So far, the following commands have selectors. Only `/smite` has access to the `@a` family of selectors:

```
smite
msg
burn
hat
tppos
fly
spawnmob
tpa
tpahere
```

Support for `/tp` will be coming up soon for `@p` only.

Other commands can be added on request.

Fixes #317