### PR TITLE
Add way to have a custom info file, rather than a section list, when running /info.

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/InfoArgument.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/InfoArgument.java
@@ -14,10 +14,11 @@ import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.args.CommandElement;
 import org.spongepowered.api.text.Text;
 
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
 
 public class InfoArgument extends CommandElement {
 
@@ -55,7 +56,7 @@ public class InfoArgument extends CommandElement {
         public final String name;
         public final List<String> text;
 
-        private Result(String name, List<String> text) {
+        public Result(String name, List<String> text) {
             this.name = name;
             this.text = text;
         }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/info/commands/MotdCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/info/commands/MotdCommand.java
@@ -7,7 +7,12 @@ package io.github.nucleuspowered.nucleus.modules.info.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.ChatUtil;
 import io.github.nucleuspowered.nucleus.internal.TextFileController;
-import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoCooldown;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoCost;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoWarmup;
+import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
+import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import io.github.nucleuspowered.nucleus.modules.info.InfoModule;
 import io.github.nucleuspowered.nucleus.modules.info.config.InfoConfigAdapter;
@@ -37,7 +42,7 @@ public class MotdCommand extends io.github.nucleuspowered.nucleus.internal.comma
             return CommandResult.empty();
         }
 
-        if (infoConfigAdapter.getNodeOrDefault().isUsePagination()) {
+        if (infoConfigAdapter.getNodeOrDefault().isMotdUsePagination()) {
             InfoHelper.sendInfo(otfc.get(), src, chatUtil, infoConfigAdapter.getNodeOrDefault().getMotdTitle());
         } else {
             InfoHelper.getTextFromStrings(otfc.get().getFileContents(), src, chatUtil).forEach(src::sendMessage);

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/info/config/InfoConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/info/config/InfoConfig.java
@@ -4,31 +4,35 @@
  */
 package io.github.nucleuspowered.nucleus.modules.info.config;
 
-import io.github.nucleuspowered.nucleus.Nucleus;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
 @ConfigSerializable
 public class InfoConfig {
 
-    @Setting(value = "show-motd-on-join", comment = "loc:config.motd.onjoin")
-    private boolean showMotdOnJoin = true;
+    @Setting(value = "motd")
+    private MotdConfig motdConfig = new MotdConfig();
 
-    @Setting(value = "motd-title", comment = "loc:config.motd.title")
-    private String motdTitle = Nucleus.getNucleus().getMessageProvider().getMessageWithFormat("motd.title");
-
-    @Setting(value = "use-pagination", comment = "loc:config.motd.pagination")
-    private boolean usePagination = true;
+    @Setting("info")
+    private InfoFileConfig infoFileConfig = new InfoFileConfig();
 
     public boolean isShowMotdOnJoin() {
-        return showMotdOnJoin;
+        return motdConfig.isShowMotdOnJoin();
     }
 
     public String getMotdTitle() {
-        return motdTitle;
+        return motdConfig.getMotdTitle();
     }
 
-    public boolean isUsePagination() {
-        return usePagination;
+    public boolean isMotdUsePagination() {
+        return motdConfig.isUsePagination();
+    }
+
+    public boolean isUseDefaultFile() {
+        return infoFileConfig.isUseDefaultFile();
+    }
+
+    public String getDefaultInfoSection() {
+        return infoFileConfig.getDefaultInfoSection();
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/info/config/InfoConfigAdapter.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/info/config/InfoConfigAdapter.java
@@ -4,11 +4,22 @@
  */
 package io.github.nucleuspowered.nucleus.modules.info.config;
 
+import com.google.common.collect.Lists;
 import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
+
+import java.util.List;
 
 public class InfoConfigAdapter extends NucleusConfigAdapter.StandardWithSimpleDefault<InfoConfig> {
 
     public InfoConfigAdapter() {
         super(InfoConfig.class);
+    }
+
+    @Override protected List<Transformation> getTransformations() {
+        return Lists.newArrayList(
+            new Transformation(new Object[] { "show-motd-on-join" }, (inputPath, valueAtPath) -> new Object[] { "motd", "show-motd-on-join" }),
+            new Transformation(new Object[] { "motd-title" }, (inputPath, valueAtPath) -> new Object[] { "motd", "motd-title" }),
+            new Transformation(new Object[] { "show-motd-on-join" }, (inputPath, valueAtPath) -> new Object[] { "motd", "use-pagination" })
+        );
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/info/config/InfoFileConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/info/config/InfoFileConfig.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.info.config;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+@ConfigSerializable
+public class InfoFileConfig {
+
+    @Setting(value = "use-default-info-section", comment = "loc:config.info.defaultinfo")
+    private boolean useDefaultFile = false;
+
+    @Setting(value = "default-info-section", comment = "loc:config.info.section")
+    private String defaultInfoSection = "info";
+
+    public boolean isUseDefaultFile() {
+        return useDefaultFile;
+    }
+
+    public String getDefaultInfoSection() {
+        return defaultInfoSection;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/info/config/MotdConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/info/config/MotdConfig.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.info.config;
+
+import io.github.nucleuspowered.nucleus.Nucleus;
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+@ConfigSerializable
+public class MotdConfig {
+
+    @Setting(value = "show-motd-on-join", comment = "loc:config.motd.onjoin")
+    private boolean showMotdOnJoin = true;
+
+    @Setting(value = "motd-title", comment = "loc:config.motd.title")
+    private String motdTitle = Nucleus.getNucleus().getMessageProvider().getMessageWithFormat("motd.title");
+
+    @Setting(value = "use-pagination", comment = "loc:config.motd.pagination")
+    private boolean usePagination = true;
+
+    public boolean isShowMotdOnJoin() {
+        return showMotdOnJoin;
+    }
+
+    public String getMotdTitle() {
+        return motdTitle;
+    }
+
+    public boolean isUsePagination() {
+        return usePagination;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/info/listeners/InfoListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/info/listeners/InfoListener.java
@@ -43,7 +43,7 @@ public class InfoListener extends ListenerBase {
         Sponge.getScheduler().createAsyncExecutor(plugin).schedule(() -> {
                 if (player.hasPermission(getMotdPermission())) {
                     plugin.getTextFileController(InfoModule.MOTD_KEY).ifPresent(x -> {
-                        if (ica.getNodeOrDefault().isUsePagination()) {
+                        if (ica.getNodeOrDefault().isMotdUsePagination()) {
                             InfoHelper.sendInfo(x, player, chatUtil, ica.getNodeOrDefault().getMotdTitle());
                         } else {
                             InfoHelper.getTextFromStrings(x.getFileContents(), player, chatUtil).forEach(player::sendMessage);

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -207,6 +207,10 @@ config.motd.title=The title to show at the top of each MOTD page. Colour codes a
 config.motd.pagination=If false, this disables the pagination system for the MOTD. Set this to false if you have one page, do not want a title, and do not want the << >> marks to appear, \
 otherwise, it is recommended to set this to true.
 
+config.info.defaultinfo=If true, when a player runs "/info", the section specified in "default-info-section" will be used, that is, /info will work the same as /info <default-section>. \n\
+The list of sections can still be viewed by running "/info -l", if the user has the "nucleus.info.list" permission. If false, or the section does not exist, this list is shown, regardless of this permission.
+config.info.section=If "use-default-info-section" is true, this section is displayed when a player runs "/info", not the section list.
+
 config.commandlogger.source.base=If any option is true, log commands from the source.
 config.commandlogger.whitelist=If true, the "command-filter" containing the list of commands to be logged is a whitelist (command must be specfied to be logged), not a blacklist.
 config.commandlogger.list=A comma separated list of commands in the blacklist or whitelist (see whitelist option). Only one alias per command is required.
@@ -1253,6 +1257,7 @@ permission.back.onportal=Sets the player''s /back location on portal teleports.
 permission.enchant.unsafe=Allows setting enchantments and levels that are not ordinarily available to the held item.
 
 permission.motd.join=If granted, the user will see the MOTD when joining the server.
+permission.info.list=If granted, the player can run /info -l to see all the available info sections.
 
 permission.spawn.exempt.login=If granted, and the configuration is set to send players to spawn on login, this permission will prevent the player from going to spawn on login.
 


### PR DESCRIPTION
To do this, set `info.info.use-default-info-section` to `true` and `info.info.default-info-section` to the section you want to display by default. So, if you want to display `/info first` by default, set this `default-info-section` option to `first`, and `use-default-info-section` to `true`.

* Add -l to /info to display the list, if the permission "nucleus.info.list" is granted.
* Moves MOTD config options into a sub-level, "motd".

Fixes #391