### PR TITLE
[WIP] Item /buy, /sell, aliases and backend improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,7 @@ before_install:
   - chmod +x gradlew
 install: true
 script: "./gradlew build --refresh-dependencies"
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ ext.url = 'http://nucleuspowered.org'
 group 'io.github.nucleuspowered'
 version '0.9.0-SNAPSHOT'
 
-def qsmlDep = "uk.co.drnaylor:quickstart-moduleloader:0.2.0";
+def qsmlDep = "uk.co.drnaylor:quickstart-moduleloader:0.2.1";
 
 defaultTasks 'licenseFormat'
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/Nucleus.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/Nucleus.java
@@ -18,6 +18,7 @@ import io.github.nucleuspowered.nucleus.config.CommandsConfig;
 import io.github.nucleuspowered.nucleus.config.MessageConfig;
 import io.github.nucleuspowered.nucleus.configurate.ConfigurateHelper;
 import io.github.nucleuspowered.nucleus.dataservices.GeneralService;
+import io.github.nucleuspowered.nucleus.dataservices.ItemDataService;
 import io.github.nucleuspowered.nucleus.dataservices.dataproviders.DataProviders;
 import io.github.nucleuspowered.nucleus.dataservices.loaders.UserDataManager;
 import io.github.nucleuspowered.nucleus.dataservices.loaders.WorldDataManager;
