### PR TITLE
Add ability to check options when checking for warmups, cooldowns and costs.

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/Util.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/Util.java
@@ -244,6 +244,32 @@ public class Util {
         return firstPlayed.isAfter(lastPlayed.minus(3, ChronoUnit.SECONDS));
     }
 
+    public static Optional<Double> getDoubleOptionFromSubject(Subject player, String... options) {
+        try {
+            Optional<String> optional = getOptionFromSubject(player, options);
+            if (optional.isPresent()) {
+                return Optional.ofNullable(Double.parseDouble(optional.get()));
+            }
+        } catch (NumberFormatException e) {
+            // ignored
+        }
+
+        return Optional.empty();
+    }
+
+    public static Optional<Integer> getIntOptionFromSubject(Subject player, String... options) {
+        try {
+            Optional<String> optional = getOptionFromSubject(player, options);
+            if (optional.isPresent()) {
+                return Optional.ofNullable(Integer.parseUnsignedInt(optional.get()));
+            }
+        } catch (NumberFormatException e) {
+            // ignored
+        }
+
+        return Optional.empty();
+    }
+
     /**
      * Utility method for getting the first available option from an {@link Subject}
      *


### PR DESCRIPTION
The options are of the form:

* `nucleus.<commandstring>.warmup`
* `nucleus.<commandstring>.cooldown`
* `nucleus.<commandstring>.cost`

where cooldown is a period separated path for a subcommand (so, `/warp list` would be `warp.list`).

Fixes #467

<!--
    When submitting a PR, please include the following:

    * Use case
    * A list of changes
    * Any related changes/issues

    If your PR is not finished but you're seeking a review on it, mark it with [WIP].
-->
