### PR TITLE
Social spy enhancements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ group 'io.github.nucleuspowered'
 version '0.18.0-5.0-SNAPSHOT'
 
 def mixinversion = '0.15.0-5.0'
-def qsmlDep = "uk.co.drnaylor:quickstart-moduleloader:0.4.1"
+def qsmlDep = "uk.co.drnaylor:quickstart-moduleloader:0.4.2"
 def geoIpDep = 'com.maxmind.geoip2:geoip2:2.8.0'
 def mixinDep = "io.github.nucleuspowered:NucleusMixins:" + mixinversion
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/dataservices/UserService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/dataservices/UserService.java
@@ -24,6 +24,7 @@ import io.github.nucleuspowered.nucleus.configurate.datatypes.LocationNode;
 import io.github.nucleuspowered.nucleus.configurate.datatypes.UserDataNode;
 import io.github.nucleuspowered.nucleus.dataservices.dataproviders.DataProvider;
 import io.github.nucleuspowered.nucleus.dataservices.loaders.UserDataManager;
+import io.github.nucleuspowered.nucleus.internal.CommandPermissionHandler;
 import io.github.nucleuspowered.nucleus.modules.message.commands.SocialSpyCommand;
 import io.github.nucleuspowered.nucleus.modules.nickname.config.NicknameConfigAdapter;
 import org.spongepowered.api.Sponge;
@@ -57,6 +58,7 @@ public class UserService extends Service<UserDataNode>
     private final NucleusPlugin plugin;
     private final UUID uuid;
     private final Instant serviceLoadTime = Instant.now();
+    private final CommandPermissionHandler ssSocialSpy;
 
     // Use to keep hold of whether this is the first time on the server for a player.
     private boolean firstPlay = false;
@@ -85,6 +87,7 @@ public class UserService extends Service<UserDataNode>
         Preconditions.checkNotNull("plugin", plugin);
         this.plugin = plugin;
         this.uuid = uuid;
