### PR TITLE
Added integration with the Nucleus Mixin project, add enhanced world generation command.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,11 @@ ext.url = 'http://nucleuspowered.org'
 group 'io.github.nucleuspowered'
 version '0.12.0-5.0-SNAPSHOT'
 
+def mixinversion = '0.12.0-5.0-SNAPSHOT';
 def qsmlDep = "uk.co.drnaylor:quickstart-moduleloader:0.3.0";
+def mixinDep = "io.github.nucleuspowered:NucleusMixins:" + mixinversion;
 
-defaultTasks 'licenseFormat'
+defaultTasks 'licenseFormat build'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -28,6 +30,10 @@ repositories {
     maven {
         name 'Sponge maven repo'
         url 'http://repo.spongepowered.org/maven'
+    }
+    maven {
+        name 'drnaylor-minecraft'
+        url 'http://repo.drnaylor.co.uk/artifactory/list/minecraft'
     }
     maven {
         name 'drnaylor'
@@ -41,6 +47,12 @@ repositories {
 dependencies {
     compile "org.spongepowered:spongeapi:5.0.0-SNAPSHOT"
     compile qsmlDep
+    compile(mixinDep) {
+        exclude module: 'mixin'
+        exclude module: 'launchwrapper'
+        exclude module: 'guava'
+    }
+
     compile "com.github.hsyyid:EssentialCmds:v8.1.7"
 
     testCompile "junit:junit:4.12"
@@ -80,6 +92,7 @@ blossom {
 
     replaceToken '@description@', project.description, location
     replaceToken '@url@', project.url, location
+    replaceToken '@mixinversion@', mixinversion, location
 }
 
 jar {

--- a/src/main/java/io/github/nucleuspowered/nucleus/Nucleus.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/Nucleus.java
@@ -65,4 +65,6 @@ public abstract class Nucleus {
     public abstract MessageProvider getMessageProvider();
 
     public abstract MessageProvider getCommandMessageProvider();
+
+    public abstract boolean areMixinsAvailable();
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/NucleusPlugin.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/NucleusPlugin.java
@@ -108,6 +108,7 @@ public class NucleusPlugin extends Nucleus {
     @Inject private Logger logger;
     private Path configDir;
     private Path dataDir;
+    private boolean mixinsAvailable = false;
 
     // We inject this into the constructor so we can build the config path ourselves.
     @Inject
@@ -119,6 +120,14 @@ public class NucleusPlugin extends Nucleus {
     @Listener
     public void onPreInit(GamePreInitializationEvent preInitializationEvent) {
         logger.info(messageProvider.getMessageWithFormat("startup.preinit", PluginInfo.NAME));
+
+        try {
+            Class.forName("io.github.nucleuspowered.nucleus.mixins.NucleusMixinSpongePlugin");
+            this.mixinsAvailable = true;
+            logger.info(messageProvider.getMessageWithFormat("startup.mixins-available"));
+        } catch (ClassNotFoundException e) {
+            logger.info(messageProvider.getMessageWithFormat("startup.mixins-notavailable"));
+        }
 
         dataDir = game.getSavesDirectory().resolve("nucleus");
         // Get the mandatory config files.
@@ -416,6 +425,11 @@ public class NucleusPlugin extends Nucleus {
 
     public Optional<Instant> getGameStartedTime() {
         return Optional.ofNullable(this.gameStartedTime);
+    }
+
+    @Override
+    public boolean areMixinsAvailable() {
+        return mixinsAvailable;
     }
 
     private Injector runInjectorUpdate() {

--- a/src/main/java/io/github/nucleuspowered/nucleus/PluginInfo.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/PluginInfo.java
@@ -22,6 +22,8 @@ public final class PluginInfo {
     public static final String VERSION = "@version@";
     public static final String GIT_HASH = "@gitHash@";
 
+    public static final String MIXIN_VERSION = "@mixinversion@";
+
     // Preparing for 4.0.0 SpongeAPI
     public static final String DESCRIPTION = "@description@";
     public static final String URL = "@url@";

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/annotations/RequireMixinPlugin.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/annotations/RequireMixinPlugin.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.internal.annotations;
+
+import java.lang.annotation.*;
+
+/**
+ * Indicates that the Nucleus Mixin plugin is required for this command/listener/event to be loaded.
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequireMixinPlugin {
+
+    /**
+     * Returns whether to document this requirement in DocGen.
+     *
+     * @return {@code true} if so.
+     */
+    boolean document() default true;
+
+    /**
+     * Returns whether the console is notified on startup that this class may be skipped.
+     *
+     * @return {@code true} if so.
+     */
+    boolean notifyOnLoad() default true;
+
+    /**
+     * Sets whether this command should only be loaded when the Mixin Companion plugin is present, not, or in both caes.
+     * Defaults to both.
+     *
+     * @return {@link MixinLoad} that defines whether to load the command or not.
+     */
+    MixinLoad value();
+
+    enum MixinLoad {
+        BOTH,
+        NO_MIXIN,
+        MIXIN_ONLY
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/command/AbstractCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/command/AbstractCommand.java
@@ -970,6 +970,10 @@ public abstract class AbstractCommand<T extends CommandSource> implements Comman
                 textMessages.add(plugin.getMessageProvider().getTextMessageWithFormat("command.usage.playeronly"));
             }
 
+            if (parent.getClass().isAnnotationPresent(RequireMixinPlugin.class)) {
+                textMessages.add(plugin.getMessageProvider().getTextMessageWithFormat("command.usage.mixin"));
+            }
+
             textMessages.add(plugin.getMessageProvider().getTextMessageWithFormat("command.usage.module", module, moduleId));
 
             String desc = getDescription();

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/docgen/CommandDoc.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/docgen/CommandDoc.java
@@ -46,6 +46,9 @@ public class CommandDoc {
     private boolean cost;
 
     @Setting
+    private boolean requiresMixin;
+
+    @Setting
     private List<PermissionDoc> permissions;
 
     public String getCommandName() {
@@ -142,5 +145,13 @@ public class CommandDoc {
 
     public void setPermissions(List<PermissionDoc> permissions) {
         this.permissions = permissions;
+    }
+
+    public boolean isRequiresMixin() {
+        return requiresMixin;
+    }
+
+    public void setRequiresMixin(boolean requiresMixin) {
+        this.requiresMixin = requiresMixin;
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/docgen/DocGenCache.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/docgen/DocGenCache.java
@@ -60,6 +60,9 @@ public class DocGenCache {
         cmd.setCost(!cac.isAnnotationPresent(NoCost.class));
         cmd.setWarmup(!cac.isAnnotationPresent(NoWarmup.class));
 
+        RequireMixinPlugin rmp = cac.getAnnotation(RequireMixinPlugin.class);
+        cmd.setRequiresMixin(rmp != null && rmp.document() && rmp.value() == RequireMixinPlugin.MixinLoad.MIXIN_ONLY);
+
         String desc = abstractCommand.getDescription();
         if (!desc.contains(" ")) {
             logger.warn("Cannot generate description for: " + abstractCommand.getAliases()[0] + ": " + desc);

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/world/WorldHelper.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/world/WorldHelper.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.LoggerWrapper;
 import io.github.nucleuspowered.nucleus.NucleusPlugin;
+import io.github.nucleuspowered.nucleus.modules.world.commands.border.gen.EnhancedGeneration;
 import org.slf4j.Logger;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.scheduler.Task;
@@ -26,6 +27,16 @@ public class WorldHelper {
     public boolean isPregenRunningForWorld(UUID uuid) {
         cleanup();
         return pregen.containsKey(uuid);
+    }
+
+    public boolean addPregenForWorld(World world, EnhancedGeneration.NucleusChunkPreGenerator preGenerator) {
+        cleanup();
+        if (!isPregenRunningForWorld(world.getUniqueId())) {
+            pregen.put(world.getUniqueId(), Sponge.getScheduler().createTaskBuilder().intervalTicks(4).execute(preGenerator).submit(plugin));
+            return true;
+        }
+
+        return false;
     }
 
     public boolean startPregenningForWorld(World world) {

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/border/gen/EnhancedGeneration.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/border/gen/EnhancedGeneration.java
@@ -1,0 +1,267 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.world.commands.border.gen;
+
+import com.flowpowered.math.GenericMath;
+import com.flowpowered.math.vector.Vector3i;
+import io.github.nucleuspowered.nucleus.Nucleus;
+import io.github.nucleuspowered.nucleus.NucleusPlugin;
+import io.github.nucleuspowered.nucleus.mixins.interfaces.INucleusMixinWorld;
+import io.github.nucleuspowered.nucleus.mixins.interfaces.INucleusMixinWorldServer;
+import io.github.nucleuspowered.nucleus.modules.world.WorldHelper;
+import org.apache.commons.lang3.time.DurationFormatUtils;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.scheduler.Task;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.channel.MessageChannel;
+import org.spongepowered.api.world.Chunk;
+import org.spongepowered.api.world.World;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+
+/**
+ * Generation for the NucleusMixin enhanced version.
+ */
+public class EnhancedGeneration implements BiFunction<World, CommandSource, CommandResult> {
+
+    private final String notifyPermission;
+    private final WorldHelper worldHelper;
+
+    public EnhancedGeneration(WorldHelper worldHelper, String notifyPermission) {
+        this.worldHelper = worldHelper;
+        this.notifyPermission = notifyPermission;
+    }
+
+    @Override
+    public CommandResult apply(World world, CommandSource source) {
+        worldHelper.addPregenForWorld(world, new NucleusChunkPreGenerator(world, notifyPermission));
+        source.sendMessage(NucleusPlugin.getNucleus().getMessageProvider().getTextMessageWithFormat("command.world.gen.using.enhanced"));
+        source.sendMessage(Nucleus.getNucleus().getMessageProvider().getTextMessageWithFormat("command.world.gen.started", world.getProperties().getWorldName()));
+        return CommandResult.success();
+    }
+
+    /* (non-Javadoc)
+     * This is based on the SpongeChunkPreGenerator by SpongePowered, and is reused under the terms of the MIT licence,
+     * with modification.
+     */
+    public static class NucleusChunkPreGenerator implements Consumer<Task> {
+
+        private static final Vector3i[] OFFSETS = {
+                Vector3i.UNIT_Z.negate().mul(2),
+                Vector3i.UNIT_X.mul(2),
+                Vector3i.UNIT_Z.mul(2),
+                Vector3i.UNIT_X.negate().mul(2)
+        };
+        private static final String TIME_FORMAT = "s's 'S'ms'";
+        private final World world;
+        private final int chunkRadius;
+        private final long tickTimeLimit;
+        private final String notifyPermission;
+        private double finalTotal;
+        private Vector3i currentPosition;
+        private int currentGenCount;
+        private int currentLayer;
+        private int currentIndex;
+        private int nextJump;
+        private int totalCount;
+        private long totalTime;
+
+        private int totalChunksGenerated = 0;
+        private long originalStartTime;
+        private long lastLogTime;
+        private long lastSaveTime;
+        private long deltaTime = 0;
+        private int chunksGenerated = 0;
+        private int skipped = 0;
+        private boolean highMemTriggered = false;
+
+        private NucleusChunkPreGenerator(World world, String permission) {
+            this.notifyPermission = permission;
+            this.world = world;
+            this.chunkRadius = GenericMath.floor(world.getWorldBorder().getDiameter() / (2 * Sponge.getServer().getChunkLayout().getChunkSize().getX()));
+            this.tickTimeLimit = Math.round(Sponge.getScheduler().getPreferredTickInterval() * 0.8);
+            final Optional<Vector3i> currentPosition = Sponge.getServer().getChunkLayout().toChunk(world.getWorldBorder().getCenter().toInt());
+            if (currentPosition.isPresent()) {
+                this.currentPosition = currentPosition.get();
+            } else {
+                throw new IllegalArgumentException("Center is not a valid chunk coordinate");
+            }
+            this.currentGenCount = 4;
+            this.currentLayer = 0;
+            this.currentIndex = 0;
+            this.nextJump = 0;
+            this.totalCount = 0;
+            this.totalTime = 0;
+            this.finalTotal = Math.pow(this.chunkRadius * 2 + 1, 2);
+        }
+
+        @Override
+        public void accept(Task task) {
+            final long startTime = System.currentTimeMillis();
+            if (originalStartTime == 0) {
+                originalStartTime = startTime;
+                lastLogTime = startTime;
+                lastSaveTime = startTime;
+            }
+
+            long percent = getMemPercent();
+            if (percent >= 90) {
+                if (!highMemTriggered) {
+                    world.getLoadedChunks().forEach(Chunk::unloadChunk);
+                    save();
+                    NucleusPlugin.getNucleus().getMessageProvider().getTextMessageWithFormat("command.pregen.gen.memory.high", String.valueOf(percent));
+                    highMemTriggered = true;
+                }
+
+                // Try again next tick.
+                return;
+            } else if (highMemTriggered && percent <= 80) {
+                // Get the memory usage down to 80% to prevent too much ping pong.
+                highMemTriggered = false;
+                NucleusPlugin.getNucleus().getMessageProvider().getTextMessageWithFormat("command.pregen.gen.memory.low");
+            }
+
+            INucleusMixinWorld inmw = ((INucleusMixinWorld)world);
+            do {
+                final Vector3i position = nextChunkPosition();
+                Vector3i pos1 = position.sub(Vector3i.UNIT_X);
+                Vector3i pos2 = position.sub(Vector3i.UNIT_Z);
+                Vector3i pos3 = pos2.sub(Vector3i.UNIT_X);
+
+                // Try not to load chunks that have already been loaded to minimise memory usage.
+                if (!(inmw.hasChunkBeenGenerated(position) && inmw.hasChunkBeenGenerated(pos1)
+                        && inmw.hasChunkBeenGenerated(pos2) && inmw.hasChunkBeenGenerated(pos3))) {
+                    // Only mark as generated if we actually have to generate at least one.
+                    chunksGenerated += this.currentGenCount;
+                    this.world.loadChunk(position, true);
+                    this.world.loadChunk(position.sub(Vector3i.UNIT_X), true);
+                    this.world.loadChunk(position.sub(Vector3i.UNIT_Z), true);
+                    this.world.loadChunk(position.sub(Vector3i.UNIT_X).sub(Vector3i.UNIT_Z), true);
+                } else {
+                    skipped += this.currentGenCount;
+                }
+            } while (hasNextChunkPosition() && checkTickTime(System.currentTimeMillis() - startTime));
+
+            final long currentTimeMillis = System.currentTimeMillis();
+            deltaTime += currentTimeMillis - startTime;
+
+            if (lastLogTime + 5000 < currentTimeMillis) {
+                this.totalCount += (chunksGenerated + skipped);
+                this.totalChunksGenerated += chunksGenerated;
+                final long logTime = System.currentTimeMillis() - lastLogTime;
+                this.totalTime += deltaTime;
+
+                Text message;
+                if (skipped > 0) {
+                    message = NucleusPlugin.getNucleus().getMessageProvider().getTextMessageWithFormat("command.pregen.gen.notifyskipped",
+                            String.valueOf(chunksGenerated),
+                            String.valueOf(skipped),
+                            DurationFormatUtils.formatDuration(deltaTime, TIME_FORMAT, false),
+                            DurationFormatUtils.formatDuration(logTime, TIME_FORMAT, false),
+                            String.valueOf(GenericMath.floor((this.totalCount * 100) / this.finalTotal)));
+                } else {
+                    message = NucleusPlugin.getNucleus().getMessageProvider().getTextMessageWithFormat("command.pregen.gen.notify",
+                            String.valueOf(chunksGenerated),
+                            DurationFormatUtils.formatDuration(deltaTime, TIME_FORMAT, false),
+                            DurationFormatUtils.formatDuration(logTime, TIME_FORMAT, false),
+                            String.valueOf(GenericMath.floor((this.totalCount * 100) / this.finalTotal)));
+                }
+
+                getChannel().send(message);
+                lastLogTime = System.currentTimeMillis();
+                deltaTime = 0;
+                skipped = 0;
+                chunksGenerated = 0;
+            }
+
+            if (lastSaveTime + 20000 < currentTimeMillis) {
+                MessageChannel.TO_ALL.send(NucleusPlugin.getNucleus().getMessageProvider().getTextMessageWithFormat("command.pregen.gen.all"));
+                save();
+            }
+
+            if (!hasNextChunkPosition()) {
+                this.totalCount += (chunksGenerated + skipped);
+                this.totalChunksGenerated += chunksGenerated;
+                save();
+                getChannel().send(
+                        NucleusPlugin.getNucleus().getMessageProvider().getTextMessageWithFormat("command.pregen.gen.completed",
+                                String.valueOf(this.totalChunksGenerated),
+                                String.valueOf(this.totalCount - this.totalChunksGenerated),
+                                DurationFormatUtils.formatDuration(this.totalTime, TIME_FORMAT, false),
+                                DurationFormatUtils.formatDuration(currentTimeMillis - this.originalStartTime, TIME_FORMAT, false)
+                        ));
+                task.cancel();
+            }
+        }
+
+        private boolean hasNextChunkPosition() {
+            return this.currentLayer <= this.chunkRadius;
+        }
+
+        private MessageChannel getChannel() {
+            return MessageChannel.combined(MessageChannel.TO_CONSOLE, MessageChannel.permission(this.notifyPermission));
+        }
+
+        private Vector3i nextChunkPosition() {
+            final Vector3i nextPosition = this.currentPosition;
+            final int currentLayerIndex;
+            if (this.currentIndex >= this.nextJump) {
+                // Reached end of layer, jump to the next so we can keep spiralling
+                this.currentPosition = this.currentPosition.sub(Vector3i.UNIT_X).sub(Vector3i.UNIT_Z);
+                this.currentLayer++;
+                // Each the jump increment increases by 4 at each new layer
+                this.nextJump += this.currentLayer * 4;
+                currentLayerIndex = 1;
+            } else {
+                // Get the current index since the last jump
+                currentLayerIndex = this.currentIndex - (this.nextJump - this.currentLayer * 4);
+                // Move to next position in layer, by following a square
+                this.currentPosition = this.currentPosition.add(OFFSETS[currentLayerIndex / this.currentLayer]);
+            }
+            // If we're at the corner it's 3, else 2 for an edge
+            this.currentGenCount = currentLayerIndex % this.currentLayer == 0 ? 3 : 2;
+            this.currentIndex++;
+            return nextPosition;
+        }
+
+        private boolean checkTickTime(long tickTime) {
+            return tickTime < this.tickTimeLimit;
+        }
+
+        private long getMemPercent() {
+            // Check system memory
+            long max = Runtime.getRuntime().maxMemory() / 1024 / 1024;
+            long total = Runtime.getRuntime().totalMemory() / 1024 / 1024;
+            long free = Runtime.getRuntime().freeMemory() / 1024 / 1024;
+
+            return ((max - total + free ) * 100)/ max;
+        }
+
+        private void save() {
+            getChannel().send(
+                    NucleusPlugin.getNucleus().getMessageProvider().getTextMessageWithFormat("command.pregen.gen.saving"));
+            try {
+                try {
+                    world.save();
+                } catch (AbstractMethodError e) {
+                    ((INucleusMixinWorldServer) world).saveWorld();
+                }
+
+                getChannel().send(
+                        NucleusPlugin.getNucleus().getMessageProvider().getTextMessageWithFormat("command.pregen.gen.saved"));
+            } catch (Throwable e) {
+                getChannel().send(
+                        NucleusPlugin.getNucleus().getMessageProvider().getTextMessageWithFormat("command.pregen.gen.savefailed"));
+                e.printStackTrace();
+            } finally {
+                lastSaveTime = System.currentTimeMillis();
+            }
+        }
+    }
+}

--- a/src/main/resources/assets/nucleus/commands.properties
+++ b/src/main/resources/assets/nucleus/commands.properties
@@ -163,7 +163,15 @@ world.teleport.desc=Teleports to a world.
 world.spawn.desc=Teleports to world spawn.
 world.border.desc=Parent command for world border commands.
 world.border.set.desc=Sets the world border.
-world.border.gen.desc=Instructs Sponge to pregenerate chunks within the world border.
+world.border.gen.desc=Generates chunks up to the world border.
+world.border.gen.extended=When invoked, Nucleus will start generating chunks up to the world border. During this time, \
+  the server will be susceptible to reduced performance.\n\n\
+  If Nucleus Mixins are loaded on this server, Nucleus will use a custom routine that provides greater information to \
+  server admins, and will not attempt to generate any chunks that have been deemed to be loaded already, though \
+  enhancement of the Sponge routinues.\n\n\
+  If Nucleus Mixins are not available, or the -s flag is specified, Nucleus will fall back to the standard Sponge \
+  pre-gen routines.
+
 world.border.cancelgen.desc=Cancels any current world border generation.
 
 blacklist.desc=Parent command for all other blacklist commands.

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -35,6 +35,8 @@ standard.on=on
 standard.off=off
 
 startup.preinit={0} is now starting. Entering pre-init phase.
+startup.mixins-available=Nucleus Mixin companion plugin has been detected. Enhanced functionality is available.
+startup.mixins-notavailable=Nucleus Mixin companion plugin has not been detected.
 startup.postinit={0} is now entering the post-init phase.
 startup.moduleloading={0} is now loading and enabling modules. This may take a few seconds.
 startup.modulenotloaded={0} was unable to load modules and has aborted loading.
@@ -65,6 +67,14 @@ nucleus.module.disabled.forceloadtwo=Be aware: this might cause conflicts with t
 nucleus.module.disabled.modulerequest=The plugin {0} ({1} has requested that the module {2} be disabled. It will not be loaded.
 
 nucleus.injector.duplicate=Attempted to register the class {0} in Guice when it has already been registered. Skipping.
+
+loader.mixinrequired.command=Will not load the command "{0}", requires mixin plugin.
+loader.mixinrequired.listener=Will not load the listener "{0}", requires mixin plugin.
+loader.mixinrequired.runnable=Will not load the runnable "{0}", requires mixin plugin.
+
+loader.nomixinrequired.command=Will not load the command "{0}", requires that there is no mixin plugin.
+loader.nomixinrequired.listener=Will not load the listener "{0}", requires that there is no mixin plugin.
+loader.nomixinrequired.runnable=Will not load the runnable "{0}", requires that there is no mixin plugin.
 
 warmup.start=&aWarmup started. Your command will be executed in &e{0}&a.
 warmup.both=&aDo not move or run a command.
@@ -341,6 +351,7 @@ commandlog.couldnotwrite=Could not write log entry to Nucleus command log file
 command.usage.module=&eModule: &f{0} &e(ID: &f{1}&e)
 command.usage.header=&aUsage for &e/{0}
 command.usage.playeronly=&eThe command can only be run by players.
+command.usage.mixin=&eThis command requires the installation of the Nucleus Mixin plugin.
 command.usage.summary=&eSummary:
 command.usage.description=&eDescription:
 command.usage.usage=&eUsage:
@@ -363,7 +374,7 @@ command.file.load=&cCould not load user information.
 
 command.error=&cAn error occurred trying to perform that command.
 command.targetisafk=&f{0} &7is currently AFK and may not respond quickly.
-command.economyrequired=&cAn economy is required for this command to work, no compatibile plugins are installed.
+command.economyrequired=&cAn economy is required for this command to work, no compatible plugins are installed.
 
 command.playeronly=&cThis command can only be executed by players.
 

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -512,11 +512,23 @@ command.world.gen.started=&aGeneration of chunks within the world border for the
 command.world.gen.continue=Generation of chunks for "{0}" is still ongoing. Last message:
 command.world.cancelgen.cancelled=&aGeneration of chunks within the world border for the world &e{0} &ahas been cancelled.
 command.world.cancelgen.notask=&cThere is no chunk generation task running for the world "&e{0}&c".
+command.world.gen.using.standard=Using Sponge''s chunk generation routines.
+command.world.gen.using.enhanced=Using Nucleus'' mixin enhanced chunk generation routines.
 
 command.world.border.centre=&aCentre - x: {0}, z: {1}
 command.world.border.currentdiameter=&aCurrent Diameter: {0} blocks
 command.world.border.targetdiameter=&aTarget Diameter: {0} blocks in {1} seconds.
 command.world.border.title=&aWorld Border: &e{0}
+
+command.pregen.gen.notify=&e{0} chunks were generated in {1} (over {2}). Generation is {3}% complete.
+command.pregen.gen.notifyskipped=&e{0} chunks were generated ({1} skipped) in {2} (over {3}). Generation is {4}% complete.
+command.pregen.gen.saving=&eNow saving world, just in case.
+command.pregen.gen.savefailed=&cCould not save world. Going to continue anyway, check the console for details.
+command.pregen.gen.saved=&eWorld has been saved. Continuing generation.
+command.pregen.gen.memory.high=&cMemory usage is high ({0}%). Generation is paused, requesting unload of chunks.
+command.pregen.gen.memory.low=&cMemory usage has reduced. Generation is restarting.
+command.pregen.gen.all=&cA world pre-generation is in progress. The server may run slowly whilst this completes.
+command.pregen.gen.completed=&aWorld generation is complete. {0} chunks were generated ({1} were pre existing), taking {2} of server time (overall: {3}).
 
 command.blacklist.add.success=&a{0} has been added to the blacklist.
 command.blacklist.add.alreadyadded=&c{0} is already blacklisted.
@@ -1198,3 +1210,5 @@ permission.speed.exempt.max=Allows the user to specified a speed greater than th
 
 permission.voice.auto=Automatically grants the user voice if a global mute is in effect.
 permission.voice.notify=If granted, this user is told when a player''s voice status is changed.
+
+permission.world.border.gen.notify=If granted and enhanced generation is being used, these players are notified of progress to the generation.

--- a/src/test/java/io/github/nucleuspowered/nucleus/tests/TestBase.java
+++ b/src/test/java/io/github/nucleuspowered/nucleus/tests/TestBase.java
@@ -190,5 +190,10 @@ public abstract class TestBase {
         public MessageProvider getCommandMessageProvider() {
             return null;
         }
+
+        @Override
+        public boolean areMixinsAvailable() {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
There are a few things that probably won't fit into the Sponge API, but as an essentials style plugin might be nice to do. This has come about due to #389, to see if I can create a better pre-gen routine, and also adding a precursor to `/invsee` if I can. However, Nucleus as a core should be available to all implementations of Sponge, and some might not be able to use our Mixins due to mod conflicts.

So, https://github.com/NucleusPowered/NucleusMixins is the companion plugin for SpongeCommon based servers, and Nucleus will detect this plugin and use the enhanced functionality if it exists.