### PR TITLE
Add ability to have multiple custom prefixes.

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/message/handlers/MessageHandler.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/message/handlers/MessageHandler.java
@@ -29,6 +29,7 @@ import org.spongepowered.api.text.format.TextColors;
 import org.spongepowered.api.text.serializer.TextSerializers;
 
 import java.util.*;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -108,11 +109,11 @@ public class MessageHandler implements NucleusPrivateMessagingService {
         }
 
         // Create the tokens.
-        Map<String, Function<CommandSource, Text>> tokens = Maps.newHashMap();
-        tokens.put("{{from}}", cs -> chatUtil.addCommandToName(sender));
-        tokens.put("{{to}}", cs -> chatUtil.addCommandToName(receiver));
-        tokens.put("{{fromdisplay}}", cs -> chatUtil.addCommandToDisplayName(sender));
-        tokens.put("{{todisplay}}", cs -> chatUtil.addCommandToDisplayName(receiver));
+        Map<String, BiFunction<CommandSource, String, Text>> tokens = Maps.newHashMap();
+        tokens.put("{{from}}", (cs, g) -> chatUtil.addCommandToName(sender));
+        tokens.put("{{to}}", (cs, g) -> chatUtil.addCommandToName(receiver));
+        tokens.put("{{fromdisplay}}", (cs, g) -> chatUtil.addCommandToDisplayName(sender));
+        tokens.put("{{todisplay}}", (cs, g) -> chatUtil.addCommandToDisplayName(receiver));
 
         MessageChannel mc = MessageChannel.fixed(lm);
         Text tm = useMessage(sender, message);
@@ -153,7 +154,7 @@ public class MessageHandler implements NucleusPrivateMessagingService {
     }
 
     @SuppressWarnings("unchecked")
-    private Text constructMessage(CommandSource sender, Text message, String template, Map<String, Function<CommandSource, Text>> tokens) {
+    private Text constructMessage(CommandSource sender, Text message, String template, Map<String, BiFunction<CommandSource, String, Text>> tokens) {
         return Text.of(chatUtil.getMessageFromTokens(template, sender, false, false, false, tokens), message);
     }
 

--- a/src/test/java/io/github/nucleuspowered/nucleus/tests/ChatUtilTests.java
+++ b/src/test/java/io/github/nucleuspowered/nucleus/tests/ChatUtilTests.java
@@ -24,23 +24,27 @@ import java.util.regex.Pattern;
  */
 public class ChatUtilTests extends TestBase {
 
+    private static Pattern patternToTest;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        TestBase.testSetup();
+
+        Nucleus plugin = Guice.createInjector(new TestModule()).getInstance(Nucleus.class);
+
+        Field parserToTest = ChatUtil.class.getDeclaredField("urlParser");
+        parserToTest.setAccessible(true);
+        patternToTest = (Pattern)parserToTest.get(new ChatUtil(plugin));
+    }
+
     /**
      * Tests that the specified permissions are in the permission list.
      */
     @RunWith(Parameterized.class)
     public static class URLtests {
-
-        private static Pattern patternToTest;
-
         @BeforeClass
         public static void setup() throws Exception {
-            TestBase.testSetup();
-
-            Nucleus plugin = Guice.createInjector(new TestModule()).getInstance(Nucleus.class);
-
-            Field parserToTest = ChatUtil.class.getDeclaredField("urlParser");
-            parserToTest.setAccessible(true);
-            patternToTest = (Pattern)parserToTest.get(new ChatUtil(plugin));
+            ChatUtilTests.setup();
         }
 
         @Parameterized.Parameters(name = "{index}: Message {0}, expecting {1}")
@@ -91,7 +95,5 @@ public class ChatUtilTests extends TestBase {
                 Assert.assertEquals(codes, m.group("colour"));
             }
         }
-
     }
-
 }


### PR DESCRIPTION
Chat formatting now supports new tokens, `{{o:[option]}}` and `{{o:[option]:s}}`. In both cases, this will display the text in the specified permission option, and if `:s` is specified in the token, a space will be inserted afterwards if the option exists.