### PR TITLE
Improve /seen

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/api/data/seen/BasicSeenInformationProvider.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/data/seen/BasicSeenInformationProvider.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.api.data.seen;
+
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.text.Text;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.function.BiFunction;
+
+public class BasicSeenInformationProvider implements SeenInformationProvider {
+
+    private final String permission;
+    private final BiFunction<CommandSource, User, Collection<Text>> getterFunction;
+
+    public BasicSeenInformationProvider(String permission, BiFunction<CommandSource, User, Collection<Text>> getterFunction) {
+        this.permission = permission;
+        this.getterFunction = getterFunction;
+    }
+
+    @Override
+    public boolean hasPermission(@Nonnull CommandSource source, @Nonnull User user) {
+        return source.hasPermission(permission);
+    }
+
+    @Nonnull
+    @Override
+    public Collection<Text> getInformation(@Nonnull CommandSource source, @Nonnull User user) {
+        return getterFunction.apply(source, user);
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/api/data/seen/SeenInformationProvider.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/data/seen/SeenInformationProvider.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.api.data.seen;
+
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.text.Text;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+
+/**
+ * A {@link SeenInformationProvider} object can hook into the {@code seen} command and provide extra information on a player.
+ *
+ * <p>
+ *     This must be registered with the {@link io.github.nucleuspowered.nucleus.api.service.NucleusSeenService}
+ * </p>
+ */
+public interface SeenInformationProvider {
+
+    /**
+     * Gets whether the requesting {@link CommandSource} has permission to request the provided information for the
+     * requested {@link User}.
+     *
+     * @param source The {@link CommandSource} who ran the {@code seen} command.
+     * @param user The {@link User} that information has been requested about.
+     * @return {@code true} if the command should show the user this information.
+     */
+    boolean hasPermission(@Nonnull CommandSource source, @Nonnull User user);
+
+    /**
+     * Gets the information to display to the {@link CommandSource} about the {@link User}
+     *
+     * <p>
+     *     Permission checks should NOT be done here, but in the {@link #hasPermission(CommandSource, User)} check.
+     * </p>
+     *
+     * @param source The {@link CommandSource} who ran the {@code seen} command.
+     * @param user The {@link User} that information has been requested about.
+     * @return The {@link Collection} containing the {@link Text} to display to the user, or an empty iterable. It is
+     *         recommended, for obvious reasons, that this is ordered! May return {@code null} if there is nothing
+     *         to return.
+     */
+    Collection<Text> getInformation(@Nonnull CommandSource source, @Nonnull User user);
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/api/service/NucleusSeenService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/service/NucleusSeenService.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.api.service;
+
+import io.github.nucleuspowered.nucleus.api.data.seen.SeenInformationProvider;
+
+import javax.annotation.Nonnull;
+
+/**
+ * This service allows plugins to register handlers that will display information when a player runs the /seen command.
+ *
+ * <p>
+ *     Plugins are expected to only register <strong>one</strong> {@link SeenInformationProvider}.
+ * </p>
+ *
+ * <p>
+ *     Consumers of this API should also note that this will run <strong>asynchronously</strong>. No methods that would
+ *     require the use of a synchronous API should be used here.
+ * </p>
+ */
+public interface NucleusSeenService {
+
+    /**
+     * Registers a {@link SeenInformationProvider} with Nucleus.
+     *
+     * @param plugin The plugin registering the service.
+     * @param seenInformationProvider The {@link SeenInformationProvider}
+     * @throws IllegalArgumentException Thrown if the plugin has either
+     * <ul>
+     *  <li>Registered a {@link SeenInformationProvider} already</li>
+     *  <li>Not provided the {@link org.spongepowered.api.plugin.Plugin} annotated class</li>
+     * </ul>
+     */
+    void register(@Nonnull Object plugin, @Nonnull SeenInformationProvider seenInformationProvider) throws IllegalArgumentException;
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/datatypes/UserDataNode.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/datatypes/UserDataNode.java
@@ -83,6 +83,9 @@ public class UserDataNode {
     @Setting
     private boolean isFrozen = false;
 
+    @Setting
+    private LocationNode lastLocation;
+
     public MuteData getMuteData() {
         return muteData;
     }
@@ -245,5 +248,13 @@ public class UserDataNode {
 
     public void setFrozen(boolean isFrozen) {
         this.isFrozen = isFrozen;
+    }
+
+    public LocationNode getLastLocation() {
+        return lastLocation;
+    }
+
+    public void setLastLocation(LocationNode lastLocation) {
+        this.lastLocation = lastLocation;
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/dataservices/UserService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/dataservices/UserService.java
@@ -406,8 +406,9 @@ public class UserService extends Service<UserDataNode>
         setJailData(null);
     }
 
-    public void setOnLogout() {
+    public void setOnLogout(Location<World> location) {
         setLastLogout(Instant.now());
+        data.setLastLocation(new LocationNode(location));
 
         // Set data based toggles.
         isFlying();
@@ -577,6 +578,14 @@ public class UserService extends Service<UserDataNode>
      */
     public final Instant serviceLoadTime() {
         return serviceLoadTime;
+    }
+
+    public Optional<Location<World>> getLogoutLocation() {
+        try {
+            return Optional.ofNullable(data.getLastLocation().getLocation());
+        } catch (NoSuchWorldException | NullPointerException e) {
+            return Optional.empty();
+        }
     }
 
     private String getNickPrefix() {

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/qsml/module/StandardModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/qsml/module/StandardModule.java
@@ -8,6 +8,7 @@ import com.google.inject.Inject;
 import com.google.inject.Injector;
 import io.github.nucleuspowered.nucleus.Nucleus;
 import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.api.data.seen.BasicSeenInformationProvider;
 import io.github.nucleuspowered.nucleus.config.CommandsConfig;
 import io.github.nucleuspowered.nucleus.internal.InternalServiceManager;
 import io.github.nucleuspowered.nucleus.internal.ListenerBase;
@@ -16,15 +17,22 @@ import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.annotations.SkipOnError;
 import io.github.nucleuspowered.nucleus.internal.command.AbstractCommand;
 import io.github.nucleuspowered.nucleus.internal.command.CommandBuilder;
+import io.github.nucleuspowered.nucleus.modules.playerinfo.handlers.SeenHandler;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.scheduler.Task;
+import org.spongepowered.api.text.Text;
 import uk.co.drnaylor.quickstart.Module;
+import uk.co.drnaylor.quickstart.annotations.ModuleData;
 import uk.co.drnaylor.quickstart.config.AbstractConfigAdapter;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -147,5 +155,13 @@ public abstract class StandardModule implements Module {
 
             throw e;
         }
+    }
+
+    protected final void createSeenModule(Class<? extends AbstractCommand> permissionClass, BiFunction<CommandSource, User, Collection<Text>> function) {
+        // Register seen information. Get the permission from Check Ban...
+        nucleus.getPermissionRegistry().getService(permissionClass).ifPresent(permissionHandler ->
+                // then get if the seen handler exists.
+                nucleus.getInternalServiceManager().getService(SeenHandler.class).ifPresent(x -> x.register(nucleus, this.getClass().getAnnotation(ModuleData.class).name(),
+                        new BasicSeenInformationProvider(permissionHandler.getBase(), function))));
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/StopCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/StopCommand.java
@@ -42,6 +42,7 @@ public class StopCommand extends CommandBase<CommandSource> {
         } else {
             Sponge.getServer().shutdown();
         }
+
         return CommandResult.success();
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/core/config/CoreConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/core/config/CoreConfig.java
@@ -25,6 +25,9 @@ public class CoreConfig {
     @Setting(value = "command-on-name-click", comment = "loc:config.core.commandonname")
     private String commandOnNameClick = "/msg {{player}}";
 
+    @Setting(value = "kick-on-stop")
+    private KickOnStopConfig kickOnStop = new KickOnStopConfig();
+
     public boolean isDebugmode() {
         return debugmode;
     }
@@ -43,5 +46,13 @@ public class CoreConfig {
 
     public String getCommandOnNameClick() {
         return commandOnNameClick;
+    }
+
+    public boolean isKickOnStop() {
+        return kickOnStop.isKickOnStop();
+    }
+
+    public String getKickOnStopMessage() {
+        return kickOnStop.getKickOnStopMessage();
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/core/config/KickOnStopConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/core/config/KickOnStopConfig.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.core.config;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+@ConfigSerializable
+public class KickOnStopConfig {
+    @Setting(value = "enabled", comment = "loc:config.core.kickonstop.flag")
+    private boolean kickOnStop = false;
+
+    @Setting(value = "message", comment = "loc:config.core.kickonstop.message")
+    private String kickOnStopMessage = "Server closed";
+
+    public boolean isKickOnStop() {
+        return kickOnStop;
+    }
+
+    public String getKickOnStopMessage() {
+        return kickOnStopMessage;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/core/listeners/CoreListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/core/listeners/CoreListener.java
@@ -9,25 +9,32 @@ import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.dataservices.UserService;
 import io.github.nucleuspowered.nucleus.dataservices.loaders.UserDataManager;
 import io.github.nucleuspowered.nucleus.internal.ListenerBase;
+import io.github.nucleuspowered.nucleus.modules.core.config.CoreConfigAdapter;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.Order;
+import org.spongepowered.api.event.filter.Getter;
 import org.spongepowered.api.event.game.GameReloadEvent;
+import org.spongepowered.api.event.game.state.GameStoppingServerEvent;
 import org.spongepowered.api.event.network.ClientConnectionEvent;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.format.TextColors;
+import org.spongepowered.api.text.serializer.TextSerializers;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
 import java.time.Instant;
+import java.util.Iterator;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 public class CoreListener extends ListenerBase {
 
     @Inject private UserDataManager loader;
+    @Inject private CoreConfigAdapter cca;
+    private boolean runSync = false;
 
     /* (non-Javadoc)
      * We do this first to try to get the first play status as quick as possible.
@@ -59,14 +66,40 @@ public class CoreListener extends ListenerBase {
     }
 
     @Listener
-    public void onPlayerQuit(final ClientConnectionEvent.Disconnect event) {
-        Sponge.getScheduler().createAsyncExecutor(plugin).schedule(() -> {
-            try {
-                this.plugin.getUserDataManager().get(event.getTargetEntity()).ifPresent(UserService::setOnLogout);
-            } catch (Exception e) {
+    public void onPlayerQuit(final ClientConnectionEvent.Disconnect event, @Getter("getTargetEntity") final Player player) {
+        final Location<World> location = player.getLocation();
+        if (runSync) {
+            // Work around things not existing, run quit events sync just as the server draws to a close.
+            onPlayerQuitInner(player, location);
+        } else {
+            Sponge.getScheduler().createAsyncExecutor(plugin).schedule(() -> onPlayerQuitInner(player, location), 200, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    private void onPlayerQuitInner(final Player player, final Location<World> location) {
+        try {
+            this.plugin.getUserDataManager().get(player).ifPresent(x -> x.setOnLogout(location));
+        } catch (Exception e) {
+            if (cca.getNodeOrDefault().isDebugmode()) {
                 e.printStackTrace();
             }
-        }, 200, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @Listener
+    public void onServerAboutToStop(final GameStoppingServerEvent event) {
+        runSync = true;
+        if (cca.getNodeOrDefault().isKickOnStop()) {
+            Iterator<Player> players = Sponge.getServer().getOnlinePlayers().iterator();
+            while (players.hasNext()) {
+                Text msg = TextSerializers.FORMATTING_CODE.deserialize(cca.getNodeOrDefault().getKickOnStopMessage());
+                if (msg.isEmpty()) {
+                    players.next().kick();
+                } else {
+                    players.next().kick(msg);
+                }
+            }
+        }
     }
 
     @Listener

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/note/NoteModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/note/NoteModule.java
@@ -4,13 +4,18 @@
  */
 package io.github.nucleuspowered.nucleus.modules.note;
 
+import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.service.NucleusNoteService;
 import io.github.nucleuspowered.nucleus.internal.qsml.module.ConfigurableModule;
+import io.github.nucleuspowered.nucleus.modules.note.commands.CheckNotesCommand;
 import io.github.nucleuspowered.nucleus.modules.note.config.NoteConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.note.handlers.NoteHandler;
 import org.slf4j.Logger;
 import org.spongepowered.api.Game;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.action.TextActions;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
 
 
@@ -40,5 +45,26 @@ public class NoteModule extends ConfigurableModule<NoteConfigAdapter> {
             ex.printStackTrace();
             throw ex;
         }
+    }
+
+    @Override
+    public void onEnable() {
+        super.onEnable();
+
+        // Take base permission from /checkwarnings.
+        createSeenModule(CheckNotesCommand.class, (c, u) -> {
+
+            NoteHandler jh = nucleus.getInternalServiceManager().getService(NoteHandler.class).get();
+            int active = jh.getNotes(u).size();
+
+            Text r = Util.getTextMessageWithFormat("seen.notes", String.valueOf(active));
+            if (active > 0) {
+                return Lists.newArrayList(
+                        r.toBuilder().onClick(TextActions.runCommand("/checknotes " + u.getName()))
+                                .onHover(TextActions.showText(Util.getTextMessageWithFormat("standard.clicktoseemore"))).build());
+            }
+
+            return Lists.newArrayList(r);
+        });
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/playerinfo/PlayerInfoModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/playerinfo/PlayerInfoModule.java
@@ -4,8 +4,11 @@
  */
 package io.github.nucleuspowered.nucleus.modules.playerinfo;
 
+import io.github.nucleuspowered.nucleus.api.service.NucleusSeenService;
 import io.github.nucleuspowered.nucleus.internal.qsml.module.ConfigurableModule;
 import io.github.nucleuspowered.nucleus.modules.playerinfo.config.PlayerInfoConfigAdapter;
+import io.github.nucleuspowered.nucleus.modules.playerinfo.handlers.SeenHandler;
+import org.spongepowered.api.Sponge;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
 
 @ModuleData(id = "playerinfo", name = "Player Info")
@@ -14,5 +17,14 @@ public class PlayerInfoModule extends ConfigurableModule<PlayerInfoConfigAdapter
     @Override
     public PlayerInfoConfigAdapter getAdapter() {
         return new PlayerInfoConfigAdapter();
+    }
+
+    @Override
+    protected void performPreTasks() throws Exception {
+        super.performPreTasks();
+
+        SeenHandler sh = new SeenHandler();
+        Sponge.getServiceManager().setProvider(nucleus, NucleusSeenService.class, sh);
+        nucleus.getInternalServiceManager().registerService(SeenHandler.class, sh);
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/playerinfo/handlers/SeenHandler.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/playerinfo/handlers/SeenHandler.java
@@ -1,0 +1,100 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.playerinfo.handlers;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import io.github.nucleuspowered.nucleus.Nucleus;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.api.data.seen.SeenInformationProvider;
+import io.github.nucleuspowered.nucleus.api.service.NucleusSeenService;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class SeenHandler implements NucleusSeenService {
+
+    private final Map<String, SeenInformationProvider> moduleInformationProviders = Maps.newTreeMap();
+    private final Map<String, SeenInformationProvider> pluginInformationProviders = Maps.newTreeMap();
+
+    @Override
+    public void register(@Nonnull Object plugin, @Nonnull SeenInformationProvider seenInformationProvider) throws IllegalArgumentException {
+        Preconditions.checkNotNull(plugin);
+        Preconditions.checkNotNull(seenInformationProvider);
+
+        Plugin pl = plugin.getClass().getAnnotation(Plugin.class);
+        Preconditions.checkArgument(pl != null, Util.getMessageWithFormat("seen.error.requireplugin"));
+
+        String name = pl.name();
+        Preconditions.checkArgument(!pluginInformationProviders.containsKey(name), Util.getMessageWithFormat("seen.error.pluginregistered"));
+
+        pluginInformationProviders.put(name, seenInformationProvider);
+    }
+
+    public void register(Nucleus plugin, String module, SeenInformationProvider seenInformationProvider) throws IllegalArgumentException {
+        Preconditions.checkNotNull(plugin);
+        Preconditions.checkNotNull(module);
+        Preconditions.checkNotNull(seenInformationProvider);
+        Preconditions.checkArgument(plugin.getClass().getAnnotation(Plugin.class).equals(Nucleus.class.getAnnotation(Plugin.class)));
+
+        Preconditions.checkArgument(!moduleInformationProviders.containsKey(module));
+        moduleInformationProviders.put(module, seenInformationProvider);
+    }
+
+    public List<Text> buildInformation(final CommandSource requester, final User user) {
+        List<Text> information = getModuleText(requester, user);
+        information.addAll(getText(requester, user));
+        return information;
+    }
+
+    private List<Text> getModuleText(final CommandSource requester, final User user) {
+        List<Text> information = Lists.newArrayList();
+
+        for (Map.Entry<String, SeenInformationProvider> entry : moduleInformationProviders.entrySet()) {
+            SeenInformationProvider sip = entry.getValue();
+            if (sip.hasPermission(requester, user)) {
+                Collection<Text> input = entry.getValue().getInformation(requester, user);
+                if (input != null && !input.isEmpty()) {
+                    information.addAll(input);
+                }
+            }
+        }
+
+        return information;
+    }
+
+    private List<Text> getText(final CommandSource requester, final User user) {
+        List<Text> information = Lists.newArrayList();
+
+        for (Map.Entry<String, SeenInformationProvider> entry : pluginInformationProviders.entrySet()) {
+            SeenInformationProvider sip = entry.getValue();
+            if (sip.hasPermission(requester, user)) {
+                Collection<Text> input = entry.getValue().getInformation(requester, user);
+                if (input != null && !input.isEmpty()) {
+                    if (information.isEmpty()) {
+                        information.add(Text.EMPTY);
+                        information.add(Text.of("-----"));
+                        information.add(Util.getTextMessageWithFormat("seen.header.plugins"));
+                        information.add(Text.of("-----"));
+                    }
+
+                    information.add(Text.EMPTY);
+                    information.add(Text.of(TextColors.AQUA, entry.getKey() + ":"));
+                    information.addAll(input);
+                }
+            }
+        }
+
+        return information;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/WarnModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warn/WarnModule.java
@@ -4,13 +4,18 @@
  */
 package io.github.nucleuspowered.nucleus.modules.warn;
 
+import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.service.NucleusWarnService;
 import io.github.nucleuspowered.nucleus.internal.qsml.module.ConfigurableModule;
+import io.github.nucleuspowered.nucleus.modules.warn.commands.CheckWarningsCommand;
 import io.github.nucleuspowered.nucleus.modules.warn.config.WarnConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.warn.handlers.WarnHandler;
 import org.slf4j.Logger;
 import org.spongepowered.api.Game;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.action.TextActions;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
 
 @ModuleData(id = "warn", name = "Warn")
@@ -38,5 +43,27 @@ public class WarnModule extends ConfigurableModule<WarnConfigAdapter> {
             ex.printStackTrace();
             throw ex;
         }
+    }
+
+    @Override
+    public void onEnable() {
+        super.onEnable();
+
+        // Take base permission from /checkwarnings.
+        createSeenModule(CheckWarningsCommand.class, (c, u) -> {
+
+            WarnHandler jh = nucleus.getInternalServiceManager().getService(WarnHandler.class).get();
+            int active = jh.getWarnings(u, true, false).size();
+            int expired = jh.getWarnings(u, false, true).size();
+
+            Text r = Util.getTextMessageWithFormat("seen.warnings", String.valueOf(active), String.valueOf(expired));
+            if (active > 0) {
+                return Lists.newArrayList(
+                        r.toBuilder().onClick(TextActions.runCommand("/checkwarnings " + u.getName()))
+                                .onHover(TextActions.showText(Util.getTextMessageWithFormat("standard.clicktoseemore"))).build());
+            }
+
+            return Lists.newArrayList(r);
+        });
     }
 }

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -19,9 +19,6 @@ standard.reason=Reason: {0}
 standard.accept=Accept
 standard.deny=Deny
 
-standard.offline=offline
-standard.online=online
-
 standard.flying=flying
 standard.walking=walking
 
@@ -29,11 +26,10 @@ standard.view=[View]
 standard.reply=[Reply]
 standard.delete=[Delete]
 
-standard.buy=buy
-standard.sell=sell
-
 standard.buyfrom=buy from the server
 standard.sellto=sell to the server
+
+standard.clicktoseemore=Click here to see more.
 
 startup.preinit={0} is now starting. Entering pre-init phase.
 startup.postinit={0} is now entering the post-init phase.
@@ -223,6 +219,8 @@ config.core.warmup.info=If true, cancel a user''s warmup on...
 config.core.warmup.move=movement
 config.core.warmup.command=running a command
 config.core.commandonname='If set, this command will be suggested if a player clicks on the user name in chat in templated messages. Use {{player}} to indicate the player name.'
+config.core.kickonstop.flag=If true, Nucleus will kick all users just prior to the server stopping.
+config.core.kickonstop.message=The message to display to players when restarting the server. Overridden when using the /stop [reason] command.
 
 config.misc.speed.max=Sets the maximum speed that a player can set via the /speed command.
 
@@ -635,14 +633,18 @@ command.tpa.question=&e{0} has requested that they teleport to you.
 command.tpask.sent=&aA teleport request was sent to &e{0}&a.
 
 command.seen.title=&aPlayer Info: &e{0}
-command.seen.iscurrently=&e{0}&b is currently
-command.seen.displayname=&bDisplay name:&f
-command.seen.ipaddress=&bIP Address:&f
-command.seen.isjailed=&bJailed:&f
-command.seen.ismuted=&bMuted:&f
-command.seen.isbanned=&bBanned:&f
-command.seen.loggedon=&bOnline for:&f
-command.seen.loggedoff=&bLast online:&f
+command.seen.iscurrently.online=&e{0}&b is currently &aonline
+command.seen.iscurrently.offline=&e{0}&b is currently &coffline
+command.seen.displayname=&bDisplay name: &f{0}
+command.seen.ipaddress=&bIP Address: &f{0}
+command.seen.loggedon=&bOnline for: &f{0}
+command.seen.loggedoff=&bLast online: &f{0}
+command.seen.currentlocation=&bCurrent Location: &f{0}
+command.seen.lastlocation=&bLast Location: &f{0}
+command.seen.speed.walk=&bWalking Speed: &f{0}
+command.seen.speed.fly=&bFlying Speed: &f{0}
+command.seen.core=Core
+command.seen.locationtemplate=World: {0}, Co-ords: {1}
 
 command.ban.alreadyset=&e{0} &chas already been banned.
 command.ban.applied=&e{0} &awas banned by &e{1}&a.
@@ -978,6 +980,23 @@ gameprofile.new=&eThe user {0} has not logged onto the server before. They have 
 # Info
 info.load.duplicate=Duplicate file name detected - {0}. It has not been loaded - note that case does not matter.
 
+# Seen
+seen.error.requireplugin=The plugin (annotated with @Plugin) must be provided as the plugin object.
+seen.error.pluginregistered=This plugin has already registered a provider.
+seen.header.modules=&bModules
+seen.header.plugins=&bPlugins
+seen.isbanned.temp=&bBans: &c&oTemporarily banned for {0}.
+seen.isbanned.perm=&bBans: &c&oPermanently banned.
+seen.isjailed.temp=&bJails: &c&oTemporarily jailed for {0}.
+seen.isjailed.perm=&bJails: &c&oPermanently jailed.
+seen.ismuted.temp=&bMutes: &c&oTemporarily muted for {0}.
+seen.ismuted.perm=&bMutes: &c&oPermanently muted.
+seen.notbanned=&bBan: &fNot banned.
+seen.notjailed=&bJail: &fNot jailed.
+seen.notmuted=&bMute: &fNot muted.
+seen.warnings=&bWarnings: &f{0} active, {1} expired.
+seen.notes=&bNotes: &f{0} notes attached.
+
 # Teleport
 teleport.to.success=&aYou have teleported to &e{0}&a''s location.
 teleport.from.success=&e{0} &ateleported to your location.
@@ -1022,7 +1041,7 @@ permission.nick.magic=Allows the user to use "magic" characters in their nicknam
 
 permission.list.seevanished=Allows the user to see vanished players in /list.
 
-permission.seen.extended=Allows the user to see entended information about a player in /seen.
+permission.seen.extended=Allows the user to see extended information about a player in /seen.
 
 permission.spawn.otherworlds=Allows the user to go to another world''s spawnpoint.
 


### PR DESCRIPTION
Resolves #346 and resolves #347 

This adds a way for plugins to add to `/seen`. Plugins require the `NucleusSeenService`, and need to register a `SeenInformationProvider`. The methods get passed a `CommandSource` - the requesting player, and `User`, the user that information is required.

Also, adds ability to kick on stop, because some people have requested that.