### PR TITLE
Add gamemode specific permissions if enabled in the config.

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/config/AdminConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/config/AdminConfig.java
@@ -13,7 +13,15 @@ public class AdminConfig {
     @Setting(value = "broadcast-message-template", comment = "loc:config.broadcast.template")
     private BroadcastConfig broadcastMessage = new BroadcastConfig();
 
+    // TODO: Make the default true in future versions?
+    @Setting(value = "separate-gamemode-permissions", comment = "loc:config.gamemode.separate")
+    private boolean separateGamemodePermission = false;
+
     public BroadcastConfig getBroadcastMessage() {
         return broadcastMessage;
+    }
+
+    public boolean isSeparateGamemodePermission() {
+        return separateGamemodePermission;
     }
 }

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -320,6 +320,8 @@ config.commandspy.usewhitelist=If true, only display commands from the whitelist
 
 config.world.defaultborder=If positive, any new worlds that are created using "/world create" (or "/nworld create") will automatically get a world border that has this diameter (that is, from border to border). Set to 0 or a negative number to disable.
 
+config.gamemode.separate=If true, then changing gamemode using the /gm command requires an extra permission to change to the target gamemode - "nucleus.gamemode.modes.<gamemode>"
+
 afk.kickreason=You have been kicked for being AFK for too long.
 
 # Arguments
@@ -1066,6 +1068,7 @@ command.gamemode.set.base=&aYour game mode was set to &e{0}&a.
 command.gamemode.set.other=&e{0}''s &agame mode was set to &e{1}&a.
 command.gamemode.get.base=&aYour game mode is currently &e{0}&a.
 command.gamemode.get.other=&e{0}''s &agame mode is currently &e{1}&a.
+command.gamemode.permission=&cYou do not have permission to switch to the &e{0}&c gamemode.
 
 command.ignore.exempt=&cYou cannot ignore the user {0}.
 command.ignore.self=&cYou cannot ignore yourself.
@@ -1434,6 +1437,10 @@ permission.kit.give.override=Allows the user to grant kits to those who would no
 permission.kits=Allows the user to use all kits.
 
 permission.gamemode.other=Allows the user to change the gamemode for any user.
+permission.gamemode.modes.survival=If "admin.separate-gamemode-permissions" is set in the config, allows the user to change a target''s gamemode to survival.
+permission.gamemode.modes.creative=If "admin.separate-gamemode-permissions" is set in the config, allows the user to change a target''s gamemode to creative.
+permission.gamemode.modes.adventure=If "admin.separate-gamemode-permissions" is set in the config, allows the user to change a target''s gamemode to adventure.
+permission.gamemode.modes.spectator=If "admin.separate-gamemode-permissions" is set in the config, allows the user to change a target''s gamemode to spectator.
 
 permission.ignore.chat=Exempts the user from having their chat, messages and mail ignored.
 


### PR DESCRIPTION
Adds catchall for gamemodes that are not in the registry, the permission would be "nucleus.gamemode.modes.<id-without-prefix>"

Fixes #524

<!--
    When submitting a PR, please include the following:

    * Use case
    * A list of changes
    * Any related changes/issues

    If your PR is not finished but you're seeking a review on it, mark it with [WIP].
-->