+        this.ssSocialSpy = plugin.getPermissionRegistry().getService(SocialSpyCommand.class);
     }
 
     @Override public Optional<Player> getPlayer() {
@@ -198,7 +201,8 @@ public class UserService extends Service<UserDataNode>
 
     public boolean isSocialSpy() {
         // Only a spy if they have the permission!
-        return data.isSocialspy() && plugin.getPermissionRegistry().getService(SocialSpyCommand.class).testBase(getUser());
+
+        return (ssSocialSpy.testSuffix(getUser(), "force") || data.isSocialspy()) && ssSocialSpy.testBase(getUser());
     }
 
     public boolean setSocialSpy(boolean socialSpy) {

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/message/MessageModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/message/MessageModule.java
@@ -6,19 +6,25 @@ package io.github.nucleuspowered.nucleus.modules.message;
 
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.service.NucleusPrivateMessagingService;
 import io.github.nucleuspowered.nucleus.dataservices.UserService;
+import io.github.nucleuspowered.nucleus.internal.messages.MessageProvider;
 import io.github.nucleuspowered.nucleus.internal.qsml.module.ConfigurableModule;
 import io.github.nucleuspowered.nucleus.modules.message.commands.SocialSpyCommand;
 import io.github.nucleuspowered.nucleus.modules.message.config.MessageConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.message.handlers.MessageHandler;
 import org.spongepowered.api.Game;
+import org.spongepowered.api.text.Text;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
 
+import java.util.List;
 import java.util.Optional;
 
-@ModuleData(id = "message", name = "message")
+@ModuleData(id = MessageModule.ID, name = "Message")
 public class MessageModule extends ConfigurableModule<MessageConfigAdapter> {
+
+    public static final String ID = "message";
 
     @Inject private Game game;
 
@@ -31,7 +37,8 @@ public class MessageModule extends ConfigurableModule<MessageConfigAdapter> {
     protected void performPreTasks() throws Exception {
         super.performPreTasks();
 
-        MessageHandler m = new MessageHandler();
+        MessageHandler m = new MessageHandler(plugin);
+        plugin.registerReloadable(m::onReload);
         serviceManager.registerService(MessageHandler.class, m);
         game.getServiceManager().setProvider(plugin, NucleusPrivateMessagingService.class, m);
     }
@@ -42,9 +49,16 @@ public class MessageModule extends ConfigurableModule<MessageConfigAdapter> {
         createSeenModule(SocialSpyCommand.class, (cs, user) -> {
             Optional<UserService> userServiceOptional = plugin.getUserDataManager().get(user);
             boolean socialSpy = userServiceOptional.isPresent() && userServiceOptional.get().isSocialSpy();
-            return Lists.newArrayList(
-                plugin.getMessageProvider().getTextMessageWithFormat("seen.socialspy",
-                    plugin.getMessageProvider().getMessageWithFormat("standard.yesno." + Boolean.toString(socialSpy).toLowerCase())));
+            MessageProvider mp = plugin.getMessageProvider();
+            List<Text> lt = Lists.newArrayList(
+                mp.getTextMessageWithFormat("seen.socialspy",
+                    mp.getMessageWithFormat("standard.yesno." + Boolean.toString(socialSpy).toLowerCase())));
+
+            getConfigAdapter().ifPresent(x -> lt.add(
+                mp.getTextMessageWithFormat("seen.socialspylevel", String.valueOf(Util.getIntOptionFromSubject(user, MessageHandler.socialSpyOption).orElse(0)))
+            ));
+
+            return lt;
         });
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/message/commands/MessageCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/message/commands/MessageCommand.java
@@ -37,13 +37,6 @@ public class MessageCommand extends io.github.nucleuspowered.nucleus.internal.co
 
     private final MessageHandler handler;
 
-    /**
-     * Testing only.
-     */
-    public MessageCommand() {
-        handler = new MessageHandler();
-    }
-
     @Inject
     private MessageCommand(MessageHandler handler) {
         this.handler = handler;

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/message/commands/SocialSpyCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/message/commands/SocialSpyCommand.java
@@ -7,7 +7,14 @@ package io.github.nucleuspowered.nucleus.modules.message.commands;
 import com.google.inject.Inject;
 import io.github.nucleuspowered.nucleus.dataservices.UserService;
 import io.github.nucleuspowered.nucleus.dataservices.loaders.UserDataManager;
-import io.github.nucleuspowered.nucleus.internal.annotations.*;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoCooldown;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoCost;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoWarmup;
+import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
+import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.command.ReturnMessageException;
+import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
@@ -15,6 +22,9 @@ import org.spongepowered.api.command.args.CommandElement;
 import org.spongepowered.api.command.args.GenericArguments;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.text.Text;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Permissions(suggestedLevel = SuggestedLevel.MOD)
 @RunAsync
@@ -27,6 +37,12 @@ public class SocialSpyCommand extends io.github.nucleuspowered.nucleus.internal.
     private final String arg = "Social Spy";
     @Inject private UserDataManager userConfigLoader;
 
+    @Override protected Map<String, PermissionInformation> permissionSuffixesToRegister() {
+        return new HashMap<String, PermissionInformation>() {{
+            put("force", new PermissionInformation(plugin.getMessageProvider().getMessageWithFormat("permission.socialspy.force"), SuggestedLevel.NONE));
+        }};
+    }
+
     @Override
     public CommandElement[] getArguments() {
         return new CommandElement[] {GenericArguments.optional(GenericArguments.onlyOne(GenericArguments.bool(Text.of(arg))))};
@@ -34,6 +50,10 @@ public class SocialSpyCommand extends io.github.nucleuspowered.nucleus.internal.
 
     @Override
     public CommandResult executeCommand(Player src, CommandContext args) throws Exception {
+        if (permissions.testSuffix(src, "force")) {
+            throw new ReturnMessageException(plugin.getMessageProvider().getTextMessageWithFormat("command.socialspy.forced"));
+        }
+
         UserService qs = userConfigLoader.get(src).get();
         boolean spy = args.<Boolean>getOne(arg).orElse(!qs.isSocialSpy());
         if (qs.setSocialSpy(spy)) {

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/message/config/MessageConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/message/config/MessageConfig.java
@@ -19,17 +19,8 @@ public class MessageConfig {
     @Setting(value = "msg-sender-prefix", comment = "loc:config.message.sender.prefix")
     private String messageSenderPrefix = "&7[me -> {{toDisplay}}&7]: &r";
 
-    @Setting(value = "msg-socialspy-prefix", comment = "loc:config.message.socialspy.prefix")
-    private String messageSocialSpyPrefix = "&7[SocialSpy] [{{fromDisplay}}&7 -> {{toDisplay}}&7]: &r";
-
-    @Setting(value = "socialspy-cancelled-messages", comment = "loc:config.message.socialspy.mutedshow")
-    private boolean showMessagesInSocialSpyWhileMuted = false;
-
-    @Setting(value = "socialspy-cancelled-tag", comment = "loc:config.message.socialspy.mutedtag")
-    private String mutedTag = "&c[cancelled] ";
-
-    @Setting(value = "socialspy-only-players", comment = "loc:config.message.socialspy.playeronly")
-    private boolean onlyPlayerSocialSpy = false;
+    @Setting(value = "socialspy")
+    private SocialSpy socialSpy = new SocialSpy();
 
     public String getHelpOpPrefix() {
         return helpOpPrefix;
@@ -44,18 +35,54 @@ public class MessageConfig {
     }
 
     public String getMessageSocialSpyPrefix() {
-        return messageSocialSpyPrefix;
+        return socialSpy.messageSocialSpyPrefix;
+    }
+
+    public boolean isSocialSpyLevels() {
+        return socialSpy.socialSpyLevels;
+    }
+
+    public boolean isSocialSpySameLevel() {
+        return socialSpy.socialSpySameLevel;
+    }
+
+    public int getServerLevel() {
+        return socialSpy.serverLevel;
     }
 
     public boolean isShowMessagesInSocialSpyWhileMuted() {
-        return showMessagesInSocialSpyWhileMuted;
+        return socialSpy.showMessagesInSocialSpyWhileMuted;
     }
 
     public String getMutedTag() {
-        return mutedTag;
+        return socialSpy.mutedTag;
     }
 
     public boolean isOnlyPlayerSocialSpy() {
-        return onlyPlayerSocialSpy;
+        return socialSpy.onlyPlayerSocialSpy;
+    }
+
+    @ConfigSerializable
+    public static class SocialSpy {
+        @Setting(value = "msg-prefix", comment = "loc:config.message.socialspy.prefix")
+        private String messageSocialSpyPrefix = "&7[SocialSpy] [{{fromDisplay}}&7 -> {{toDisplay}}&7]: &r";
+
+        @Setting(value = "use-levels", comment = "loc:config.message.socialspy.levels")
+        private boolean socialSpyLevels = false;
+
+        @Setting(value = "same-levels-can-see-each-other", comment = "loc:config.message.socialspy.samelevel")
+        private boolean socialSpySameLevel = true;
+
+        @Setting(value = "server-level", comment = "loc:config.message.socialspy.serverlevel")
+        private int serverLevel = Integer.MAX_VALUE;
+
+        @Setting(value = "show-cancelled-messages", comment = "loc:config.message.socialspy.mutedshow")
+        private boolean showMessagesInSocialSpyWhileMuted = false;
+
+        @Setting(value = "cancelled-messages-tag", comment = "loc:config.message.socialspy.mutedtag")
+        private String mutedTag = "&c[cancelled] ";
+
+        @Setting(value = "show-only-players", comment = "loc:config.message.socialspy.playeronly")
+        private boolean onlyPlayerSocialSpy = false;
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/message/config/MessageConfigAdapter.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/message/config/MessageConfigAdapter.java
@@ -4,13 +4,22 @@
  */
 package io.github.nucleuspowered.nucleus.modules.message.config;
 
-import com.google.common.reflect.TypeToken;
+import com.google.common.collect.Lists;
 import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
-import ninja.leaping.configurate.ConfigurationNode;
-import ninja.leaping.configurate.commented.SimpleCommentedConfigurationNode;
-import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+
+import java.util.List;
 
 public class MessageConfigAdapter extends NucleusConfigAdapter.StandardWithSimpleDefault<MessageConfig> {
+
+    @Override protected List<Transformation> getTransformations() {
+        return Lists.newArrayList(
+            // 0.18.0
+            Transformation.moveTopLevel("msg-socialspy-prefix", "socialspy", "msg-prefix"),
+            Transformation.moveTopLevel("socialspy-cancelled-messages", "socialspy", "show-cancelled-messages"),
+            Transformation.moveTopLevel("socialspy-cancelled-tag", "socialspy", "cancelled-messages-tag"),
+            Transformation.moveTopLevel("socialspy-only-players", "socialspy", "show-only-players")
+        );
+    }
 
     public MessageConfigAdapter() {
         super(MessageConfig.class);

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -221,6 +221,10 @@ config.message.receiver.prefix='The prefix for received messages. This is displa
 config.message.socialspy.mutedshow=If true, show messages that players try to send and are cancelled (usually due to being muted).
 config.message.socialspy.mutedtag=The tag to show at the beginning of a Social Spy message when a player is muted (or otherwise has the message cancelled).
 config.message.socialspy.playeronly=If true, only messages sent by players will be visible via Social Spy.
+config.message.socialspy.levels=If true, Nucleus will check the "nucleus.socialspy.level" option on the subject for an integer level. A level can see their messages from and to players with levels below their own, \n\
+unless "same-levels-can-see-each-other" is set to true, in which case, social spies can see messages from their own level. Players have a default level of 0.
+config.message.socialspy.samelevel=If true, and "use-levels" is true, players with social spy will also see messages from players at their own level.
+config.message.socialspy.serverlevel=The server's social spy level.
 
 config.back.ondeath=Log player''s location on death.
 config.back.onteleport=Log player''s last location on warp.
@@ -735,6 +739,7 @@ command.freezeplayer.success.unfrozen={0} &ahas now been unfrozen and can move.
 command.socialspy.on=&aYou can now see others'' private messages.
 command.socialspy.off=&aYou can no longer see others'' private messages.
 command.socialspy.unable=&cYour social spy status could not be set.
+command.socialspy.forced=&cYou cannot turn off social spy.
 
 command.weather.set=&aYou set the weather to &e{0} &ain the world &e{1}&a.
 command.weather.time=&aYou set the weather to &e{0} &ain the world &e{1} &afor &e{2}&a.
@@ -1342,6 +1347,7 @@ seen.notes=&bNotes: &f{0} notes attached.
 seen.frozen=&bFrozen: &c&oYes.
 seen.notfrozen=&bFrozen: &fNo.
 seen.socialspy=&bSocial Spy: &f{0}
+seen.socialspylevel=&bSocial Spy Level: &f{0}
 seen.godmode=&bInvulnerable (Nucleus God mode): &f{0}
 
 # Teleport
@@ -1508,5 +1514,7 @@ permission.getpos.others=Allows the user to view the position of other players.
 permission.kittycannon.damage=If granted, the user can use the -d flag to damage entities with exploding ocelots.
 permission.kittycannon.fire=If granted, the user can use the -f flag to cause fires with exploding ocelots.
 permission.kittycannon.break=If granted, the user can use the -b flag to break blocks with exploding ocelots.
+
+permission.socialspy.force=If granted, along with the "nucleus.socialspy.base" permission, the target player cannot turn social spy off.
 
 permission.commandspy.exempt.target=If granted, prevents commands from this player being sent to other command spies.


### PR DESCRIPTION
Fixes #461 

**Social Spy levels** 

Requires `message.socialspy.use-levels` to be `true` in `main.conf`.

If on, a player's social spy level is specified by the `nucleus.socialspy.level` option on players. Defaults to zero. Higher numbers can spy on lower numbers, if `same-levels-can-see-each-other` is set to `true`. players on the same level can also see each other.

Server level is set in config, defaults to 2,147,483,647.

**Force social spy permission**

The permission `nucleus.socialspy.force` can be granted, _alongside_ the `nucleus.socialspy.base` permission, to force players to use `/socialspy`. This permission is not recommended in any permission set.