### PR TITLE
Add the GeoIP module (disabled by default).

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ Nucleus is available via a Maven repository.
 
 You can also use [JitPack](https://jitpack.io/#NucleusPowered/Nucleus) as a repository, if you prefer.
 
+## Third Party Libraries
+
+The compiled Nucleus plugin includes the following libraries (with their licences in parentheses):
+
+* QuickStart Module Loader (MIT)
+* MaxMind GeoIP2 API (Apache 2)
+* MaxMind DB (Apache 2)
+* Jackson (Apache 2)
+
+See [THIRDPARTY.md](THIRDPARTY.md) for more details.
+
 [Source]: https://github.com/NucleusPowered/Nucleus
 [Issues]: https://github.com/NucleusPowered/Nucleus/issues
 [Downloads]: https://github.com/NucleusPowered/Nucleus/releases

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -1,0 +1,238 @@
+Third Party Inclusions
+===
+
+Nucleus includes several open source third party libraries and data. We are thankful to all those who
+ provide such tools to allow us to provide the services that we do.
+   
+### QuickStart Module Loader
+
+Used to load all modules, included in the plugin JAR. Licenced under the MIT licence.
+
+### MaxMind GeoLite2 IP database
+
+Used in the GeoIP module, and is downloaded directly from MaxMind. When using the GeoIP2 databases, 
+the following statement applies: 
+
+This product includes GeoLite2 data created by MaxMind, available from http://maxmind.com
+
+The databases are licenced under the [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/)
+
+The Nucleus team is grateful for the free use of their databases under the CC licence.
+
+### MaxMind DB and MaxMind GeoIP2 API wrapper
+
+Used in the GeoIP module, included in the plugin JAR.
+
+These libraries are available under the terms of the Apache 2 licence, certified as open source and compatible with the MIT licence.
+The Apache 2 licence will be reproduced at the bottom of this file. 
+
+## Jackson JSON library
+
+Used in the GeoIP module, included in the plugin JAR.
+
+These libraries are available under the terms of the Apache 2 licence, certified as open source and compatible with the MIT licence.
+The Apache 2 licence will be reproduced at the bottom of this file.
+
+## Apache Licence Version 2.0
+
+Apache License<br/>
+Version 2.0, January 2004<br/>
+http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ version '0.16.0-5.0-SNAPSHOT'
 
 def mixinversion = '0.15.0-5.0'
 def qsmlDep = "uk.co.drnaylor:quickstart-moduleloader:0.4.0"
+def geoIpDep = 'com.maxmind.geoip2:geoip2:2.8.0'
 def mixinDep = "io.github.nucleuspowered:NucleusMixins:" + mixinversion
 
 defaultTasks 'licenseFormat build'
@@ -55,6 +56,9 @@ dependencies {
 
     compile "com.github.hsyyid:EssentialCmds:v8.1.7"
 
+    // For Geo IP
+    compile geoIpDep
+
     testCompile "junit:junit:4.12"
     testCompile "org.mockito:mockito-all:1.10.19"
     testCompile "org.powermock:powermock-module-junit4:1.6.4"
@@ -67,6 +71,7 @@ license {
     exclude "**/*.info"
     exclude "assets/**"
     exclude "*.properties"
+    exclude "*.txt"
 
     header file('HEADER.txt')
     sourceSets = project.sourceSets
@@ -128,6 +133,15 @@ def private String getGitHash() {
 shadowJar {
     dependencies {
         include(dependency(qsmlDep))
+        include(dependency(geoIpDep))
+        include(dependency("com.maxmind.db:maxmind-db"))
+        include(dependency("com.fasterxml.jackson.core:jackson-core"))
+        include(dependency("com.fasterxml.jackson.core:jackson-databind"))
+        include(dependency("com.fasterxml.jackson.core:jackson-annotations"))
     }
+
+    relocate 'com.maxmind.geoip2', 'io.github.nucleuspowered.relocate.com.maxmind.geoip2'
+    relocate 'com.maxmind.db', 'io.github.nucleuspowered.relocate.com.maxmind.db'
+    relocate 'com.fasterxml.jackson', 'io.github.nucleuspowered.relocate.com.fasterxml.jackson'
 }
 build.dependsOn(shadowJar)

--- a/src/main/java/io/github/nucleuspowered/nucleus/NucleusPlugin.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/NucleusPlugin.java
@@ -244,7 +244,7 @@ public class NucleusPlugin extends Nucleus {
             if (moduleContainer.getConfigAdapterForModule("core", CoreConfigAdapter.class).getNodeOrDefault().isErrorOnStartup()) {
                 throw new IllegalStateException("In main.conf, core.simulate-error-on-startup is set to TRUE. Remove this config entry to allow Nucleus to start. Simulating error and disabling Nucleus.");
             }
-        } catch (Exception construction) {
+        } catch (Throwable construction) {
             logger.info(messageProvider.getMessageWithFormat("startup.modulenotloaded", PluginInfo.NAME));
             construction.printStackTrace();
             disable();
@@ -271,7 +271,7 @@ public class NucleusPlugin extends Nucleus {
                 // Save any additions.
                 moduleContainer.refreshSystemConfig();
                 fireReloadables();
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 isErrored = e;
                 disable();
                 errorOnStartup();

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/geoip/GeoIpModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/geoip/GeoIpModule.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.geoip;
+
+import io.github.nucleuspowered.nucleus.internal.qsml.module.ConfigurableModule;
+import io.github.nucleuspowered.nucleus.modules.geoip.config.GeoIpConfigAdapter;
+import io.github.nucleuspowered.nucleus.modules.geoip.handlers.GeoIpDatabaseHandler;
+import uk.co.drnaylor.quickstart.annotations.ModuleData;
+import uk.co.drnaylor.quickstart.enums.LoadingStatus;
+
+@ModuleData(id = GeoIpModule.ID, name = "Geo IP", status = LoadingStatus.DISABLED)
+public class GeoIpModule extends ConfigurableModule<GeoIpConfigAdapter> {
+
+    public static final String ID = "geo-ip";
+
+    @Override public GeoIpConfigAdapter getAdapter() {
+        return new GeoIpConfigAdapter();
+    }
+
+    @Override protected void performPreTasks() throws Exception {
+        super.performPreTasks();
+
+        GeoIpDatabaseHandler databaseHandler = new GeoIpDatabaseHandler(plugin);
+        plugin.getInternalServiceManager().registerService(GeoIpDatabaseHandler.class, databaseHandler);
+    }
+
+    @Override public void onEnable() {
+        super.onEnable();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/geoip/commands/GeoIpCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/geoip/commands/GeoIpCommand.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.geoip.commands;
+
+import com.google.inject.Inject;
+import com.maxmind.geoip2.record.Country;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoCooldown;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoCost;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoWarmup;
+import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
+import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.command.AbstractCommand;
+import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
+import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import io.github.nucleuspowered.nucleus.modules.geoip.handlers.GeoIpDatabaseHandler;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.text.Text;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@RunAsync
+@NoCooldown
+@NoCost
+@NoWarmup
+@Permissions
+@RegisterCommand("geoip")
+public class GeoIpCommand extends AbstractCommand<CommandSource> {
+
+    @Inject private GeoIpDatabaseHandler databaseHandler;
+
+    private final String playerKey = "player";
+
+    @Override protected Map<String, PermissionInformation> permissionSuffixesToRegister() {
+        return new HashMap<String, PermissionInformation>() {{
+            put("login", new PermissionInformation(plugin.getMessageProvider().getMessageWithFormat("permission.geoip.login"), SuggestedLevel.ADMIN));
+        }};
+    }
+
+    @Override public CommandElement[] getArguments() {
+        return new CommandElement[] {
+            GenericArguments.player(Text.of(playerKey))
+        };
+    }
+
+    @Override public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        Optional<Country> country = databaseHandler.getDetails(args.<Player>getOne(playerKey).get().getConnection().getAddress().getAddress()).get();
+        if (country.isPresent()) {
+            src.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat("geoip.playerfrom", country.get().getName()));
+        } else {
+            src.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat("geoip.noinfo"));
+        }
+
+        return CommandResult.success();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/geoip/commands/GeoIpUpdateCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/geoip/commands/GeoIpUpdateCommand.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.geoip.commands;
+
+import io.github.nucleuspowered.nucleus.internal.annotations.NoCooldown;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoCost;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoWarmup;
+import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
+import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.command.AbstractCommand;
+import io.github.nucleuspowered.nucleus.modules.geoip.handlers.GeoIpDatabaseHandler;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+
+@RunAsync
+@NoCooldown
+@NoCost
+@NoWarmup
+@Permissions
+@RegisterCommand(value = "update", subcommandOf = GeoIpCommand.class)
+public class GeoIpUpdateCommand extends AbstractCommand<CommandSource> {
+
+    @Override public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        src.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat("command.geoip.update.start"));
+        try {
+            plugin.getInternalServiceManager().getService(GeoIpDatabaseHandler.class).get().load(
+                GeoIpDatabaseHandler.LoadType.DOWNLOAD, false);
+            src.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat("command.geoip.update.complete"));
+        } catch (IllegalStateException e) {
+            src.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat("command.geoip.update.licence"));
+        } catch (Exception e) {
+            if (plugin.isDebugMode()) {
+                e.printStackTrace();
+            }
+        }
+
+        return CommandResult.success();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/geoip/config/GeoIpConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/geoip/config/GeoIpConfig.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.geoip.config;
+
+import io.github.nucleuspowered.nucleus.configurate.annotations.DoNotGenerate;
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+@ConfigSerializable
+public class GeoIpConfig {
+
+    // Not localised, this is a legal statement that should be adhered to.
+    @Setting(value = "accept-licences", comment = "By setting this to true, you agree to the licences for the MaxMind GeoLite 2 databases, and the information as displayed at http://nucleuspowered.org/thirdparty/geoip.html \nor in the geoip.txt file in the plugin JAR (you can open the Nucleus JAR with any zip program)")
+    private boolean acceptLicence = false;
+
+    @Setting(value = "alert-on-login", comment = "loc:config.geoip.onlogin")
+    private boolean alertOnLogin = false;
+
+    // Not generated, only should be added if there is a problem to redress.
+    @DoNotGenerate
+    @Setting(value = "country-data")
+    private String countryUrl = "http://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.mmdb.gz";
+
+    public boolean isAcceptLicence() {
+        return acceptLicence;
+    }
+
+    public boolean isAlertOnLogin() {
+        return alertOnLogin;
+    }
+
+    public String getCountryData() {
+        return countryUrl;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/geoip/config/GeoIpConfigAdapter.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/geoip/config/GeoIpConfigAdapter.java
@@ -1,0 +1,14 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.geoip.config;
+
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
+
+public class GeoIpConfigAdapter extends NucleusConfigAdapter.StandardWithSimpleDefault<GeoIpConfig> {
+
+    public GeoIpConfigAdapter() {
+        super(GeoIpConfig.class);
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/geoip/handlers/GeoIpDatabaseHandler.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/geoip/handlers/GeoIpDatabaseHandler.java
@@ -1,0 +1,196 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.geoip.handlers;
+
+import com.google.common.base.Preconditions;
+import com.maxmind.db.CHMCache;
+import com.maxmind.db.Reader;
+import com.maxmind.geoip2.DatabaseReader;
+import com.maxmind.geoip2.exception.AddressNotFoundException;
+import com.maxmind.geoip2.record.Country;
+import io.github.nucleuspowered.nucleus.Nucleus;
+import io.github.nucleuspowered.nucleus.NucleusPlugin;
+import io.github.nucleuspowered.nucleus.modules.geoip.GeoIpModule;
+import io.github.nucleuspowered.nucleus.modules.geoip.config.GeoIpConfigAdapter;
+import org.spongepowered.api.Sponge;
+
+import java.io.Closeable;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+import java.util.zip.GZIPInputStream;
+
+public class GeoIpDatabaseHandler implements Closeable {
+
+    private GeoIpConfigAdapter geoIpConfigAdapter = null;
+    private final Path downloadDirectory;
+    private final Path countries;
+    private DatabaseReader databaseReader;
+    private boolean isLoading = false;
+
+    public GeoIpDatabaseHandler(NucleusPlugin plugin) {
+        downloadDirectory = plugin.getDataPath().resolve("geoip");
+        countries = downloadDirectory.resolve("countries.mmdb");
+    }
+
+    /**
+     * Loads the IP database.
+     *
+     * <p>This method will respond in one of three ways, dependent on what {@link LoadType} is provided:</p>
+     * <ul>
+     *     <li>
+     *         {@link LoadType#IF_REQUIRED} will only load the database if it isn't already loaded.
+     *     </li>
+     *     <li>
+     *         {@link LoadType#RELOAD} will reload the database, but it won't re-download it.
+     *     </li>
+     *     <li>
+     *         {@link LoadType#DOWNLOAD} will re-download the database, even if it exists, and reload it.
+     *     </li>
+     * </ul>
+     *
+     * @param type The {@link LoadType}
+     * @param runAsync If true, will run the loading routines on a different thread.
+     * @throws Exception If there is a problem. {@link IllegalStateException} is thrown if the licence has not been accepted.
+     */
+    public void load(LoadType type, boolean runAsync) throws Exception {
+        if (isLoading) {
+            return;
+        }
+
+        Preconditions.checkNotNull(type);
+        init();
+
+        if (type == LoadType.IF_REQUIRED && databaseReader != null) {
+            return;
+        }
+
+        if (runAsync) {
+            Sponge.getScheduler().createAsyncExecutor(Nucleus.getNucleus()).execute(() -> onRun(type));
+        } else {
+            onRun(type);
+        }
+    }
+
+    private void onRun(LoadType type) {
+        try {
+            isLoading = true;
+
+            // Check in case we need it.
+            downloadUpdate(type == LoadType.DOWNLOAD);
+
+            if (databaseReader != null) {
+                databaseReader.close();
+            }
+
+            InputStream inputStream = new FileInputStream(countries.toFile());
+            databaseReader = new DatabaseReader.Builder(inputStream).withCache(new CHMCache()).fileMode(Reader.FileMode.MEMORY).build();
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            isLoading = false;
+        }
+    }
+
+    public CompletableFuture<Optional<Country>> getDetails(InetAddress address) throws Exception {
+        init();
+        load(LoadType.IF_REQUIRED, true);
+
+        final CompletableFuture<Optional<Country>> completableFuture = new CompletableFuture<>();
+
+        Sponge.getScheduler().createAsyncExecutor(Nucleus.getNucleus()).execute(() -> {
+            try {
+                int counter = 0;
+
+                // Load check.
+                if (isLoading) {
+                    while (counter < 30) {
+                        Thread.sleep(500);
+                        if (!isLoading) {
+                            break;
+                        }
+
+                        counter++;
+                    }
+
+                    if (counter == 30) {
+                        completableFuture.completeExceptionally(new TimeoutException("loading"));
+                        return;
+                    }
+                }
+
+                completableFuture.complete(Optional.ofNullable(databaseReader.country(address).getCountry()));
+            } catch (AddressNotFoundException ex) {
+                completableFuture.complete(Optional.empty());
+            } catch (Exception e) {
+                completableFuture.completeExceptionally(e);
+            }
+        });
+
+        return completableFuture;
+    }
+
+    private void init() throws Exception {
+        if (geoIpConfigAdapter == null) {
+            geoIpConfigAdapter = Nucleus.getNucleus().getModuleContainer().getConfigAdapterForModule(GeoIpModule.ID, GeoIpConfigAdapter.class);
+        }
+
+        if (!geoIpConfigAdapter.getNodeOrDefault().isAcceptLicence()) {
+            throw new IllegalStateException("licence");
+        }
+    }
+
+    private void downloadUpdate(boolean loadAnyway) throws Exception {
+        init();
+
+        Files.createDirectories(downloadDirectory);
+
+        if (loadAnyway || !Files.exists(countries)) {
+            downloadFile(geoIpConfigAdapter.getNodeOrDefault().getCountryData(), countries);
+        }
+    }
+
+    private void downloadFile(String url, Path path) throws IOException {
+        URL downloadUrl = new URL(url);
+        URLConnection conn = downloadUrl.openConnection();
+        conn.setConnectTimeout(10000);
+        conn.connect();
+
+        try(InputStream input = new GZIPInputStream(conn.getInputStream());
+            OutputStream output = new FileOutputStream(path.toFile())) {
+            byte[] buffer = new byte[2048];
+            int length = input.read(buffer);
+            while (length >= 0) {
+                output.write(buffer, 0, length);
+                length = input.read(buffer);
+            }
+
+            output.flush();
+        }
+    }
+
+    @Override public void close() throws IOException {
+        if (databaseReader != null) {
+            databaseReader.close();
+            databaseReader = null;
+        }
+    }
+
+    public enum LoadType {
+        IF_REQUIRED,
+        RELOAD,
+        DOWNLOAD
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/geoip/listeners/GeoIpListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/geoip/listeners/GeoIpListener.java
@@ -1,0 +1,99 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.geoip.listeners;
+
+import com.google.inject.Inject;
+import com.maxmind.geoip2.record.Country;
+import io.github.nucleuspowered.nucleus.Nucleus;
+import io.github.nucleuspowered.nucleus.internal.CommandPermissionHandler;
+import io.github.nucleuspowered.nucleus.internal.ListenerBase;
+import io.github.nucleuspowered.nucleus.internal.annotations.ConditionalListener;
+import io.github.nucleuspowered.nucleus.modules.geoip.GeoIpModule;
+import io.github.nucleuspowered.nucleus.modules.geoip.commands.GeoIpCommand;
+import io.github.nucleuspowered.nucleus.modules.geoip.config.GeoIpConfig;
+import io.github.nucleuspowered.nucleus.modules.geoip.config.GeoIpConfigAdapter;
+import io.github.nucleuspowered.nucleus.modules.geoip.handlers.GeoIpDatabaseHandler;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.Order;
+import org.spongepowered.api.event.network.ClientConnectionEvent;
+import org.spongepowered.api.text.channel.MessageChannel;
+import uk.co.drnaylor.quickstart.exceptions.IncorrectAdapterTypeException;
+import uk.co.drnaylor.quickstart.exceptions.NoModuleException;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+
+@ConditionalListener(GeoIpListener.Condition.class)
+public class GeoIpListener extends ListenerBase {
+
+    private CommandPermissionHandler commandPermissionHandler = null;
+
+    @Inject
+    private GeoIpDatabaseHandler handler;
+
+    @Listener(order = Order.LAST)
+    public void onPlayerJoin(ClientConnectionEvent.Join event) {
+        if (commandPermissionHandler == null) {
+            commandPermissionHandler = plugin.getPermissionRegistry().getService(GeoIpCommand.class);
+        }
+
+        Sponge.getScheduler().createAsyncExecutor(plugin).execute(() -> {
+            try {
+                CompletableFuture<Optional<Country>> future = handler.getDetails(event.getTargetEntity().getConnection().getAddress().getAddress());
+                future.handleAsync((result, exception) -> {
+                    if (result != null) {
+                        if (result.isPresent()) {
+                            MessageChannel.permission(commandPermissionHandler.getPermissionWithSuffix("login"))
+                                .send(plugin.getMessageProvider().getTextMessageWithFormat("geoip.playerfrom", result.get().getName()));
+                        } else {
+                            MessageChannel.permission(commandPermissionHandler.getPermissionWithSuffix("login"))
+                                .send(plugin.getMessageProvider().getTextMessageWithFormat("geoip.noinfo"));
+                        }
+                    } else if (exception != null) {
+                        if (plugin.isDebugMode()) {
+                            exception.printStackTrace();
+                        }
+                    }
+
+                    return result == null ? Optional.empty() : result;
+                });
+            } catch (Exception e) {
+                if (plugin.isDebugMode()) {
+                    e.printStackTrace();
+                }
+            }
+        });
+    }
+
+    public static final class Condition implements Predicate<Nucleus> {
+
+        private static boolean isPrinted = false;
+
+        @Override public boolean test(Nucleus nucleus) {
+            try {
+                GeoIpConfig gic = nucleus.getModuleContainer().getConfigAdapterForModule(GeoIpModule.ID, GeoIpConfigAdapter.class).getNodeOrDefault();
+                if (gic.isAcceptLicence()) {
+                    if (!isPrinted) {
+                        nucleus.getLogger()
+                            .info("GeoIP is enabled. Nucleus makes use of GeoLite2 data created by MaxMind, available from http://www.maxmind.com");
+                        isPrinted = true;
+                    }
+
+                    return gic.isAlertOnLogin();
+                }
+
+                return false;
+            } catch (NoModuleException | IncorrectAdapterTypeException e) {
+                if (nucleus.isDebugMode()) {
+                    e.printStackTrace();
+                }
+
+                return false;
+            }
+        }
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/util/ThrownFunction.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/util/ThrownFunction.java
@@ -1,0 +1,18 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.util;
+
+/**
+ * A function that accepts one argument and returns a result, but can also throw a checked exception.
+ *
+ * @param <I> The argument type.
+ * @param <R> The type of the result.
+ * @param <X> The type of {@link Exception} that could be thrown.
+ */
+@FunctionalInterface
+public interface ThrownFunction<I, R, X extends Throwable> {
+
+    R accept(I input) throws X;
+}

--- a/src/main/resources/assets/nucleus/commands.properties
+++ b/src/main/resources/assets/nucleus/commands.properties
@@ -365,3 +365,6 @@ nameunban.desc=Allows a specific IGN (rather than specific player) to join the s
 
 blockzap.desc=Sets the target block to air.
 blockzap.extended=Intended as an admin command to turn a problematic block to air.
+
+geoip.desc=Get the country a player has connected via.
+geoip.update.desc=Update the GeoIP database. It is recommended that you do this no more than once a month.

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -302,6 +302,8 @@ config.itemdatanode.blacklist.block-use=Prevents the item being used.
 
 config.item.skullcompat=If true, Nucleus will simply treat /skull as an alias to '"/give [player] skull [number] 3 {SkullOwner:[skullplayer]}"'
 
+config.geoip.onlogin=If true, Nucleus will tell players with the "nucleus.geoip.login" permission the country the player is connecting via. Please be considerate with this permission, do not give it to everyone.
+
 afk.kickreason=You have been kicked for being AFK for too long.
 
 # Arguments
@@ -1211,6 +1213,10 @@ command.blockzap.success=&aSuccessfully zapped the block at &e{0}&a in the world
 command.blockzap.fail=&cCould not zap the block at &e{0}&c in the world &e{1}&c.
 command.blockzap.alreadyair=&cThe block at &e{0} &cin the world &e{0}&c is already air.
 
+command.geoip.update.licence=&cYou must accept the GeoIP module licence in the main configration file before downloading the IP location databases.
+command.geoip.update.start=&aStarting download of GeoIP databases.
+command.geoip.update.complete=&aUpdate of GeoIP databases has completed.
+
 # Ban
 ban.defaultreason=The BanHammer has spoken!
 
@@ -1313,6 +1319,10 @@ teleport.warmup=&aYou will teleport in &e{0}&a seconds. Do not move or run a com
 
 teleport.accept.hover=&aClick to accept (&e/tpaccept&a)
 teleport.deny.hover=&cClick to deny (&e/tpdeny&c)
+
+# GeoIP
+geoip.playerfrom=&e[Nucleus GeoIP] &r{0} &eis connecting from {1}.
+geoip.noinfo=&e[Nucleus GeoIP] Cannot determine where &r{0} &eis connecting from.
 
 # Permission Descriptions
 permission.base=Allows the user to run the command /{0}
@@ -1447,3 +1457,4 @@ permission.enderchest.others=Allows the user to inspect other players'' ender ch
 permission.connectionmesssages.disable=If set in config, players with this permission will not trigger a connection message.
 permission.top.others=Force other players to teleport to the topmost block.
 
+permission.geoip.login=Displays player country on login, if enabled in the configuration.

--- a/src/main/resources/geoip.txt
+++ b/src/main/resources/geoip.txt
@@ -1,0 +1,239 @@
+The GeoIP module uses third party data and libraries, their licencing can been found below. However, we also ask that you take heed of the following and
+consider the privacy implications. For this reason, Nucleus will only ever download and use Country based data.
+
+By using the GeoIP module, you accept that you are responsible for the data you retrieve from the GeoIP services. **The authors cannot be
+held responsible for your use of the GeoIP databases and are not liable for any action you take, pursuant to the MIT licence.**
+
+Location data **must not** be used for illegal or fraudulent purposes. We also ask you do not broadcast location data to all players, keeping the
+ data within trusted circles.
+
+Should there be widespread misuse of the GeoIP data, the feature may be withdrawn in a future release. Minecraft is meant to be a fun game that the whole
+world can enjoy, regardless of who they are, what language they speak and where they come from, please keep it this way.
+
+============================
+* Third Party Licences
+
+** MaxMind GeoLite2 IP database
+
+If you accept the licences for the GeoIP module, your server will automatically download this data. When using the GeoLite 2 databases, the following statement applies:
+
+This product includes GeoLite2 data created by MaxMind, available from http://maxmind.com
+
+The databases are licenced under the [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/)
+
+The Nucleus team is grateful for the free use of their databases under free licencing.
+
+** MaxMind DB and MaxMind GeoIP2 API wrapper
+
+These libraries are available under the terms of the Apache 2 licence, certified as open source and compatible with the MIT licence.
+The Apache 2 licence will be reproduced at the bottom of this file.
+
+** Jackson JSON library
+
+These libraries are available under the terms of the Apache 2 licence, certified as open source and compatible with the MIT licence.
+The Apache 2 licence will be reproduced at the bottom of this file.
+
+============================
+* Apache Licence Version 2.0
+
+Apache License<br/>
+Version 2.0, January 2004<br/>
+http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
The GeoIP module requires including the MaxMind DB and GeoIP2 APIs, and the Jackson libraries. They are governed by the Apache 2.0 licence.

 GeoIP requires you accept the third party licences, and we ask that users are considerate. Only country data will be downloaded, city data is not downloaded or included. See http://nucleuspowered.org/thirdparty/geoip.html

Closes #334