@@ -74,6 +75,7 @@ public class Nucleus {
     private boolean isErrored = false;
     private CommandsConfig commandsConfig;
     private GeneralService generalService;
+    private ItemDataService itemDataService;
     private UserDataManager userDataManager;
     private WorldDataManager worldDataManager;
     private ChatUtil chatUtil;
@@ -120,6 +122,7 @@ public class Nucleus {
             generalService = new GeneralService(d.getGeneralDataProvider());
             userDataManager = new UserDataManager(this, d::getUserFileDataProviders);
             worldDataManager = new WorldDataManager(this, d::getWorldFileDataProvider);
+            itemDataService = new ItemDataService(d.getItemDataProvider());
             warmupManager = new WarmupManager();
             chatUtil = new ChatUtil(this);
         } catch (Exception e) {
@@ -263,6 +266,7 @@ public class Nucleus {
             moduleContainer.reloadSystemConfig();
             reloadMessages();
             commandsConfig.load();
+            itemDataService.load();
 
             for (TextFileController tfc : textFileControllers.values()) {
                 tfc.load();
@@ -313,6 +317,10 @@ public class Nucleus {
 
     public GeneralService getGeneralService() {
         return generalService;
+    }
+
+    public ItemDataService getItemDataService() {
+        return itemDataService;
     }
 
     public CommandsConfig getCommandsConfig() {

--- a/src/main/java/io/github/nucleuspowered/nucleus/Nucleus.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/Nucleus.java
@@ -16,7 +16,7 @@ import io.github.nucleuspowered.nucleus.api.service.NucleusWarmupManagerService;
 import io.github.nucleuspowered.nucleus.api.service.NucleusWorldLoaderService;
 import io.github.nucleuspowered.nucleus.config.CommandsConfig;
 import io.github.nucleuspowered.nucleus.config.MessageConfig;
-import io.github.nucleuspowered.nucleus.configurate.objectmapper.NucleusObjectMapperFactory;
+import io.github.nucleuspowered.nucleus.configurate.ConfigurateHelper;
 import io.github.nucleuspowered.nucleus.dataservices.GeneralService;
 import io.github.nucleuspowered.nucleus.dataservices.dataproviders.DataProviders;
 import io.github.nucleuspowered.nucleus.dataservices.loaders.UserDataManager;
@@ -40,7 +40,6 @@ import io.github.nucleuspowered.nucleus.internal.services.WarmupManager;
 import io.github.nucleuspowered.nucleus.modules.core.config.CoreConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.core.events.NucleusReloadConfigEvent;
 import io.github.nucleuspowered.nucleus.util.ThrowableAction;
-import ninja.leaping.configurate.ConfigurationOptions;
 import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
 import org.slf4j.Logger;
 import org.spongepowered.api.Game;
@@ -136,10 +135,11 @@ public class Nucleus {
         serviceManager.registerService(WarmupManager.class, warmupManager);
 
         try {
+            HoconConfigurationLoader.Builder builder = HoconConfigurationLoader.builder();
             moduleContainer = DiscoveryModuleContainer.builder()
                     .setConstructor(new QuickStartModuleConstructor(injector))
-                    .setConfigurationLoader(HoconConfigurationLoader.builder()
-                            .setDefaultOptions(ConfigurationOptions.defaults().setObjectMapperFactory(NucleusObjectMapperFactory.getInstance()))
+                    .setConfigurationLoader(
+                        builder.setDefaultOptions(ConfigurateHelper.setOptions(logger, builder.getDefaultOptions()))
                             .setPath(Paths.get(configDir.toString(), "main.conf"))
                             .build())
                     .setPackageToScan(getClass().getPackage().getName() + ".modules")

--- a/src/main/java/io/github/nucleuspowered/nucleus/Util.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/Util.java
@@ -13,9 +13,12 @@ import io.github.nucleuspowered.nucleus.internal.messages.MessageProvider;
 import io.github.nucleuspowered.nucleus.internal.qsml.module.StandardModule;
 import io.github.nucleuspowered.nucleus.util.Action;
 import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.service.permission.Subject;
 import org.spongepowered.api.service.permission.option.OptionSubject;
 import org.spongepowered.api.text.Text;
@@ -229,6 +232,30 @@ public class Util {
         }
 
         return Optional.empty();
+    }
+
+    public static Optional<CatalogType> getCatalogTypeForItemFromId(String id) {
+        // Check for ItemType.
+        Optional<ItemType> oit = Sponge.getRegistry().getAllOf(ItemType.class).stream().filter(x -> x.getId().equalsIgnoreCase(id)).findFirst();
+        if (oit.isPresent()) {
+            return Optional.of(oit.get());
+        }
+
+        // BlockState, you're up next!
+        Optional<BlockState> obs = Sponge.getRegistry().getAllOf(BlockState.class).stream().filter(x -> x.getId().equalsIgnoreCase(id)).findFirst();
+        if (obs.isPresent()) {
+            return Optional.of(obs.get());
+        }
+
+        return Optional.empty();
+    }
+
+    public static <T extends CatalogType> String getTranslatableIfPresentOnCatalogType(T ct) {
+        if (ct instanceof Translatable) {
+            return getTranslatableIfPresent((Translatable & CatalogType)ct);
+        }
+
+        return ct.getName();
     }
 
     /**

--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/ImprovedCatalogTypeArgument.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/ImprovedCatalogTypeArgument.java
@@ -4,9 +4,11 @@
  */
 package io.github.nucleuspowered.nucleus.argumentparsers;
 
+import com.google.common.collect.Lists;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.*;
+import org.spongepowered.api.command.args.parsing.SingleArg;
 import org.spongepowered.api.text.Text;
 
 import javax.annotation.Nonnull;
@@ -33,14 +35,14 @@ public class ImprovedCatalogTypeArgument extends CommandElement {
         String arg = args.peek();
         if (!arg.contains(":")) {
             args.next();
-            Object state = args.getState();
-
-            // May need to question this.
-            args.removeArgs(state, state);
-            args.insertArg("minecraft:" + arg);
+            String newArg = "minecraft:" + arg;
+            String raw = args.getRaw().replace(arg, newArg);
+            int startindex = raw.indexOf(newArg);
+            CommandArgs newArgs = new CommandArgs(raw, Lists.newArrayList(new SingleArg(newArg, startindex, startindex + newArg.length() - 1)));
+            wrapped.parse(source, newArgs, context);
+        } else {
+            wrapped.parse(source, args, context);
         }
-
-        wrapped.parse(source, args, context);
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/ItemAliasArgument.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/ItemAliasArgument.java
@@ -1,0 +1,109 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.argumentparsers;
+
+import com.google.common.base.Preconditions;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.dataservices.ItemDataService;
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.ArgumentParseException;
+import org.spongepowered.api.command.args.CommandArgs;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.text.Text;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Note that the ItemAlias argument may return either a {@link BlockState} or an {@link ItemType}, depending on what
+ * is returned. As they are both {@link org.spongepowered.api.CatalogType}s, this is the simplest way to retrieve the
+ * information.
+ */
+public class ItemAliasArgument extends CommandElement {
+
+    private final ImprovedCatalogTypeArgument itemType;
+    private final ImprovedCatalogTypeArgument blockStateType;
+    private final ItemDataService itemDataService;
+
+    public ItemAliasArgument(@Nullable Text key, ItemDataService itemDataService) {
+        super(key);
+        Preconditions.checkNotNull(key);
+        this.itemType = new ImprovedCatalogTypeArgument(key, ItemType.class);
+        this.blockStateType = new ImprovedCatalogTypeArgument(key, BlockState.class);
+        this.itemDataService = itemDataService;
+    }
+
+    @Nullable
+    @Override
+    protected Object parseValue(@Nonnull CommandSource source, @Nonnull CommandArgs args) throws ArgumentParseException {
+        // The error is ignored anyway, so might as well stick with the empty text.
+        String arg = args.next().toLowerCase();
+        Optional<CatalogType> result = parseAlias(arg, args);
+        if (result.isPresent()) {
+            return result.get();
+        }
+
+        // OK, if it doesn't contain a colon, add the prefix now
+        final String modifiedArg;
+        if (!arg.contains(":")) {
+            modifiedArg = "minecraft:" + arg;
+        } else {
+            modifiedArg = arg;
+        }
+
+        // Check for ItemType.
+        Optional<ItemType> oit = Sponge.getRegistry().getAllOf(ItemType.class).stream().filter(x -> x.getId().equalsIgnoreCase(modifiedArg)).findFirst();
+        if (oit.isPresent()) {
+            return oit.get();
+        }
+
+        // BlockState, you're up next!
+        Optional<BlockState> obs = Sponge.getRegistry().getAllOf(BlockState.class).stream().filter(x -> x.getId().equalsIgnoreCase(modifiedArg)).findFirst();
+        if (obs.isPresent()) {
+            return obs.get();
+        }
+
+        throw args.createError(Util.getTextMessageWithFormat("args.itemarg.nomatch", arg));
+    }
+
+    private Optional<CatalogType> parseAlias(String arg, @Nonnull CommandArgs args) throws ArgumentParseException {
+        Optional<String> oid = itemDataService.getIdFromAlias(arg);
+        if (!oid.isPresent()) {
+            return Optional.empty();
+        }
+
+        String id = oid.get();
+
+        // Is it an Item?
+        Optional<ItemType> obs = Sponge.getRegistry().getAllOf(ItemType.class).stream().filter(x -> x.getId().equalsIgnoreCase(id)).findFirst();
+        if (obs.isPresent()) {
+            return Optional.of(obs.get());
+        }
+
+        // Well, hopefully it's a blockstate then.
+        return Optional.of(Sponge.getRegistry().getAllOf(BlockState.class).stream().filter(x -> x.getId().equalsIgnoreCase(id)).findFirst()
+                .orElseThrow(() -> args.createError(Util.getTextMessageWithFormat("args.itemarg.orphanedarg", arg, id))));
+    }
+
+    @Override
+    @Nonnull
+    public List<String> complete(@Nonnull CommandSource src, @Nonnull CommandArgs args, @Nonnull CommandContext context) {
+        try {
+            String arg = args.peek().toLowerCase();
+            return itemDataService.getAliases().stream().filter(x -> x.startsWith(arg)).sorted().collect(Collectors.toList());
+        } catch (ArgumentParseException e) {
+            return new ArrayList<>(itemDataService.getAliases());
+        }
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/SimpleProviderChoicesArgument.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/SimpleProviderChoicesArgument.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.argumentparsers;
+
+import com.google.common.base.Preconditions;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.*;
+import org.spongepowered.api.text.Text;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public final class SimpleProviderChoicesArgument extends CommandElement {
+
+    private final Supplier<Map<String, ?>> choiceSupplier;
+
+    public static SimpleProviderChoicesArgument withSetSupplier(Text key, Supplier<Set<String>> choices) {
+        Preconditions.checkNotNull(key);
+        Preconditions.checkNotNull(choices);
+        return new SimpleProviderChoicesArgument(key, () -> choices.get().stream().collect(Collectors.toMap(k -> k, k -> k)));
+    }
+
+    public static SimpleProviderChoicesArgument withMapSupplier(Text key, Supplier<Map<String, ?>> choices) {
+        Preconditions.checkNotNull(key);
+        Preconditions.checkNotNull(choices);
+        return new SimpleProviderChoicesArgument(key, choices);
+    }
+
+    private SimpleProviderChoicesArgument(@Nullable Text key, Supplier<Map<String, ?>> choices) {
+        super(key);
+        choiceSupplier = choices;
+    }
+
+    @Nullable
+    @Override
+    protected Object parseValue(CommandSource source, CommandArgs args) throws ArgumentParseException {
+        return null;
+    }
+
+    @Override
+    public void parse(CommandSource source, CommandArgs args, CommandContext context) throws ArgumentParseException {
+        GenericArguments.choices(getKey(), choiceSupplier.get()).parse(source, args, context);
+    }
+
+    @Override
+    public List<String> complete(CommandSource src, CommandArgs args, CommandContext context) {
+        return new ArrayList<>(choiceSupplier.get().keySet());
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/ConfigurateHelper.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/ConfigurateHelper.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.configurate;
+
+import com.flowpowered.math.vector.Vector3d;
+import com.google.common.reflect.TypeToken;
+import io.github.nucleuspowered.nucleus.configurate.objectmapper.NucleusObjectMapperFactory;
+import io.github.nucleuspowered.nucleus.configurate.typeserialisers.ItemStackSnapshotSerialiser;
+import io.github.nucleuspowered.nucleus.configurate.typeserialisers.SetTypeSerialiser;
+import io.github.nucleuspowered.nucleus.configurate.typeserialisers.Vector3dTypeSerialiser;
+import ninja.leaping.configurate.ConfigurationOptions;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializerCollection;
+import org.slf4j.Logger;
+import org.spongepowered.api.item.inventory.ItemStackSnapshot;
+
+import java.util.Set;
+
+public class ConfigurateHelper {
+
+    private ConfigurateHelper() {}
+
+    /**
+     * Set Nucleus specific options on the {@link ConfigurationOptions}
+     *
+     * @param logger The Nucleus {@link Logger}
+     * @param options The {@link ConfigurationOptions} to alter.
+     * @return The {@link ConfigurationOptions}, for easier inline use of this function.
+     */
+    public static ConfigurationOptions setOptions(Logger logger, ConfigurationOptions options) {
+        TypeSerializerCollection tsc = options.getSerializers();
+
+        // Custom type serialisers for Nucleus
+        tsc.registerType(TypeToken.of(Vector3d.class), new Vector3dTypeSerialiser());
+        tsc.registerType(TypeToken.of(ItemStackSnapshot.class), new ItemStackSnapshotSerialiser(logger));
+        tsc.registerPredicate(
+                typeToken -> Set.class.isAssignableFrom(typeToken.getRawType()),
+                new SetTypeSerialiser()
+        );
+
+        // Allows us to use localised comments and @ProcessSetting annotations
+        return options.setSerializers(tsc).setObjectMapperFactory(NucleusObjectMapperFactory.getInstance());
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/annotations/ProcessSetting.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/annotations/ProcessSetting.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.configurate.annotations;
+
+import io.github.nucleuspowered.nucleus.configurate.settingprocessor.SettingProcessor;
+
+import java.lang.annotation.*;
+
+/**
+ * Indicates that, when this annotation is present alongside a {@link ninja.leaping.configurate.objectmapping.Setting}
+ * annotation, some transformation of the node should occur at the following moments:
+ *
+ * <ul>
+ *     <li>before the value of the field is set from the {@link ninja.leaping.configurate.ConfigurationNode}</li>
+ *     <li>after the value of the field is read from the {@link ninja.leaping.configurate.ConfigurationNode}, but just
+ *     before it is written to the file</li>
+ * </ul>
+ *
+ * <p>
+ *     {@link SettingProcessor}s are used to take the {@link ninja.leaping.configurate.ConfigurationNode}s and alter
+ *     them directly before the final value for the task is read.
+ * </p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+@Documented
+public @interface ProcessSetting {
+
+    /**
+     * The {@link Class}es that represent the {@link SettingProcessor}s to run on the
+     * {@link ninja.leaping.configurate.ConfigurationNode} that populates this field. The processors are executed in
+     * the order provided here. They must all have parameterless constructors.
+     *
+     * @return The {@link Class}es of the {@link SettingProcessor}s to use.
+     */
+    Class<? extends SettingProcessor>[] value();
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/datatypes/ItemDataNode.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/datatypes/ItemDataNode.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.configurate.datatypes;
+
+import com.google.common.collect.ImmutableList;
+import io.github.nucleuspowered.nucleus.configurate.annotations.ProcessSetting;
+import io.github.nucleuspowered.nucleus.configurate.settingprocessor.LowercaseSetStringSettingProcessor;
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@ConfigSerializable
+public class ItemDataNode {
+
+    public ItemDataNode() {}
+
+    public ItemDataNode(Set<String> aliases, int buy, int sell) {
+        this.aliases = aliases;
+        this.price = new PriceNode(buy, sell);
+    }
+
+    public ItemDataNode(ItemDataNode copy) {
+        this(copy.aliases, copy.price.getBuy(), copy.price.getSell());
+    }
+
+    @Setting
+    @ProcessSetting(LowercaseSetStringSettingProcessor.class)
+    private Set<String> aliases = new HashSet<>();
+
+    @Setting
+    private PriceNode price = new PriceNode();
+
+    public List<String> getAliases() {
+        return ImmutableList.copyOf(aliases);
+    }
+
+    public void addAlias(String alias) {
+        String lowerCase = alias.toLowerCase();
+        if (aliases.contains(lowerCase)) {
+            aliases.add(lowerCase);
+        }
+    }
+
+    public void removeAlias(String alias) {
+        alias = alias.toLowerCase();
+        aliases.remove(alias);
+    }
+
+    public int getServerBuyPrice() {
+        return price.getBuy();
+    }
+
+    public void setServerBuyPrice(int serverBuyPrice) {
+        price.setBuy(serverBuyPrice);
+    }
+
+    public int getServerSellPrice() {
+        return price.getSell();
+    }
+
+    public void setServerSellPrice(int serverSellPrice) {
+        price.setSell(serverSellPrice);
+    }
+
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/datatypes/ItemDataNode.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/datatypes/ItemDataNode.java
@@ -25,11 +25,11 @@ public class ItemDataNode {
 
     public ItemDataNode(Set<String> aliases, int buy, int sell) {
         this.aliases = aliases;
-        this.price = new PriceNode(buy, sell);
+        this.shop = new PriceNode(buy, sell);
     }
 
     public ItemDataNode(ItemDataNode copy) {
-        this(copy.aliases, copy.price.getBuy(), copy.price.getSell());
+        this(copy.aliases, copy.shop.getBuy(), copy.shop.getSell());
     }
 
     @Setting(comment = "loc:config.itemdatanode.aliases")
@@ -37,7 +37,7 @@ public class ItemDataNode {
     private Set<String> aliases = new HashSet<>();
 
     @Setting
-    private PriceNode price = new PriceNode();
+    private PriceNode shop = new PriceNode();
 
     public List<String> getAliases() {
         return ImmutableList.copyOf(aliases);
@@ -62,19 +62,19 @@ public class ItemDataNode {
     }
 
     public int getServerBuyPrice() {
-        return price.getBuy();
+        return shop.getBuy();
     }
 
     public void setServerBuyPrice(int serverBuyPrice) {
-        price.setBuy(serverBuyPrice);
+        shop.setBuy(serverBuyPrice);
     }
 
     public int getServerSellPrice() {
-        return price.getSell();
+        return shop.getSell();
     }
 
     public void setServerSellPrice(int serverSellPrice) {
-        price.setSell(serverSellPrice);
+        shop.setSell(serverSellPrice);
     }
 
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/datatypes/ItemDataNode.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/datatypes/ItemDataNode.java
@@ -4,18 +4,22 @@
  */
 package io.github.nucleuspowered.nucleus.configurate.datatypes;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import io.github.nucleuspowered.nucleus.configurate.annotations.ProcessSetting;
-import io.github.nucleuspowered.nucleus.configurate.settingprocessor.LowercaseSetStringSettingProcessor;
+import io.github.nucleuspowered.nucleus.configurate.settingprocessor.ItemAliasSettingProcessor;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 @ConfigSerializable
 public class ItemDataNode {
+
+    public final static Pattern ALIAS_PATTERN = Pattern.compile("^[a-z0-9_-]+$");
 
     public ItemDataNode() {}
 
@@ -28,8 +32,8 @@ public class ItemDataNode {
         this(copy.aliases, copy.price.getBuy(), copy.price.getSell());
     }
 
-    @Setting
-    @ProcessSetting(LowercaseSetStringSettingProcessor.class)
+    @Setting(comment = "loc:config.itemdatanode.aliases")
+    @ProcessSetting(ItemAliasSettingProcessor.class)
     private Set<String> aliases = new HashSet<>();
 
     @Setting
@@ -41,7 +45,9 @@ public class ItemDataNode {
 
     public void addAlias(String alias) {
         String lowerCase = alias.toLowerCase();
-        if (aliases.contains(lowerCase)) {
+        Preconditions.checkArgument(ALIAS_PATTERN.matcher(lowerCase).matches());
+
+        if (!aliases.contains(lowerCase)) {
             aliases.add(lowerCase);
         }
     }
@@ -49,6 +55,10 @@ public class ItemDataNode {
     public void removeAlias(String alias) {
         alias = alias.toLowerCase();
         aliases.remove(alias);
+    }
+
+    public void clearAliases() {
+        aliases.clear();
     }
 
     public int getServerBuyPrice() {

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/datatypes/PriceNode.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/datatypes/PriceNode.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.configurate.datatypes;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+@ConfigSerializable
+public class PriceNode {
+
+    public PriceNode() {
+        this(-1, -1);
+    }
+
+    public PriceNode(int buy, int sell) {
+        this.buy = buy;
+        this.sell = sell;
+    }
+
+    @Setting
+    private int buy = -1;
+
+    @Setting
+    private int sell = -1;
+
+    public int getBuy() {
+        return buy;
+    }
+
+    public void setBuy(int buy) {
+        this.buy = buy;
+    }
+
+    public int getSell() {
+        return sell;
+    }
+
+    public void setSell(int sell) {
+        this.sell = sell;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/objectmapper/NucleusObjectMapper.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/objectmapper/NucleusObjectMapper.java
@@ -5,11 +5,16 @@
 package io.github.nucleuspowered.nucleus.configurate.objectmapper;
 
 import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.configurate.annotations.ProcessSetting;
+import io.github.nucleuspowered.nucleus.configurate.settingprocessor.SettingProcessor;
+import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.objectmapping.ObjectMapper;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import ninja.leaping.configurate.objectmapping.Setting;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class NucleusObjectMapper<T> extends ObjectMapper<T> {
@@ -37,11 +42,56 @@ public class NucleusObjectMapper<T> extends ObjectMapper<T> {
                     comment = Util.getMessageWithFormat(setting.comment().split(":", 2)[1]);
                 }
 
-                FieldData data = new FieldData(field, comment);
+                FieldData data;
+                if (field.isAnnotationPresent(ProcessSetting.class)) {
+                    try {
+                        data = new PreprocessedFieldData(field, comment);
+                    } catch (IllegalArgumentException e) {
+                        data = new FieldData(field, comment);
+                    }
+                } else {
+                    data = new FieldData(field, comment);
+                }
+
                 field.setAccessible(true);
                 if (!cachedFields.containsKey(path)) {
                     cachedFields.put(path, data);
                 }
+            }
+        }
+    }
+
+    private static class PreprocessedFieldData extends FieldData {
+
+        private final List<SettingProcessor> processors = new ArrayList<>();
+
+        private PreprocessedFieldData(Field field, String comment) throws ObjectMappingException, IllegalArgumentException {
+            super(field, comment);
+            try {
+                for (Class<? extends SettingProcessor> pro : field.getAnnotation(ProcessSetting.class).value()) {
+                    processors.add(pro.newInstance());
+                }
+            } catch (InstantiationException | IllegalAccessException e) {
+                e.printStackTrace();
+                throw new IllegalArgumentException("No setting processor", e);
+            }
+        }
+
+        @Override
+        public void deserializeFrom(Object instance, ConfigurationNode node) throws ObjectMappingException {
+            for (SettingProcessor processor : processors) {
+                processor.onGet(node);
+            }
+
+            super.deserializeFrom(instance, node);
+        }
+
+        @Override
+        public void serializeTo(Object instance, ConfigurationNode node) throws ObjectMappingException {
+            super.serializeTo(instance, node);
+
+            for (SettingProcessor processor : processors) {
+                processor.onSet(node);
             }
         }
     }

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/settingprocessor/ItemAliasSettingProcessor.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/settingprocessor/ItemAliasSettingProcessor.java
@@ -5,6 +5,7 @@
 package io.github.nucleuspowered.nucleus.configurate.settingprocessor;
 
 import com.google.common.reflect.TypeToken;
+import io.github.nucleuspowered.nucleus.configurate.datatypes.ItemDataNode;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 
@@ -12,9 +13,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * A {@link SettingProcessor} that will make all entries in a list lowercase.
+ * A {@link SettingProcessor} that will make all entries in the item alias list lowercase, and discard invalid
+ * entries (replacing spaces with underscores)
  */
-public class LowercaseSetStringSettingProcessor implements SettingProcessor {
+public class ItemAliasSettingProcessor implements SettingProcessor {
 
     private final TypeToken<Set<String>> ttListString = new TypeToken<Set<String>>(String.class) {};
     private final TypeToken<String> ttString = TypeToken.of(String.class);
@@ -25,6 +27,7 @@ public class LowercaseSetStringSettingProcessor implements SettingProcessor {
             return;
         }
 
-        cn.setValue(ttListString, cn.getList(ttString).stream().map(String::toLowerCase).collect(Collectors.toSet()));
+        cn.setValue(ttListString, cn.getList(ttString).stream().map(x -> x.toLowerCase().replace(" ", "_"))
+                .filter(x -> ItemDataNode.ALIAS_PATTERN.matcher(x).matches()).collect(Collectors.toSet()));
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/settingprocessor/LowercaseListStringSettingProcessor.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/settingprocessor/LowercaseListStringSettingProcessor.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.configurate.settingprocessor;
+
+import com.google.common.reflect.TypeToken;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link SettingProcessor} that will make all entries in a list lowercase.
+ */
+public class LowercaseListStringSettingProcessor implements SettingProcessor {
+
+    private final TypeToken<List<String>> ttListString = new TypeToken<List<String>>(String.class) {};
+    private final TypeToken<String> ttString = TypeToken.of(String.class);
+
+    @Override
+    public void process(ConfigurationNode cn) throws ObjectMappingException {
+        if (cn.isVirtual()) {
+            return;
+        }
+
+        cn.setValue(ttListString, cn.getList(ttString).stream().map(String::toLowerCase).collect(Collectors.toList()));
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/settingprocessor/LowercaseSetStringSettingProcessor.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/settingprocessor/LowercaseSetStringSettingProcessor.java
@@ -8,15 +8,15 @@ import com.google.common.reflect.TypeToken;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 
-import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
  * A {@link SettingProcessor} that will make all entries in a list lowercase.
  */
-public class LowercaseListStringSettingProcessor implements SettingProcessor {
+public class LowercaseSetStringSettingProcessor implements SettingProcessor {
 
-    private final TypeToken<List<String>> ttListString = new TypeToken<List<String>>(String.class) {};
+    private final TypeToken<Set<String>> ttListString = new TypeToken<Set<String>>(String.class) {};
     private final TypeToken<String> ttString = TypeToken.of(String.class);
 
     @Override
@@ -25,6 +25,6 @@ public class LowercaseListStringSettingProcessor implements SettingProcessor {
             return;
         }
 
-        cn.setValue(ttListString, cn.getList(ttString).stream().map(String::toLowerCase).collect(Collectors.toList()));
+        cn.setValue(ttListString, cn.getList(ttString).stream().map(String::toLowerCase).collect(Collectors.toSet()));
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/settingprocessor/SettingProcessor.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/settingprocessor/SettingProcessor.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.configurate.settingprocessor;
+
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+
+/**
+ * Setting Processors, when used in conjunction on a {@link ninja.leaping.configurate.objectmapping.Setting} annotated
+ * field within a {@link ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable} class, allow for some
+ * lightweight processing of getting and setting the node value.
+ *
+ * <p>
+ *     Implementors must ensure that there is a parameterless constructor.
+ * </p>
+ *
+ * <p>
+ *     While this is a {@link FunctionalInterface} for simpler matters, the two default methods can be overridden if
+ *     required.
+ * </p>
+ */
+@FunctionalInterface
+public interface SettingProcessor {
+
+    /**
+     * Transforms the node before it's set on the {@link ninja.leaping.configurate.objectmapping.Setting}.
+     *
+     * @param input The input {@link ConfigurationNode}
+     * @throws ObjectMappingException thrown if the node cannot be loaded.
+     */
+    default void onGet(ConfigurationNode input) throws ObjectMappingException {
+        process(input);
+    }
+
+    /**
+     * Transforms the node before it's set in the configuration file.
+     *
+     * @param output The output {@link ConfigurationNode}
+     * @throws ObjectMappingException thrown if the node cannot be loaded.
+     */
+    default void onSet(ConfigurationNode output) throws ObjectMappingException {
+        process(output);
+    }
+
+    /**
+     * By default, processes the configuration node and transforms it into the requested form.
+     *
+     * @param cn The {@link ConfigurationNode}
+     * @throws ObjectMappingException thrown if the node cannot be transformed.
+     */
+    void process(ConfigurationNode cn) throws ObjectMappingException;
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/typeserialisers/SetTypeSerialiser.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/typeserialisers/SetTypeSerialiser.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.configurate.typeserialisers;
+
+import com.google.common.reflect.TypeParameter;
+import com.google.common.reflect.TypeToken;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class SetTypeSerialiser implements TypeSerializer<Set<?>> {
+
+    @Override
+    public Set<?> deserialize(TypeToken<?> type, ConfigurationNode value) throws ObjectMappingException {
+        return new HashSet<>(value.getList(getInnerToken(type)));
+    }
+
+    @Override
+    public void serialize(TypeToken<?> type, Set<?> obj, ConfigurationNode value) throws ObjectMappingException {
+        value.setValue(getListTokenFromSet(type), new ArrayList<>(obj));
+    }
+
+    private TypeToken<?> getInnerToken(TypeToken<?> type) {
+        return type.resolveType(Set.class.getTypeParameters()[0]);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <E> TypeToken<List<E>> getListTokenFromSet(TypeToken<?> type) {
+        // Get the inner type out of the type token
+        TypeToken<?> innerType = getInnerToken(type);
+
+        // Put it into the new list token
+        return new TypeToken<List<E>>() {}.where(new TypeParameter<E>() {}, (TypeToken<E>)innerType);
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/dataservices/ItemDataService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/dataservices/ItemDataService.java
@@ -7,18 +7,36 @@ package io.github.nucleuspowered.nucleus.dataservices;
 import com.google.common.base.Preconditions;
 import io.github.nucleuspowered.nucleus.configurate.datatypes.ItemDataNode;
 import io.github.nucleuspowered.nucleus.dataservices.dataproviders.DataProvider;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
+import org.spongepowered.api.util.Tuple;
 
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class ItemDataService extends Service<Map<String, ItemDataNode>> {
+
+    private Map<String, String> aliasToItemIdCache = null;
 
     public ItemDataService(DataProvider<Map<String, ItemDataNode>> dataProvider) throws Exception {
         super(dataProvider);
     }
 
+    @Override
+    public boolean load() {
+        aliasToItemIdCache = null;
+        return super.load();
+    }
+
+    public Set<String> getAliases() {
+        return getCache().keySet();
+    }
+
     public ItemDataNode getDataForItem(ItemStackSnapshot itemStackSnapshot) {
-        return getDataForItem(itemStackSnapshot.getType().getId());
+        return getDataForItem(getIdFromSnapshot(itemStackSnapshot));
     }
 
     public ItemDataNode getDataForItem(String id) {
@@ -27,23 +45,48 @@ public class ItemDataService extends Service<Map<String, ItemDataNode>> {
     }
 
     public void setDataForItem(ItemStackSnapshot itemStackSnapshot, ItemDataNode node) {
-        setDataForItem(itemStackSnapshot.getType().getId(), node);
+        setDataForItem(getIdFromSnapshot(itemStackSnapshot), node);
     }
 
     public void setDataForItem(String id, ItemDataNode node) {
         Preconditions.checkNotNull(id);
         Preconditions.checkNotNull(node);
         data.put(id, node);
+        aliasToItemIdCache = null;
         save();
     }
 
     public void resetDataForItem(ItemStackSnapshot itemStackSnapshot) {
-        resetDataForItem(itemStackSnapshot.getType().getId());
+        resetDataForItem(getIdFromSnapshot(itemStackSnapshot));
     }
 
     public void resetDataForItem(String id) {
         Preconditions.checkNotNull(id);
         data.remove(id);
+        aliasToItemIdCache = null;
         save();
+    }
+
+    public Optional<String> getIdFromAlias(String alias) {
+        return Optional.ofNullable(getCache().get(alias));
+    }
+
+    private Map<String, String> getCache() {
+        if (aliasToItemIdCache == null) {
+            aliasToItemIdCache = data.entrySet().stream()
+                    .flatMap(k -> k.getValue().getAliases().stream().map(i -> Tuple.of(i, k.getKey())))
+                    .collect(Collectors.toMap(Tuple::getFirst, Tuple::getSecond));
+        }
+
+        return aliasToItemIdCache;
+    }
+
+    private String getIdFromSnapshot(ItemStackSnapshot stackSnapshot) {
+        Optional<BlockState> blockState = stackSnapshot.get(Keys.ITEM_BLOCKSTATE);
+        if (blockState.isPresent()) {
+            return blockState.get().getId().toLowerCase();
+        }
+
+        return stackSnapshot.getType().getId();
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/dataservices/ItemDataService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/dataservices/ItemDataService.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.dataservices;
+
+import com.google.common.base.Preconditions;
+import io.github.nucleuspowered.nucleus.configurate.datatypes.ItemDataNode;
+import io.github.nucleuspowered.nucleus.dataservices.dataproviders.DataProvider;
+import org.spongepowered.api.item.inventory.ItemStackSnapshot;
+
+import java.util.Map;
+
+public class ItemDataService extends Service<Map<String, ItemDataNode>> {
+
+    public ItemDataService(DataProvider<Map<String, ItemDataNode>> dataProvider) throws Exception {
+        super(dataProvider);
+    }
+
+    public ItemDataNode getDataForItem(ItemStackSnapshot itemStackSnapshot) {
+        return getDataForItem(itemStackSnapshot.getType().getId());
+    }
+
+    public ItemDataNode getDataForItem(String id) {
+        Preconditions.checkNotNull(id);
+        return data.getOrDefault(id.toLowerCase(), new ItemDataNode());
+    }
+
+    public void setDataForItem(ItemStackSnapshot itemStackSnapshot, ItemDataNode node) {
+        setDataForItem(itemStackSnapshot.getType().getId(), node);
+    }
+
+    public void setDataForItem(String id, ItemDataNode node) {
+        Preconditions.checkNotNull(id);
+        Preconditions.checkNotNull(node);
+        data.put(id, node);
+        save();
+    }
+
+    public void resetDataForItem(ItemStackSnapshot itemStackSnapshot) {
+        resetDataForItem(itemStackSnapshot.getType().getId());
+    }
+
+    public void resetDataForItem(String id) {
+        Preconditions.checkNotNull(id);
+        data.remove(id);
+        save();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/dataservices/dataproviders/DataProviders.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/dataservices/dataproviders/DataProviders.java
@@ -4,18 +4,13 @@
  */
 package io.github.nucleuspowered.nucleus.dataservices.dataproviders;
 
-import com.flowpowered.math.vector.Vector3d;
 import com.google.common.reflect.TypeToken;
 import io.github.nucleuspowered.nucleus.Nucleus;
+import io.github.nucleuspowered.nucleus.configurate.ConfigurateHelper;
 import io.github.nucleuspowered.nucleus.configurate.datatypes.GeneralDataNode;
 import io.github.nucleuspowered.nucleus.configurate.datatypes.UserDataNode;
 import io.github.nucleuspowered.nucleus.configurate.datatypes.WorldDataNode;
-import io.github.nucleuspowered.nucleus.configurate.typeserialisers.ItemStackSnapshotSerialiser;
-import io.github.nucleuspowered.nucleus.configurate.typeserialisers.Vector3dTypeSerialiser;
-import ninja.leaping.configurate.ConfigurationOptions;
 import ninja.leaping.configurate.gson.GsonConfigurationLoader;
-import ninja.leaping.configurate.objectmapping.serialize.TypeSerializerCollection;
-import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -79,9 +74,6 @@ public class DataProviders {
 
     private GsonConfigurationLoader.Builder getBuilder() {
         GsonConfigurationLoader.Builder gsb = GsonConfigurationLoader.builder();
-        ConfigurationOptions configurationOptions = gsb.getDefaultOptions();
-        TypeSerializerCollection tsc = configurationOptions.getSerializers().registerType(TypeToken.of(Vector3d.class), new Vector3dTypeSerialiser());
-        tsc.registerType(TypeToken.of(ItemStackSnapshot.class), new ItemStackSnapshotSerialiser(plugin.getLogger()));
-        return gsb.setDefaultOptions(configurationOptions.setSerializers(tsc));
+        return gsb.setDefaultOptions(ConfigurateHelper.setOptions(plugin.getLogger(), gsb.getDefaultOptions()));
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/dataservices/dataproviders/DataProviders.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/dataservices/dataproviders/DataProviders.java
@@ -17,6 +17,7 @@ import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
@@ -66,7 +67,7 @@ public class DataProviders {
         // For now, just the Configurate one.
         try {
             Path p = plugin.getConfigDirPath().resolve("items.conf");
-            return new ConfigurateDataProvider<>(ttmsi, getHoconBuilder().setPath(p).build(), p);
+            return new ConfigurateDataProvider<>(ttmsi, getHoconBuilder().setPath(p).build(), HashMap::new, p);
         } catch (Exception e) {
             return null;
         }

--- a/src/main/java/io/github/nucleuspowered/nucleus/dataservices/dataproviders/DataProviders.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/dataservices/dataproviders/DataProviders.java
@@ -8,13 +8,16 @@ import com.google.common.reflect.TypeToken;
 import io.github.nucleuspowered.nucleus.Nucleus;
 import io.github.nucleuspowered.nucleus.configurate.ConfigurateHelper;
 import io.github.nucleuspowered.nucleus.configurate.datatypes.GeneralDataNode;
+import io.github.nucleuspowered.nucleus.configurate.datatypes.ItemDataNode;
 import io.github.nucleuspowered.nucleus.configurate.datatypes.UserDataNode;
 import io.github.nucleuspowered.nucleus.configurate.datatypes.WorldDataNode;
 import ninja.leaping.configurate.gson.GsonConfigurationLoader;
+import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
 
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.UUID;
 
 public class DataProviders {
@@ -23,6 +26,7 @@ public class DataProviders {
     private final TypeToken<UserDataNode> ttu = TypeToken.of(UserDataNode.class);
     private final TypeToken<WorldDataNode> ttw = TypeToken.of(WorldDataNode.class);
     private final TypeToken<GeneralDataNode> ttg = TypeToken.of(GeneralDataNode.class);
+    private final TypeToken<Map<String, ItemDataNode>> ttmsi = new TypeToken<Map<String, ItemDataNode>>() {};
 
     public DataProviders(Nucleus plugin) {
         this.plugin = plugin;
@@ -32,7 +36,7 @@ public class DataProviders {
         // For now, just the Configurate one.
         try {
             Path p = getFile("userdata%1$s%2$s%1$s%3$s.json", uuid);
-            return new ConfigurateDataProvider<>(ttu, getBuilder().setPath(p).build(), p);
+            return new ConfigurateDataProvider<>(ttu, getGsonBuilder().setPath(p).build(), p);
         } catch (Exception e) {
             return null;
         }
@@ -42,7 +46,7 @@ public class DataProviders {
         // For now, just the Configurate one.
         try {
             Path p = getFile("worlddata%1$s%2$s%1$s%3$s.json", uuid);
-            return new ConfigurateDataProvider<>(ttw, getBuilder().setPath(p).build(), p);
+            return new ConfigurateDataProvider<>(ttw, getGsonBuilder().setPath(p).build(), p);
         } catch (Exception e) {
             return null;
         }
@@ -52,7 +56,17 @@ public class DataProviders {
         // For now, just the Configurate one.
         try {
             Path p = plugin.getDataPath().resolve("general.json");
-            return new ConfigurateDataProvider<>(ttg, getBuilder().setPath(p).build(), p);
+            return new ConfigurateDataProvider<>(ttg, getGsonBuilder().setPath(p).build(), p);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public DataProvider<Map<String, ItemDataNode>> getItemDataProvider() {
+        // For now, just the Configurate one.
+        try {
+            Path p = plugin.getConfigDirPath().resolve("items.conf");
+            return new ConfigurateDataProvider<>(ttmsi, getHoconBuilder().setPath(p).build(), p);
         } catch (Exception e) {
             return null;
         }
@@ -72,8 +86,13 @@ public class DataProviders {
         return file;
     }
 
-    private GsonConfigurationLoader.Builder getBuilder() {
+    private GsonConfigurationLoader.Builder getGsonBuilder() {
         GsonConfigurationLoader.Builder gsb = GsonConfigurationLoader.builder();
+        return gsb.setDefaultOptions(ConfigurateHelper.setOptions(plugin.getLogger(), gsb.getDefaultOptions()));
+    }
+
+    private HoconConfigurationLoader.Builder getHoconBuilder() {
+        HoconConfigurationLoader.Builder gsb = HoconConfigurationLoader.builder();
         return gsb.setDefaultOptions(ConfigurateHelper.setOptions(plugin.getLogger(), gsb.getDefaultOptions()));
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/annotations/RequiresEconomy.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/annotations/RequiresEconomy.java
@@ -1,0 +1,16 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.internal.annotations;
+
+import java.lang.annotation.*;
+
+/**
+ * Marks a command as requiring the economy service.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Documented
+public @interface RequiresEconomy {
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/command/ReturnMessageException.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/command/ReturnMessageException.java
@@ -1,0 +1,18 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.internal.command;
+
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.util.TextMessageException;
+
+/**
+ * Simple exception to only send back an error message to the user. Useful in optionals.
+ */
+public class ReturnMessageException extends TextMessageException {
+
+    public ReturnMessageException(Text text) {
+        super(text);
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/guice/QuickStartInjectorModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/guice/QuickStartInjectorModule.java
@@ -9,6 +9,7 @@ import io.github.nucleuspowered.nucleus.ChatUtil;
 import io.github.nucleuspowered.nucleus.Nucleus;
 import io.github.nucleuspowered.nucleus.config.CommandsConfig;
 import io.github.nucleuspowered.nucleus.dataservices.GeneralService;
+import io.github.nucleuspowered.nucleus.dataservices.ItemDataService;
 import io.github.nucleuspowered.nucleus.dataservices.loaders.UserDataManager;
 import io.github.nucleuspowered.nucleus.dataservices.loaders.WorldDataManager;
 import io.github.nucleuspowered.nucleus.internal.EconHelper;
@@ -43,5 +44,6 @@ public class QuickStartInjectorModule extends AbstractModule {
         bind(GeneralService.class).toProvider(plugin::getGeneralService);
         bind(ChatUtil.class).toProvider(plugin::getChatUtil);
         bind(MessageProvider.class).toProvider(plugin::getMessageProvider);
+        bind(ItemDataService.class).toProvider(plugin::getItemDataService);
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/itemalias/ClearItemAliasesCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/itemalias/ClearItemAliasesCommand.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.core.commands.itemalias;
+
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.argumentparsers.ItemAliasArgument;
+import io.github.nucleuspowered.nucleus.configurate.datatypes.ItemDataNode;
+import io.github.nucleuspowered.nucleus.dataservices.ItemDataService;
+import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.text.Text;
+
+@RunAsync
+@NoCooldown
+@NoCost
+@NoWarmup
+@Permissions(root = "nucleus.itemalias")
+@RegisterCommand(value = {"clear"}, subcommandOf = ItemAliasCommand.class)
+public class ClearItemAliasesCommand extends CommandBase<CommandSource> {
+
+    @Inject
+    private ItemDataService itemDataService;
+    private final String item = "item";
+
+    @Override
+    public CommandElement[] getArguments() {
+        return new CommandElement[] {
+            GenericArguments.onlyOne(new ItemAliasArgument(Text.of(item), itemDataService))
+        };
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        CatalogType al = args.<CatalogType>getOne(item).get();
+        String id = al.getId().toLowerCase();
+        ItemDataNode node = itemDataService.getDataForItem(id);
+        node.clearAliases();
+        itemDataService.setDataForItem(id, node);
+
+        src.sendMessage(Util.getTextMessageWithFormat("command.nucleus.removeitemalias.cleared", id));
+        return CommandResult.success();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/itemalias/ItemAliasCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/itemalias/ItemAliasCommand.java
@@ -1,0 +1,22 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.core.commands.itemalias;
+
+import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
+import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
+import io.github.nucleuspowered.nucleus.modules.core.commands.NucleusCommand;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+
+@Permissions(root = "nucleus")
+@RegisterCommand(value = {"itemalias", "item"}, subcommandOf = NucleusCommand.class, hasExecutor = false)
+public class ItemAliasCommand extends CommandBase<CommandSource> {
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        return CommandResult.empty();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/itemalias/RemoveItemAliasCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/itemalias/RemoveItemAliasCommand.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.core.commands.itemalias;
+
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.argumentparsers.SimpleProviderChoicesArgument;
+import io.github.nucleuspowered.nucleus.configurate.datatypes.ItemDataNode;
+import io.github.nucleuspowered.nucleus.dataservices.ItemDataService;
+import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.text.Text;
+
+@RunAsync
+@NoCooldown
+@NoCost
+@NoWarmup
+@Permissions(root = "nucleus.itemalias")
+@RegisterCommand(value = {"remove", "del"}, subcommandOf = ItemAliasCommand.class)
+public class RemoveItemAliasCommand extends CommandBase<CommandSource> {
+
+    @Inject
+    private ItemDataService itemDataService;
+    private final String alias = "alias";
+
+    @Override
+    public CommandElement[] getArguments() {
+        return new CommandElement[] {
+            GenericArguments.onlyOne(SimpleProviderChoicesArgument.withSetSupplier(Text.of(alias), () -> itemDataService.getAliases()))
+        };
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        String al = args.<String>getOne(alias).get();
+        String id = itemDataService.getIdFromAlias(al).get();
+        ItemDataNode node = itemDataService.getDataForItem(id);
+        node.removeAlias(al);
+        itemDataService.setDataForItem(id, node);
+
+        src.sendMessage(Util.getTextMessageWithFormat("command.nucleus.removeitemalias.removed", al, id));
+        return CommandResult.success();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/itemalias/SetItemAliasCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/core/commands/itemalias/SetItemAliasCommand.java
@@ -1,0 +1,99 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.core.commands.itemalias;
+
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.argumentparsers.ItemAliasArgument;
+import io.github.nucleuspowered.nucleus.configurate.datatypes.ItemDataNode;
+import io.github.nucleuspowered.nucleus.dataservices.ItemDataService;
+import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.text.Text;
+
+import java.util.Optional;
+
+@RunAsync
+@NoCooldown
+@NoCost
+@NoWarmup
+@Permissions(root = "nucleus.itemalias")
+@RegisterCommand(value = "set", subcommandOf = ItemAliasCommand.class)
+public class SetItemAliasCommand extends CommandBase<CommandSource> {
+
+    @Inject private ItemDataService itemDataService;
+
+    private final String item = "item";
+    private final String alias = "alias";
+
+    @Override
+    public CommandElement[] getArguments() {
+        return new CommandElement[] {
+            GenericArguments.optionalWeak(new ItemAliasArgument(Text.of(item), itemDataService)),
+            GenericArguments.string(Text.of(alias))
+        };
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        // Do we have an item or blockstate?
+        String a = args.<String>getOne(alias).get().toLowerCase();
+        if (itemDataService.getIdFromAlias(a).isPresent()) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.nucleus.setitemalias.inuse", a));
+            return CommandResult.empty();
+        }
+
+        if (!ItemDataNode.ALIAS_PATTERN.matcher(a).matches()) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.nucleus.setitemalias.notvalid", a));
+            return CommandResult.empty();
+        }
+
+        Optional<CatalogType> catalogTypeOptional = args.getOne(item);
+        CatalogType type;
+        if (catalogTypeOptional.isPresent()) {
+            type = catalogTypeOptional.get();
+        } else {
+            // If player, get the item in hand, otherwise, we can't continue.
+            if (src instanceof Player) {
+                Player pl = (Player)src;
+                if (pl.getItemInHand().isPresent()) {
+                    final ItemStack is = pl.getItemInHand().get();
+                    Optional<BlockState> blockState = is.get(Keys.ITEM_BLOCKSTATE);
+                    if (blockState.isPresent()) {
+                        type = blockState.get();
+                    } else {
+                        type = is.getItem();
+                    }
+                } else {
+                    src.sendMessage(Util.getTextMessageWithFormat("command.nucleus.setitemalias.noneinhand"));
+                    return CommandResult.empty();
+                }
+            } else {
+                src.sendMessage(Util.getTextMessageWithFormat("command.nucleus.setitemalias.noidconsole"));
+                return CommandResult.empty();
+            }
+        }
+
+        // Set the alias.
+        String id = type.getId().toLowerCase();
+        ItemDataNode idn = itemDataService.getDataForItem(id);
+        idn.addAlias(a);
+        itemDataService.setDataForItem(id, idn);
+
+        // Tell the user
+        src.sendMessage(Util.getTextMessageWithFormat("command.nucleus.setitemalias.success", a, id));
+        return CommandResult.success();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/fun/commands/HatCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/fun/commands/HatCommand.java
@@ -9,6 +9,7 @@ import io.github.nucleuspowered.nucleus.argumentparsers.NicknameArgument;
 import io.github.nucleuspowered.nucleus.argumentparsers.SelectorWrapperArgument;
 import io.github.nucleuspowered.nucleus.internal.annotations.*;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
+import io.github.nucleuspowered.nucleus.internal.command.ReturnMessageException;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.command.CommandResult;
@@ -60,28 +61,23 @@ public class HatCommand extends CommandBase<Player> {
             return CommandResult.empty();
         }
 
-        if (pl.getItemInHand().isPresent()) {
-            ItemStack stack = pl.getItemInHand().get();
-            stack.setQuantity(1);
-            opl.get().setHelmet(stack);
-            String itemName = stack.get(Keys.DISPLAY_NAME).orElse(Text.of(stack.getItem().getName())).toPlain();
+        ItemStack stack = pl.getItemInHand().orElseThrow(() -> new ReturnMessageException(Util.getTextMessageWithFormat("command.generalerror.handempty")));
+        stack.setQuantity(1);
+        opl.get().setHelmet(stack);
+        String itemName = stack.get(Keys.DISPLAY_NAME).orElse(Text.of(stack.getItem().getName())).toPlain();
 
-            if (pl.get(Keys.GAME_MODE).get() == GameModes.SURVIVAL) {
-                stack = pl.getItemInHand().get();
+        if (pl.get(Keys.GAME_MODE).get() == GameModes.SURVIVAL) {
+            stack = pl.getItemInHand().get();
 
-                if (stack.getQuantity() > 1) {
-                    stack.setQuantity(stack.getQuantity() - 1);
-                    pl.setItemInHand(stack);
-                } else {
-                    pl.setItemInHand(null);
-                }
+            if (stack.getQuantity() > 1) {
+                stack.setQuantity(stack.getQuantity() - 1);
+                pl.setItemInHand(stack);
+            } else {
+                pl.setItemInHand(null);
             }
-
-            pl.sendMessage(Util.getTextMessageWithFormat("command.hat.success", opl.get().getName(), itemName));
-            return CommandResult.success();
-        } else {
-            pl.sendMessage(Util.getTextMessageWithFormat("command.hat.error.handempty"));
-            return CommandResult.empty();
         }
+
+        pl.sendMessage(Util.getTextMessageWithFormat("command.hat.success", opl.get().getName(), itemName));
+        return CommandResult.success();
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/BlockInfoCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/BlockInfoCommand.java
@@ -30,12 +30,7 @@ import org.spongepowered.api.util.blockray.BlockRay;
 import org.spongepowered.api.util.blockray.BlockRayHit;
 import org.spongepowered.api.world.World;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 @Permissions
 @RegisterCommand({"blockinfo"})
@@ -70,6 +65,7 @@ public class BlockInfoCommand extends CommandBase<Player> {
 
             List<Text> lt = new ArrayList<>();
             lt.add(Util.getTextMessageWithFormat("command.blockinfo.id", it.getId(), it.getTranslation().get()));
+            lt.add(Util.getTextMessageWithFormat("command.iteminfo.extendedid", b.getId()));
 
             if (args.hasAny("e") || args.hasAny("extended")) {
                 Collection<Property<?, ?>> cp = b.getApplicableProperties();

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/ItemInfoCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/ItemInfoCommand.java
@@ -16,6 +16,7 @@ import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import io.github.nucleuspowered.nucleus.modules.servershop.ServerShopModule;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockState;
@@ -112,7 +113,7 @@ public class ItemInfoCommand extends CommandBase<Player> {
         ItemDataNode itemDataNode = itemDataService.getDataForItem(id);
 
         // /buy and /sell prices
-        if (econHelper.economyServiceExists()) {
+        if (econHelper.economyServiceExists() && plugin.getModuleContainer().isModuleLoaded(ServerShopModule.ID)) {
             boolean space = false;
             int buyPrice = itemDataNode.getServerBuyPrice();
             if (buyPrice > -1) {
@@ -127,7 +128,7 @@ public class ItemInfoCommand extends CommandBase<Player> {
                     lt.add(Text.EMPTY);
                 }
 
-                lt.add(Util.getTextMessageWithFormat("command.iteminfo.sellprice", econHelper.getCurrencySymbol(buyPrice)));
+                lt.add(Util.getTextMessageWithFormat("command.iteminfo.sellprice", econHelper.getCurrencySymbol(sellPrice)));
             }
         }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/ItemInfoCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/misc/commands/ItemInfoCommand.java
@@ -4,39 +4,54 @@
  */
 package io.github.nucleuspowered.nucleus.modules.misc.commands;
 
+import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.argumentparsers.ItemAliasArgument;
+import io.github.nucleuspowered.nucleus.configurate.datatypes.ItemDataNode;
+import io.github.nucleuspowered.nucleus.dataservices.ItemDataService;
 import io.github.nucleuspowered.nucleus.internal.DataScanner;
+import io.github.nucleuspowered.nucleus.internal.EconHelper;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.Sponge;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.command.CommandException;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.args.CommandElement;
 import org.spongepowered.api.command.args.GenericArguments;
 import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.value.BaseValue;
 import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.service.pagination.PaginationService;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.format.TextColors;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Permissions
 @RegisterCommand({"iteminfo", "itemdb"})
 public class ItemInfoCommand extends CommandBase<Player> {
 
+    @Inject private ItemDataService itemDataService;
+    @Inject private EconHelper econHelper;
+
+    private final String key = "key";
+    private final Text comma = Text.of(TextColors.GREEN, ", ");
+
     @Override
     public CommandElement[] getArguments() {
-        return new CommandElement[] {GenericArguments.flags().permissionFlag(permissions.getPermissionWithSuffix("extended"), "e", "-extended")
-                .buildWith(GenericArguments.none())};
+        return new CommandElement[] {
+                GenericArguments.flags().permissionFlag(permissions.getPermissionWithSuffix("extended"), "e", "-extended")
+            .buildWith(GenericArguments.optional(new ItemAliasArgument(Text.of(key), itemDataService)))
+        };
     }
 
     @Override
@@ -48,36 +63,92 @@ public class ItemInfoCommand extends CommandBase<Player> {
 
     @Override
     public CommandResult executeCommand(Player player, CommandContext args) throws Exception {
-        if (player.getItemInHand().isPresent()) {
-            ItemStack it = player.getItemInHand().get();
-
-            List<Text> lt = new ArrayList<>();
-            lt.add(Util.getTextMessageWithFormat("command.iteminfo.id", it.getItem().getId(), it.getTranslation().get()));
-
-            if (args.hasAny("e") || args.hasAny("extended")) {
-                // For each key, see if the item supports it. If so, get and
-                // print the value.
-                DataScanner.getInstance().getKeysForHolder(it).entrySet().stream().filter(x -> x.getValue() != null).filter(x -> {
-                    // Work around a Sponge bug.
-                    try {
-                        return it.supports(x.getValue());
-                    } catch (Exception e) {
-                        return false;
-                    }
-                }).forEach(x -> {
-                    Key<? extends BaseValue<Object>> k = (Key<? extends BaseValue<Object>>) x.getValue();
-                    if (it.get(k).isPresent()) {
-                        DataScanner.getText(player, "command.iteminfo.key", x.getKey(), it.get(k).get()).ifPresent(lt::add);
-                    }
-                });
+        Optional<CatalogType> catalogTypeOptional = args.getOne(key);
+        ItemStack it;
+        if (catalogTypeOptional.isPresent()) {
+            CatalogType ct = catalogTypeOptional.get();
+            if (ct instanceof ItemType) {
+                it = ((ItemType) ct).getTemplate().createStack();
+            } else {
+                BlockState bs = ((BlockState) ct);
+                it = bs.getType().getItem().orElseThrow(() -> new CommandException(Util.getTextMessageWithFormat("command.iteminfo.invalidblockstate"))).getTemplate().createStack();
+                it.offer(Keys.ITEM_BLOCKSTATE, bs);
             }
-
-            Sponge.getServiceManager().provideUnchecked(PaginationService.class).builder().contents(lt).padding(Text.of(TextColors.GREEN, "-"))
-                    .title(Util.getTextMessageWithFormat("command.iteminfo.list.header")).sendTo(player);
-            return CommandResult.success();
+        } else if (player.getItemInHand().isPresent()) {
+            it = player.getItemInHand().get();
+        } else {
+            player.sendMessage(Util.getTextMessageWithFormat("command.iteminfo.none"));
+            return CommandResult.empty();
         }
 
-        player.sendMessage(Util.getTextMessageWithFormat("command.iteminfo.none"));
-        return CommandResult.empty();
+        final List<Text> lt = new ArrayList<>();
+        String id = it.getItem().getId().toLowerCase();
+        lt.add(Util.getTextMessageWithFormat("command.iteminfo.id", it.getItem().getId(), it.getTranslation().get()));
+
+        Optional<BlockState> obs = it.get(Keys.ITEM_BLOCKSTATE);
+        if (obs.isPresent()) {
+            lt.add(Util.getTextMessageWithFormat("command.iteminfo.extendedid", obs.get().getId()));
+            id = obs.get().getId().toLowerCase();
+        }
+
+        if (args.hasAny("e") || args.hasAny("extended")) {
+            // For each key, see if the item supports it. If so, get and
+            // print the value.
+            DataScanner.getInstance().getKeysForHolder(it).entrySet().stream().filter(x -> x.getValue() != null).filter(x -> {
+                // Work around a Sponge bug.
+                try {
+                    return it.supports(x.getValue());
+                } catch (Exception e) {
+                    return false;
+                }
+            }).forEach(x -> {
+                Key<? extends BaseValue<Object>> k = (Key<? extends BaseValue<Object>>) x.getValue();
+                if (it.get(k).isPresent()) {
+                    DataScanner.getText(player, "command.iteminfo.key", x.getKey(), it.get(k).get()).ifPresent(lt::add);
+                }
+            });
+        }
+
+        ItemDataNode itemDataNode = itemDataService.getDataForItem(id);
+
+        // /buy and /sell prices
+        if (econHelper.economyServiceExists()) {
+            boolean space = false;
+            int buyPrice = itemDataNode.getServerBuyPrice();
+            if (buyPrice > -1) {
+                lt.add(Text.EMPTY);
+                lt.add(Util.getTextMessageWithFormat("command.iteminfo.buyprice", econHelper.getCurrencySymbol(buyPrice)));
+                space = true;
+            }
+
+            int sellPrice = itemDataNode.getServerSellPrice();
+            if (sellPrice > -1) {
+                if (!space) {
+                    lt.add(Text.EMPTY);
+                }
+
+                lt.add(Util.getTextMessageWithFormat("command.iteminfo.sellprice", econHelper.getCurrencySymbol(buyPrice)));
+            }
+        }
+
+        List<String> aliases = itemDataNode.getAliases();
+        if (!aliases.isEmpty()) {
+            lt.add(Text.EMPTY);
+            lt.add(Util.getTextMessageWithFormat("command.iteminfo.list.aliases"));
+
+            Text.Builder tb = Text.builder();
+            Iterator<String> iterator = aliases.iterator();
+            tb.append(Text.of(TextColors.YELLOW, iterator.next()));
+
+            while (iterator.hasNext()) {
+                tb.append(comma, Text.of(TextColors.YELLOW, iterator.next()));
+            }
+
+            lt.add(tb.build());
+        }
+
+        Sponge.getServiceManager().provideUnchecked(PaginationService.class).builder().contents(lt).padding(Text.of(TextColors.GREEN, "-"))
+                .title(Util.getTextMessageWithFormat("command.iteminfo.list.header")).sendTo(player);
+        return CommandResult.success();
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/servershop/ServerShopModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/servershop/ServerShopModule.java
@@ -1,0 +1,20 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.servershop;
+
+import io.github.nucleuspowered.nucleus.internal.qsml.module.ConfigurableModule;
+import io.github.nucleuspowered.nucleus.modules.servershop.config.ServerShopConfigAdapter;
+import uk.co.drnaylor.quickstart.annotations.ModuleData;
+
+@ModuleData(id = ServerShopModule.ID, name = "Server Shop")
+public class ServerShopModule extends ConfigurableModule<ServerShopConfigAdapter> {
+
+    public static final String ID = "server-shop";
+
+    @Override
+    public ServerShopConfigAdapter getAdapter() {
+        return new ServerShopConfigAdapter();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/servershop/commands/BuyCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/servershop/commands/BuyCommand.java
@@ -1,0 +1,151 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.servershop.commands;
+
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.argumentparsers.ItemAliasArgument;
+import io.github.nucleuspowered.nucleus.argumentparsers.PositiveIntegerArgument;
+import io.github.nucleuspowered.nucleus.configurate.datatypes.ItemDataNode;
+import io.github.nucleuspowered.nucleus.dataservices.ItemDataService;
+import io.github.nucleuspowered.nucleus.internal.EconHelper;
+import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
+import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import io.github.nucleuspowered.nucleus.modules.servershop.config.ServerShopConfigAdapter;
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackSnapshot;
+import org.spongepowered.api.item.inventory.transaction.InventoryTransactionResult;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.action.TextActions;
+
+import javax.inject.Inject;
+import java.util.Collection;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+@RunAsync
+@NoCost
+@NoCooldown
+@NoWarmup
+@RequiresEconomy
+@Permissions(suggestedLevel = SuggestedLevel.USER)
+@RegisterCommand({"itembuy", "buy"})
+public class BuyCommand extends CommandBase<Player> {
+
+    @Inject private ServerShopConfigAdapter ssca;
+    @Inject private ItemDataService itemDataService;
+    @Inject private EconHelper econHelper;
+    private final String itemKey = "item";
+    private final String amountKey = "amount";
+
+    @Override
+    public CommandElement[] getArguments() {
+        return new CommandElement[] {
+            GenericArguments.flags().flag("y", "f", "a", "-yes", "-auto").buildWith(
+                GenericArguments.seq(
+                    GenericArguments.onlyOne(new ItemAliasArgument(Text.of(itemKey), itemDataService)),
+                    GenericArguments.onlyOne(new PositiveIntegerArgument(Text.of(amountKey)))))
+        };
+    }
+
+    @Override
+    public CommandResult executeCommand(final Player src, CommandContext args) throws Exception {
+        CatalogType ct = args.<CatalogType>getOne(itemKey).get();
+        int amount = args.<Integer>getOne(amountKey).get();
+
+        ItemDataNode node = itemDataService.getDataForItem(ct.getId());
+        if (node.getServerBuyPrice() < 0) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.itembuy.notforsale"));
+            return CommandResult.empty();
+        }
+
+        int max = ssca.getNodeOrDefault().getMaxPurchasableAtOnce();
+        if (amount > max) {
+            amount = max;
+            src.sendMessage(Util.getTextMessageWithFormat("command.itembuy.maximum", String.valueOf(amount)));
+        }
+
+        final ItemStack created;
+        if (ct instanceof ItemType) {
+            created = ItemStack.of((ItemType) ct, amount);
+        } else {
+            created = ItemStack.builder().fromBlockState((BlockState)ct).quantity(amount).build();
+        }
+
+        // Get the cost.
+        final int perUnitCost = node.getServerBuyPrice();
+        final int unitCount = amount;
+        final int overallCost = perUnitCost * unitCount;
+        src.sendMessage(Util.getTextMessageWithFormat("command.itembuy.summary", String.valueOf(amount), created.getTranslation().get(), econHelper.getCurrencySymbol(overallCost)));
+
+        if (args.hasAny("y")) {
+            new BuyCallback(src, overallCost, created, unitCount, perUnitCost).accept(src);
+        } else {
+            src.sendMessage(
+                    Util.getTextMessageWithFormat("command.itembuy.clickhere").toBuilder()
+                            .onClick(TextActions.executeCallback(new BuyCallback(src, overallCost, created, unitCount, perUnitCost))).build()
+            );
+        }
+
+        return CommandResult.success();
+    }
+
+    private class BuyCallback implements Consumer<CommandSource> {
+
+        private final Player src;
+        private final int overallCost;
+        private final ItemStack created;
+        private final int unitCount;
+        private final int perUnitCost;
+
+        private boolean hasRun = false;
+
+        private BuyCallback(Player src, int overallCost, ItemStack created, int unitCount, int perUnitCost) {
+            this.src = src;
+            this.overallCost = overallCost;
+            this.created = created;
+            this.unitCount = unitCount;
+            this.perUnitCost = perUnitCost;
+        }
+
+        @Override
+        public void accept(CommandSource source) {
+            if (hasRun) {
+                return;
+            }
+
+            hasRun = true;
+
+            // Get the money, transact, return the money on fail.
+            if (econHelper.withdrawFromPlayer(src, overallCost, false)) {
+                InventoryTransactionResult itr = src.getInventory().offer(created);
+                if (itr.getRejectedItems().isEmpty()) {
+                    src.sendMessage(Util.getTextMessageWithFormat("command.itembuy.transactionsuccess",
+                            String.valueOf(unitCount), created.getTranslation().get(), econHelper.getCurrencySymbol(overallCost)));
+                } else {
+                    Collection<ItemStackSnapshot> iss = itr.getRejectedItems();
+                    int rejected = iss.stream().collect(Collectors.summingInt(ItemStackSnapshot::getCount));
+                    int refund = rejected * perUnitCost;
+                    econHelper.depositInPlayer(src, refund, false);
+                    src.sendMessage(Util.getTextMessageWithFormat("command.itembuy.transactionpartial", String.valueOf(rejected), created.getTranslation().get()));
+                    src.sendMessage(Util.getTextMessageWithFormat("command.itembuy.transactionsuccess",
+                            String.valueOf(unitCount - rejected), created.getTranslation().get(), econHelper.getCurrencySymbol(overallCost - refund)));
+                }
+            } else {
+                // No funds.
+                src.sendMessage(Util.getTextMessageWithFormat("command.itembuy.nofunds"));
+            }
+        }
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/servershop/commands/SellCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/servershop/commands/SellCommand.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.servershop.commands;
+
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.configurate.datatypes.ItemDataNode;
+import io.github.nucleuspowered.nucleus.dataservices.ItemDataService;
+import io.github.nucleuspowered.nucleus.internal.EconHelper;
+import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
+import io.github.nucleuspowered.nucleus.internal.command.ReturnMessageException;
+import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.item.inventory.ItemStack;
+
+import javax.inject.Inject;
+import java.util.Optional;
+
+@RunAsync
+@NoCost
+@NoCooldown
+@NoWarmup
+@RequiresEconomy
+@Permissions(suggestedLevel = SuggestedLevel.USER)
+@RegisterCommand({"itemsell", "sell"})
+public class SellCommand extends CommandBase<Player> {
+
+    @Inject private ItemDataService itemDataService;
+    @Inject private EconHelper econHelper;
+
+    @Override
+    public CommandResult executeCommand(final Player src, CommandContext args) throws Exception {
+        // Get the item in the hand.
+        ItemStack is = src.getItemInHand().orElseThrow(() -> new ReturnMessageException(Util.getTextMessageWithFormat("command.generalerror.handempty")));
+
+        String id;
+        Optional<BlockState> blockState = is.get(Keys.ITEM_BLOCKSTATE);
+        if (blockState.isPresent()) {
+            id = blockState.get().getId().toLowerCase();
+        } else {
+            id = is.getItem().getId();
+        }
+
+        ItemDataNode node = itemDataService.getDataForItem(id);
+        final int sellPrice = node.getServerSellPrice();
+        if (sellPrice < 0) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.itemsell.notforselling"));
+            return CommandResult.empty();
+        }
+
+        // Get the cost.
+        final int amt = is.getQuantity();
+        final int overallCost = sellPrice * amt;
+        if (econHelper.depositInPlayer(src, overallCost, false)) {
+            src.setItemInHand(null);
+            src.sendMessage(Util.getTextMessageWithFormat("command.itemsell.summary", String.valueOf(amt), is.getTranslation().get(), econHelper.getCurrencySymbol(overallCost)));
+            return CommandResult.success();
+        }
+
+        src.sendMessage(Util.getTextMessageWithFormat("command.itemsell.error", is.getTranslation().get()));
+        return CommandResult.empty();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/servershop/commands/SetWorthCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/servershop/commands/SetWorthCommand.java
@@ -1,0 +1,164 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.servershop.commands;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.argumentparsers.ItemAliasArgument;
+import io.github.nucleuspowered.nucleus.configurate.datatypes.ItemDataNode;
+import io.github.nucleuspowered.nucleus.dataservices.ItemDataService;
+import io.github.nucleuspowered.nucleus.internal.EconHelper;
+import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.command.CommandBase;
+import org.spongepowered.api.CatalogType;
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.text.Text;
+
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+/**
+ * Sets or unsets an item's worth for either buying or selling.
+ */
+@RunAsync
+@NoCost
+@NoCooldown
+@NoWarmup
+@Permissions
+@RegisterCommand({"setworth", "setitemworth"})
+public class SetWorthCommand extends CommandBase<CommandSource> {
+
+    private final String item = "item";
+    private final String type = "type";
+    private final String cost = "cost";
+    @Inject private ItemDataService itemDataService;
+    @Inject private EconHelper econHelper;
+
+    @Override
+    public CommandElement[] getArguments() {
+        return new CommandElement[] {
+            GenericArguments.optionalWeak(new ItemAliasArgument(Text.of(item), itemDataService)),
+            GenericArguments.choices(Text.of(type), ImmutableMap.of("buy", Type.BUY, "sell", Type.SELL)),
+            GenericArguments.integer(Text.of(cost))
+        };
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        Type transactionType = args.<Type>getOne(type).get();
+        Optional<CatalogType> catalogTypeOptional = args.getOne(item);
+        int newCost = Math.max(-1, args.<Integer>getOne(cost).get());
+
+        String id;
+
+        if (catalogTypeOptional.isPresent()) {
+            id = catalogTypeOptional.get().getId().toLowerCase();
+        } else if (src instanceof Player) {
+            Optional<ItemStack> itemStack = ((Player) src).getItemInHand();
+            if (itemStack.isPresent()) {
+                ItemStack is = itemStack.get();
+                Optional<BlockState> blockStateOptional = is.get(Keys.ITEM_BLOCKSTATE);
+                id = (blockStateOptional.isPresent() ? blockStateOptional.get().getId() : is.getItem().getId()).toLowerCase();
+            } else {
+                src.sendMessage(Util.getTextMessageWithFormat("command.setworth.noitemhand"));
+                return CommandResult.empty();
+            }
+        } else {
+            src.sendMessage(Util.getTextMessageWithFormat("command.setworth.noitemconsole"));
+            return CommandResult.empty();
+        }
+
+        // Get the item from the system.
+        ItemDataNode node = itemDataService.getDataForItem(id);
+
+        // Get the current item worth.
+        int currentWorth = transactionType.getter.apply(node);
+        String worth;
+        String newWorth;
+
+        if (econHelper.economyServiceExists()) {
+            worth = econHelper.getCurrencySymbol(currentWorth);
+            newWorth = econHelper.getCurrencySymbol(newCost);
+        } else {
+            src.sendMessage(Util.getTextMessageWithFormat("command.setworth.noeconservice"));
+            worth = String.valueOf(currentWorth);
+            newWorth = String.valueOf(newCost);
+        }
+
+        String name;
+        Optional<CatalogType> type = Util.getCatalogTypeForItemFromId(id);
+        if (type.isPresent()) {
+            CatalogType ct = type.get();
+            if (ct instanceof ItemType) {
+                name = ItemStack.of((ItemType)ct, 1).getTranslation().get();
+            } else if (ct instanceof BlockState) {
+                name = ItemStack.builder().fromBlockState(((BlockState) ct)).build().getTranslation().get();
+            } else {
+                name = Util.getTranslatableIfPresentOnCatalogType(ct);
+            }
+        } else {
+            name = id;
+        }
+
+        if (name.isEmpty()) {
+            name = id;
+        }
+
+        if (currentWorth == newCost) {
+            if (currentWorth == -1) {
+                src.sendMessage(Util.getTextMessageWithFormat("command.setworth.alreadyunavailable", name, transactionType.getTranslation()));
+            } else {
+                src.sendMessage(Util.getTextMessageWithFormat("command.setworth.samecost", transactionType.getTranslation(), name, worth));
+            }
+
+            return CommandResult.empty();
+        }
+
+        // Set the item worth.
+        transactionType.setter.accept(node, newCost);
+        itemDataService.setDataForItem(id, node);
+
+        // Tell the user.
+        if (currentWorth == -1) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.setworth.success.new", name, transactionType.getTranslation(), newWorth));
+        } else if (newCost == -1) {
+            src.sendMessage(Util.getTextMessageWithFormat("command.setworth.success.removed", name, transactionType.getTranslation(), worth));
+        } else {
+            src.sendMessage(Util.getTextMessageWithFormat("command.setworth.success.changed", name, transactionType.getTranslation(), worth, newWorth));
+        }
+
+        return CommandResult.success();
+    }
+
+    private enum Type {
+        BUY(ItemDataNode::getServerBuyPrice, ItemDataNode::setServerBuyPrice, "standard.buyfrom"),
+        SELL(ItemDataNode::getServerSellPrice, ItemDataNode::setServerSellPrice, "standard.sellto");
+
+        private final Function<ItemDataNode, Integer> getter;
+        private final BiConsumer<ItemDataNode, Integer> setter;
+        private final String transactionKey;
+
+        Type(Function<ItemDataNode, Integer> get, BiConsumer<ItemDataNode, Integer> set, String transactionKey) {
+            this.getter = get;
+            this.setter = set;
+            this.transactionKey = transactionKey;
+        }
+
+        private String getTranslation() {
+            return Util.getMessageWithFormat(transactionKey);
+        }
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/servershop/config/ServerShopConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/servershop/config/ServerShopConfig.java
@@ -1,0 +1,19 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.servershop.config;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+@ConfigSerializable
+public class ServerShopConfig {
+
+    @Setting(value = "max-purchasable-at-once", comment = "loc:config.servershop.maxpurchasable")
+    private int maxPurchasableAtOnce = 64;
+
+    public int getMaxPurchasableAtOnce() {
+        return Math.max(maxPurchasableAtOnce, 1);
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/servershop/config/ServerShopConfigAdapter.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/servershop/config/ServerShopConfigAdapter.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.servershop.config;
+
+import com.google.common.reflect.TypeToken;
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+
+public class ServerShopConfigAdapter extends NucleusConfigAdapter<ServerShopConfig> {
+
+    private final TypeToken<ServerShopConfig> tt = TypeToken.of(ServerShopConfig.class);
+
+    @Override
+    protected ServerShopConfig getDefaultObject() {
+        return new ServerShopConfig();
+    }
+
+    @Override
+    protected ServerShopConfig convertFromConfigurateNode(ConfigurationNode node) throws ObjectMappingException {
+        return node.getValue(tt, getDefaultObject());
+    }
+
+    @Override
+    protected ConfigurationNode insertIntoConfigurateNode(ServerShopConfig data) throws ObjectMappingException {
+        return null;
+    }
+}

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -29,6 +29,12 @@ standard.view=[View]
 standard.reply=[Reply]
 standard.delete=[Delete]
 
+standard.buy=buy
+standard.sell=sell
+
+standard.buyfrom=buy from the server
+standard.sellto=sell to the server
+
 startup.preinit={0} is now starting. Entering pre-init phase.
 startup.postinit={0} is now entering the post-init phase.
 startup.moduleloading={0} is now loading and enabling modules. This may take a few seconds.
@@ -220,6 +226,8 @@ config.core.commandonname='If set, this command will be suggested if a player cl
 
 config.misc.speed.max=Sets the maximum speed that a player can set via the /speed command.
 
+config.servershop.maxpurchasable=The maximum amount a player can buy in one transaction.
+
 # Data
 config.itemdatanode.aliases=A set of aliases that Nucleus recognises for this item. They all must be lowercase, and contain only letters, numbers, hyphens or underscores.
 
@@ -315,6 +323,10 @@ commandlog.message={0} ran the command: /{1} {2}
 commandlog.couldnotwrite=Could not write log entry to Nucleus command log file
 
 # Commands
+
+# General
+command.generalerror.handempty=&cYou must be holding an item to use this command.
+
 command.afk.exempt=&cYou are currently exempted from going AFK.
 command.afk.to.vanish=&eYou have gone AFK, but you are currently vanished, so this has not been broadcasted.
 command.afk.from.vanish=&eYou have returned from AFK, but you are currently vanished, so this has not been broadcasted.
@@ -326,8 +338,10 @@ command.back.nosafe=&cCannot return you to your previous location safely.
 command.child.notloaded=Could not load the child command {0}.
 
 command.file.load=&cCould not load user information.
+
 command.error=&cAn error occurred trying to perform that command.
 command.targetisafk=&f{0} &7is currently AFK and may not respond quickly.
+command.economyrequired=&cAn economy is required for this command to work, no compatibile plugins are installed.
 
 command.playeronly=&cThis command can only be executed by players.
 
@@ -505,7 +519,6 @@ command.god.off=&aYou are no longer invulnerable.
 command.god.error=&cCould not set invulnerability status.
 
 command.hat.success=&aSet hat of &r{0}&a/ to {1}.
-command.hat.error.handempty=&cYou must be holding an item to use this command.
 
 command.lightning.success.other=&r{0}&a was smited.
 command.lightning.error=&cCould not create lightning strike.
@@ -885,6 +898,27 @@ command.rtp.success=&aYou have been teleported to the co-ordinates &e{0}, {1}, {
 command.rtp.error=&cTimed out trying to find a safe location to warp to.
 command.rtp.cancelled=&cYou cannot teleport at this time.
 
+command.setworth.noitemhand=&cYou must either specify an item, or be holding it in your hand.
+command.setworth.noitemconsole=&cYou must either specify an item.
+command.setworth.samecost=&cThe {0} cost of &e"{1}"&c is already set to {2}.
+command.setworth.alreadyunavailable=&cThe item &e"{0}" &cwas already unavailable to {1}.
+command.setworth.noeconservice=&cWarning: No economy has been detected. To make use of the server shot, you must install an economy plugin.
+command.setworth.success.new=&aThe item &e{0} &ais now available to {1} for &e{2}&a.
+command.setworth.success.removed=&aThe item &e{0} &ais no longer available to {1} (it was available for &e{2}&a).
+command.setworth.success.changed=&aThe item &e{0} &ais now available to {1} for &e{2}&a (it was previously available for &e{3}&a).
+
+command.itembuy.maximum=&cThe maximum number of items you can buy at once is &e{0}&c.
+command.itembuy.summary=&bYou can buy &e{0} {1} &bfor &e{2}&b.
+command.itembuy.clickhere=&b&nClick here to accept this.
+command.itembuy.notforsale=&cThat item is not for sale.
+command.itembuy.nofunds=&cYou do not have the funds to buy this.
+command.itembuy.transactionsuccess=&aYou have bought &e{0} {1}&a for &e{2}&a.
+command.itembuy.transactionpartial=&cDue to lack of inventory space, &e{0} {1} &cwere not bought.
+
+command.itemsell.notforselling=&cThat item cannot be sold to the server.
+command.itemsell.summary=&bYou have sold &e{0} {1} &bfor &e{2}&b.
+command.itemsell.error=&cThere was an error selling your &e{0}&c.
+
 # Ban
 ban.defaultreason=The BanHammer has spoken!
 
@@ -1261,3 +1295,7 @@ description.checkwarnings.desc=Allows the user to check a player''s warnings.
 description.clearwarnings.desc=Allows the user to clear a player''s warnings.
 
 description.plainbroadcast.desc=Allows the user to send a broadcast without prefixes or suffixes.
+
+description.setworth.desc=Allows the user to set the buy or sell price of an item.
+description.itembuy.desc=Allows the user to buy an item from the server for a set price.
+description.itemsell.desc=Allows the user to sell an item to the server for a set price.

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -220,9 +220,15 @@ config.core.commandonname='If set, this command will be suggested if a player cl
 
 config.misc.speed.max=Sets the maximum speed that a player can set via the /speed command.
 
+# Data
+config.itemdatanode.aliases=A set of aliases that Nucleus recognises for this item. They all must be lowercase, and contain only letters, numbers, hyphens or underscores.
+
 afk.kickreason=You have been kicked for being AFK for too long.
 
 # Arguments
+args.itemarg.orphanedarg=&cThe alias "{0}" points to the item id "{1}" which is no longer present on the server.
+args.itemarg.nomatch=&cThere are no aliases or IDs named "{0}".
+
 args.jail.nojail=&cThat jail does not exist.
 
 args.home.nohome=&cThe home "{0}" does not exist.
@@ -789,8 +795,13 @@ command.blockinfo.none=&cNo block was found ahead of you.
 
 command.iteminfo.list.header=&aItem Info
 command.iteminfo.id=&aItem ID: &e{0}&a. Item name: &e{1}&a.
+command.iteminfo.extendedid=&aExtended ID: &e{0}
 command.iteminfo.key=&aData Key: &e{0}&a. Value: &e{1}&a.
 command.iteminfo.none=&cYou must be holding the item you wish to inspect.
+command.iteminfo.invalidblockstate=&cThat block state does not have an item associated with it.
+command.iteminfo.buyprice=&aPlayers can buy for &e{0}
+command.iteminfo.sellprice=&aPlayers can sell for &e{0}
+command.iteminfo.list.aliases=&bItem Aliases
 
 command.spawnmob.fail=&cUnable to spawn in any {0} entities.
 command.spawnmob.success.singular=&aSpawned in {0} {1} entity.
@@ -858,6 +869,13 @@ command.info.hover=Click here or run "/info {0}" to read the section "{0}".
 command.info.none=&6There are no info pages for this server.
 
 command.nucleus.clearcache.success=&aSuccessfully cleared the user cache. Any manual changes to offline user''s files will be read next time they reconnect.
+command.nucleus.setitemalias.inuse=&cThe alias "{0}" is already in use.
+command.nucleus.setitemalias.noneinhand=&cYou must either specify the item ID or hold the item in your main hand to create an alias.
+command.nucleus.setitemalias.noidconsole=&cYou must specify the item ID you wish to create an alias for.
+command.nucleus.setitemalias.success=&aThe alias "&e{0}&a" has been set for item with ID "&e{1}&a".
+command.nucleus.setitemalias.notvalid=&cThe alias "{0}" is not valid. The alias can only contain letters, numbers, underscores and hyphens.
+command.nucleus.removeitemalias.removed=&aThe alias "&e{0}&a" has been removed from the item with ID "&e{1}&a".
+command.nucleus.removeitemalias.cleared=&aAll aliases for the item with ID "&e{0}&a" have been removed.
 
 command.realname.title=&aReal names for "&e{0}&a"
 command.realname.nonames=&cThere is no-one on the server with a name starting with "&e{0}&c".
@@ -1073,6 +1091,10 @@ description.nucleus.save.desc=Saves all files.
 description.nucleus.migrate.desc=Migrates data from other plugins.
 description.nucleus.migrate.esscmds.desc=Migrates data from EssentialCmds.
 description.nucleus.printperms.desc=Prints all permissions registered in Nucleus.
+description.nucleus.itemalias.set.desc=Sets an alias to an item.
+description.nucleus.itemalias.remove.desc=Removes an alias from an item.
+description.nucleus.itemalias.clear.desc=Removes all aliases from an item.
+description.nucleus.itemalias.desc=Manages item aliases.
 
 description.lockweather.desc=Locks the weather on the specified world.
 description.weather.desc=Sets the weather on the specified world.

--- a/src/test/java/io/github/nucleuspowered/nucleus/tests/configurate/ProcessSettingTests.java
+++ b/src/test/java/io/github/nucleuspowered/nucleus/tests/configurate/ProcessSettingTests.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.tests.configurate;
+
+import com.google.common.reflect.TypeToken;
+import io.github.nucleuspowered.nucleus.configurate.annotations.ProcessSetting;
+import io.github.nucleuspowered.nucleus.configurate.settingprocessor.SettingProcessor;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class ProcessSettingTests {
+
+    @Test
+    public void testOnGet() throws ObjectMappingException, IOException {
+        ConfigurationNode cn = TestConfigurationLoader.builder().build().load();
+        cn.getNode("test").setValue("test");
+        cn.getNode("test2").setValue("test");
+
+        TestConfig tc = cn.getValue(TypeToken.of(TestConfig.class));
+
+        Assert.assertEquals("transformed", tc.getTest());
+        Assert.assertEquals("test", tc.getTest2());
+    }
+
+    @Test
+    public void testOnSet() throws ObjectMappingException, IOException {
+        TestConfig tc = new TestConfig();
+        tc.test = "test";
+        tc.test2 = "test";
+
+        TestConfigurationLoader tcl = TestConfigurationLoader.builder().build();
+        ConfigurationNode cn = tcl.createEmptyNode(tcl.getDefaultOptions()).setValue(TypeToken.of(TestConfig.class), tc);
+
+        Assert.assertEquals("transformed", cn.getNode("test").getString());
+        Assert.assertEquals("test", cn.getNode("test2").getString());
+    }
+
+    @ConfigSerializable
+    public static class TestConfig {
+
+        @Setting
+        @ProcessSetting(TestProcess.class)
+        private String test;
+
+        @Setting
+        private String test2;
+
+        public String getTest() {
+            return test;
+        }
+
+        public String getTest2() {
+            return test2;
+        }
+    }
+
+    public static class TestProcess implements SettingProcessor {
+
+        @Override
+        public void process(ConfigurationNode cn) throws ObjectMappingException {
+            cn.setValue("transformed");
+        }
+    }
+}

--- a/src/test/java/io/github/nucleuspowered/nucleus/tests/configurate/TestConfigurationLoader.java
+++ b/src/test/java/io/github/nucleuspowered/nucleus/tests/configurate/TestConfigurationLoader.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.tests.configurate;
+
+import io.github.nucleuspowered.nucleus.configurate.objectmapper.NucleusObjectMapperFactory;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.ConfigurationOptions;
+import ninja.leaping.configurate.SimpleConfigurationNode;
+import ninja.leaping.configurate.loader.AbstractConfigurationLoader;
+import ninja.leaping.configurate.loader.CommentHandlers;
+import org.mockito.Mockito;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * Largely taken from https://github.com/zml2008/configurate/blob/master/configurate-core/src/test/java/ninja/leaping/configurate/loader/TestConfigurationLoader.java
+ */
+public class TestConfigurationLoader extends AbstractConfigurationLoader<ConfigurationNode> {
+
+    private ConfigurationNode result = SimpleConfigurationNode.root();
+
+    public static final class Builder extends AbstractConfigurationLoader.Builder<Builder> {
+
+        @Override
+        public TestConfigurationLoader build() {
+            setDefaultOptions(getDefaultOptions().setObjectMapperFactory(NucleusObjectMapperFactory.getInstance()))
+                    .setSource(() -> Mockito.mock(BufferedReader.class))
+                    .setSink(() -> Mockito.mock(BufferedWriter.class));
+            return new TestConfigurationLoader(this);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    protected TestConfigurationLoader(Builder builder) {
+        super(builder, CommentHandlers.values());
+    }
+
+    @Override
+    protected void loadInternal(ConfigurationNode node, BufferedReader reader) throws IOException {
+        node.setValue(result);
+    }
+
+    @Override
+    protected void saveInternal(ConfigurationNode node, Writer writer) throws IOException {
+        result.setValue(node);
+    }
+
+    public ConfigurationNode getNode() {
+        return this.result;
+    }
+
+    public void setNode(ConfigurationNode node) {
+        this.result = node;
+    }
+
+    /**
+     * Return an empty node of the most appropriate type for this loader
+     *
+     * @param options The options to use with this node. Must not be null (take a look at {@link ConfigurationOptions#defaults()})
+     * @return The appropriate node type
+     */
+    @Override
+    public ConfigurationNode createEmptyNode(ConfigurationOptions options) {
+        return SimpleConfigurationNode.root(options);
+    }
+}

--- a/src/test/java/io/github/nucleuspowered/nucleus/tests/configurate/TypeSerialiserTests.java
+++ b/src/test/java/io/github/nucleuspowered/nucleus/tests/configurate/TypeSerialiserTests.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.tests.configurate;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.common.reflect.TypeToken;
+import io.github.nucleuspowered.nucleus.configurate.typeserialisers.SetTypeSerialiser;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializerCollection;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Set;
+
+public class TypeSerialiserTests {
+
+    private TestConfigurationLoader getSetTestLoader() {
+        TestConfigurationLoader.Builder tclb = TestConfigurationLoader.builder();
+        TypeSerializerCollection tsc = tclb.getDefaultOptions().getSerializers();
+        tsc.registerPredicate(
+                typeToken -> Set.class.isAssignableFrom(typeToken.getRawType()),
+                new SetTypeSerialiser()
+        );
+
+        tclb.setDefaultOptions(tclb.getDefaultOptions().setSerializers(tsc));
+        return tclb.build();
+    }
+
+    @Test
+    public void testThatSetsCanBeSerialised() throws ObjectMappingException {
+        TestConfigurationLoader tcl = getSetTestLoader();
+        ConfigurationNode cn = tcl.createEmptyNode().setValue(new TypeToken<Set<String>>() {}, Sets.newHashSet("test", "test2"));
+
+        List<String> ls = cn.getList(TypeToken.of(String.class));
+        Assert.assertTrue(ls.contains("test"));
+        Assert.assertTrue(ls.contains("test2"));
+    }
+
+    @Test
+    public void testThatSetsCanBeDeserialised() throws ObjectMappingException {
+        TestConfigurationLoader tcl = getSetTestLoader();
+        ConfigurationNode cn = tcl.createEmptyNode().setValue(new TypeToken<List<String>>() {}, Lists.newArrayList("test", "test", "test2"));
+
+        Set<String> ls = cn.getValue(new TypeToken<Set<String>>() {});
+        Assert.assertEquals(2, ls.size());
+        Assert.assertTrue(ls.contains("test"));
+        Assert.assertTrue(ls.contains("test2"));
+    }
+}


### PR DESCRIPTION
This PR will include

- [x] `/buy` - buy an item from the server
- [x] `/sell` - sell an item to the server
- [x] `/setworth [buy|sell]` - set the cost of an item to buy or sell
- [x] `/nucleus itemalias set [item] <alias>` - set an alias for an item for use in `/buy` etc. (initially).
- [x] `/nucleus itemalias remove <alias>` - remove an alias
- [x] Add aliases to `/iteminfo`

There is also some configurate related updates, including a way to add additional process for a setting (in this case, to lowercase entries), and a Set serialiser. Also, improves the `ImprovedCatalogTypeParser`.

This will close #291 