### PR TITLE
implement scheduledtasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The compiled Nucleus plugin includes the following libraries (with their licence
 * MaxMind GeoIP2 API (Apache 2)
 * MaxMind DB (Apache 2)
 * Jackson (Apache 2)
+* Cron-Utils (Apache 2)
 
 See [THIRDPARTY.md](THIRDPARTY.md) for more details.
 

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -33,6 +33,13 @@ Used in the GeoIP module, included in the plugin JAR.
 These libraries are available under the terms of the Apache 2 licence, certified as open source and compatible with the MIT licence.
 The Apache 2 licence will be reproduced at the bottom of this file.
 
+## Cron-Utils library
+
+Used in the Scheduled module, included in the plugin JAR.
+
+This library is available under the terms of the Apache 2 license, certified as open source and compatible with the MIT licence.
+The Apache 2 licence will be reporduced at the bottom of this file.
+
 ## Apache Licence Version 2.0
 
 Apache License<br/>

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
     // For Geo IP
     compile geoIpDep
 
+    // For Scheduled
+    compile "com.cronutils:cron-utils:5.0.5"
+
     testCompile "junit:junit:4.12"
     testCompile "org.mockito:mockito-all:1.10.19"
     testCompile "org.powermock:powermock-module-junit4:1.6.4"
@@ -86,6 +89,12 @@ license {
 
 spongestart{
     eula true
+}
+
+test {
+    testLogging {
+        showStandardStreams = true
+    }
 }
 
 blossom {
@@ -138,10 +147,12 @@ shadowJar {
         include(dependency("com.fasterxml.jackson.core:jackson-core"))
         include(dependency("com.fasterxml.jackson.core:jackson-databind"))
         include(dependency("com.fasterxml.jackson.core:jackson-annotations"))
+        include(dependency("com.cronutils:cron-utils"))
     }
 
     relocate 'com.maxmind.geoip2', 'io.github.nucleuspowered.relocate.com.maxmind.geoip2'
     relocate 'com.maxmind.db', 'io.github.nucleuspowered.relocate.com.maxmind.db'
     relocate 'com.fasterxml.jackson', 'io.github.nucleuspowered.relocate.com.fasterxml.jackson'
+    relocate 'com.cronutils', 'io.github.nucleuspowered.relocate.com.cronutils'
 }
 build.dependsOn(shadowJar)

--- a/src/main/java/io/github/nucleuspowered/nucleus/Nucleus.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/Nucleus.java
@@ -13,6 +13,7 @@ import io.github.nucleuspowered.nucleus.internal.InternalServiceManager;
 import io.github.nucleuspowered.nucleus.internal.MixinConfigProxy;
 import io.github.nucleuspowered.nucleus.internal.PermissionRegistry;
 import io.github.nucleuspowered.nucleus.internal.messages.MessageProvider;
+import io.github.nucleuspowered.nucleus.internal.services.ScheduledManager;
 import io.github.nucleuspowered.nucleus.internal.services.WarmupManager;
 import io.github.nucleuspowered.nucleus.internal.teleport.NucleusTeleportHandler;
 import org.slf4j.Logger;
@@ -48,6 +49,8 @@ public abstract class Nucleus {
     public abstract void reload();
 
     public abstract WarmupManager getWarmupManager();
+
+    public abstract ScheduledManager getScheduledManager();
 
     public abstract EconHelper getEconHelper();
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/NucleusPlugin.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/NucleusPlugin.java
@@ -16,6 +16,7 @@ import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import io.github.nucleuspowered.nucleus.api.service.NucleusModuleService;
+import io.github.nucleuspowered.nucleus.api.service.NucleusScheduledManagerService;
 import io.github.nucleuspowered.nucleus.api.service.NucleusUserLoaderService;
 import io.github.nucleuspowered.nucleus.api.service.NucleusWarmupManagerService;
 import io.github.nucleuspowered.nucleus.api.service.NucleusWorldLoaderService;
@@ -46,6 +47,7 @@ import io.github.nucleuspowered.nucleus.internal.qsml.ModuleRegistrationProxySer
 import io.github.nucleuspowered.nucleus.internal.qsml.NucleusLoggerProxy;
 import io.github.nucleuspowered.nucleus.internal.qsml.QuickStartModuleConstructor;
 import io.github.nucleuspowered.nucleus.internal.qsml.event.BaseModuleEvent;
+import io.github.nucleuspowered.nucleus.internal.services.ScheduledManager;
 import io.github.nucleuspowered.nucleus.internal.services.WarmupManager;
 import io.github.nucleuspowered.nucleus.internal.teleport.NucleusTeleportHandler;
 import io.github.nucleuspowered.nucleus.internal.text.TokenHandler;
@@ -119,6 +121,7 @@ public class NucleusPlugin extends Nucleus {
     private MessageProvider commandMessageProvider = new ResourceMessageProvider(ResourceMessageProvider.commandMessagesBundle);
 
     private WarmupManager warmupManager;
+    private ScheduledManager scheduledManager;
     private EconHelper econHelper = new EconHelper(this);
     private PermissionRegistry permissionRegistry = new PermissionRegistry();
 
@@ -171,6 +174,7 @@ public class NucleusPlugin extends Nucleus {
             kitService = new KitService(d.getKitsDataProvider());
             nameBanService = new NameBanService(d.getNameBanDataProvider());
             warmupManager = new WarmupManager();
+            scheduledManager = new ScheduledManager(this);
             chatUtil = new ChatUtil(this);
             nameUtil = new NameUtil(this);
         } catch (Exception e) {
@@ -185,8 +189,10 @@ public class NucleusPlugin extends Nucleus {
         // We register the ModuleService NOW so that others can hook into it.
         game.getServiceManager().setProvider(this, NucleusModuleService.class, new ModuleRegistrationProxyService(this));
         game.getServiceManager().setProvider(this, NucleusWarmupManagerService.class, warmupManager);
+        game.getServiceManager().setProvider(this, NucleusScheduledManagerService.class, scheduledManager);
         this.injector = Guice.createInjector(new QuickStartInjectorModule(this));
         serviceManager.registerService(WarmupManager.class, warmupManager);
+        serviceManager.registerService(ScheduledManager.class, scheduledManager);
 
         try {
             HoconConfigurationLoader.Builder builder = HoconConfigurationLoader.builder();
@@ -403,6 +409,11 @@ public class NucleusPlugin extends Nucleus {
     @Override
     public WarmupManager getWarmupManager() {
         return warmupManager;
+    }
+
+    @Override
+    public ScheduledManager getScheduledManager() {
+        return scheduledManager;
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/api/service/NucleusScheduledManagerService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/service/NucleusScheduledManagerService.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.api.service;
+
+import io.github.nucleuspowered.nucleus.internal.scheduled.ScheduledTask;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A Manager of Scheduled Tasks from Nucleus
+ */
+public interface NucleusScheduledManagerService {
+
+    /**
+     * Adds a scheduled task if a task with the same name hasn't been queued, will set isAsync to true
+     *
+     * @param task
+     *  The ScheduledTask to add
+     * @throws IllegalArgumentException
+     *  Throws an IllegalArgumentException if a task with the same name has been queued
+     */
+    void addScheduledTask(ScheduledTask task) throws IllegalArgumentException;
+
+    /**
+     * Adds a scheduled task manually specifying isAsync
+     *
+     * @param task
+     *  The ScheduledTask to add
+     * @param isAsync
+     *  Manually specify if this job should run async
+     * @throws IllegalArgumentException
+     *  Throws an IllegalArgumentException if a task with the same name has been queued
+     */
+    void addScheduledTask(ScheduledTask task, boolean isAsync) throws IllegalArgumentException;
+
+    /**
+     * @return
+     *  All the scheduled tasks which have been queued
+     */
+    List<ScheduledTask> getScheduledTasks();
+
+    /**
+     * Get a task by name
+     *
+     * @param name
+     *  The name of the task to get
+     * @return
+     *  The scheduled task if its there
+     */
+    Optional<ScheduledTask> getTaskByName(String name);
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/DelayedTimeValueArgument.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/DelayedTimeValueArgument.java
@@ -1,0 +1,99 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.argumentparsers;
+
+import com.google.common.collect.Lists;
+import com.cronutils.model.Cron;
+import com.cronutils.model.CronType;
+import com.cronutils.model.definition.CronDefinitionBuilder;
+import com.cronutils.parser.CronParser;
+import io.github.nucleuspowered.nucleus.Nucleus;
+import io.github.nucleuspowered.nucleus.util.ClockTime;
+import io.github.nucleuspowered.nucleus.util.DelayedTimeType;
+import io.github.nucleuspowered.nucleus.util.DelayedTimeValue;
+import io.github.nucleuspowered.nucleus.util.WhenTime;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.ArgumentParseException;
+import org.spongepowered.api.command.args.CommandArgs;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.text.Text;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+
+/**
+ * Allows Parsing of a DelayedTimeValue from a command argument
+ */
+public class DelayedTimeValueArgument extends CommandElement {
+
+    private CronParser unixCronParser;
+    private CronParser quartzCronParser;
+    private CronParser cronjCronParser;
+
+    /**
+     * Construct a DelayedTimeValueArgument, used to initialize cron parsers
+     *
+     * @param key
+     *  The key of the DelayedTimeValueArgument
+     */
+    public DelayedTimeValueArgument(@Nullable Text key) {
+        super(key);
+        this.unixCronParser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX));
+        this.quartzCronParser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
+        this.cronjCronParser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.CRON4J));
+    }
+
+    /**
+     * Parses a DelayedTimeValue from a CommandSource/args
+     *
+     * @param source
+     *  The CommandSource to parse from
+     * @param args
+     *  The arguments of the command
+     * @return
+     *  A delayed time value from the next arg
+     * @throws ArgumentParseException
+     *  If we could not parse the argument as a delayedtimevalue
+     */
+    @Override
+    protected Object parseValue(CommandSource source, CommandArgs args) throws ArgumentParseException {
+        String value = args.next();
+        try {
+            WhenTime asWhenTime = WhenTime.fromString(value);
+            return new DelayedTimeValue(asWhenTime);
+        } catch (Exception e1) { }
+        try {
+            ClockTime asClockTime = ClockTime.fromString(value);
+            return new DelayedTimeValue(asClockTime);
+        } catch (Exception e1) { }
+        try {
+            Cron asUnixCron = this.unixCronParser.parse(value);
+            return new DelayedTimeValue(DelayedTimeType.UNIX_CRON, asUnixCron);
+        } catch (Exception e1) { }
+        try {
+            Cron asQuartzCron = this.quartzCronParser.parse(value);
+            return new DelayedTimeValue(DelayedTimeType.QUARTZ_CRON, asQuartzCron);
+        } catch (Exception e1) { }
+        try {
+            Cron asJavaCron = this.cronjCronParser.parse(value);
+            return new DelayedTimeValue(DelayedTimeType.CRON4J_CRON, asJavaCron);
+        } catch (Exception e1) { }
+
+        throw args.createError(Nucleus.getNucleus().getMessageProvider().getTextMessageWithFormat("args.delayedtimevalue.nomatch"));
+    }
+
+    @Override
+    public List<String> complete(CommandSource src, CommandArgs args, CommandContext context) {
+        return Lists.newArrayList();
+    }
+
+    @Override
+    public Text getUsage(CommandSource src) {
+        return Text.of(this.getKey(), "(every N minutes || HH:MM || cron)");
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/ConfigurateHelper.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/ConfigurateHelper.java
@@ -8,9 +8,13 @@ import com.flowpowered.math.vector.Vector3d;
 import com.google.common.reflect.TypeToken;
 import io.github.nucleuspowered.nucleus.configurate.objectmapper.NucleusObjectMapperFactory;
 import io.github.nucleuspowered.nucleus.configurate.typeserialisers.ConfigurationNodeTypeSerialiser;
+import io.github.nucleuspowered.nucleus.configurate.typeserialisers.DelayedTimeValueSerialiser;
 import io.github.nucleuspowered.nucleus.configurate.typeserialisers.ItemStackSnapshotSerialiser;
 import io.github.nucleuspowered.nucleus.configurate.typeserialisers.SetTypeSerialiser;
 import io.github.nucleuspowered.nucleus.configurate.typeserialisers.Vector3dTypeSerialiser;
+import io.github.nucleuspowered.nucleus.configurate.typeserialisers.WarningTimeListSerialiser;
+import io.github.nucleuspowered.nucleus.util.DelayedTimeValue;
+import io.github.nucleuspowered.nucleus.util.WarningTimeList;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.ConfigurationOptions;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializerCollection;
@@ -58,6 +62,8 @@ public class ConfigurateHelper {
                 typeToken -> Set.class.isAssignableFrom(typeToken.getRawType()),
                 new SetTypeSerialiser()
         );
+        tsc.registerType(TypeToken.of(DelayedTimeValue.class), new DelayedTimeValueSerialiser());
+        tsc.registerType(TypeToken.of(WarningTimeList.class), new WarningTimeListSerialiser());
 
         if (Sponge.getGame().getState() == GameState.SERVER_STARTED) {
             typeSerializerCollection = tsc;

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/typeserialisers/DelayedTimeValueSerialiser.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/typeserialisers/DelayedTimeValueSerialiser.java
@@ -1,0 +1,129 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.configurate.typeserialisers;
+
+import com.google.common.reflect.TypeToken;
+import com.cronutils.model.Cron;
+import com.cronutils.model.CronType;
+import com.cronutils.model.definition.CronDefinitionBuilder;
+import com.cronutils.parser.CronParser;
+import io.github.nucleuspowered.nucleus.util.ClockTime;
+import io.github.nucleuspowered.nucleus.util.DelayedTimeType;
+import io.github.nucleuspowered.nucleus.util.DelayedTimeValue;
+import io.github.nucleuspowered.nucleus.util.WhenTime;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.SimpleConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
+
+import java.util.Map;
+
+/**
+ * Manages serialization of a DelayedTimeValue
+ */
+public class DelayedTimeValueSerialiser implements TypeSerializer<DelayedTimeValue> {
+
+    private CronParser unixCronParser;
+    private CronParser quartzCronParser;
+    private CronParser cronjCronParser;
+
+    /**
+     * Constructs a DelayedTimeValueSerialiser, initializes the cron parsers
+     */
+    public DelayedTimeValueSerialiser() {
+        this.unixCronParser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX));
+        this.quartzCronParser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
+        this.cronjCronParser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.CRON4J));
+    }
+
+    @Override
+    public DelayedTimeValue deserialize(TypeToken<?> type, ConfigurationNode value) throws ObjectMappingException {
+        if (value.getValue() instanceof String) {
+            String node = value.getString();
+            try {
+                Cron asUnixCron = this.unixCronParser.parse(node);
+                return new DelayedTimeValue(DelayedTimeType.UNIX_CRON, asUnixCron);
+            } catch (Exception e1) {
+            }
+            try {
+                Cron asQuartzCron = this.quartzCronParser.parse(node);
+                return new DelayedTimeValue(DelayedTimeType.QUARTZ_CRON, asQuartzCron);
+            } catch (Exception e1) {
+            }
+            try {
+                Cron asJavaCron = this.cronjCronParser.parse(node);
+                return new DelayedTimeValue(DelayedTimeType.CRON4J_CRON, asJavaCron);
+            } catch (Exception e1) {
+            }
+            try {
+                WhenTime asWhenTime = WhenTime.fromString(node);
+                return new DelayedTimeValue(asWhenTime);
+            } catch (Exception e1) {
+            }
+            try {
+                ClockTime asClockTime = ClockTime.fromString(node);
+                return new DelayedTimeValue(asClockTime);
+            } catch (Exception e1) {
+            }
+
+            throw new ObjectMappingException("Couldn't find a delayedtimevalue amidst the string");
+        }
+
+        if (value.getValue() instanceof Map) {
+            Map node = value.getChildrenMap();
+            if (node.containsKey("type") && node.containsKey("statement")) {
+                Object typeObject = node.get("type");
+                Object statementObject = node.get("statement");
+                if (!(typeObject instanceof SimpleConfigurationNode && statementObject instanceof
+                        SimpleConfigurationNode)) {
+                    throw new IllegalArgumentException("Failed to parse map type/statement");
+                }
+                SimpleConfigurationNode asUnparsedType = (SimpleConfigurationNode) typeObject;
+                SimpleConfigurationNode asUnparsedStatement = (SimpleConfigurationNode) statementObject;
+                try {
+                    String asStringType = asUnparsedType.getString();
+                    String asStringStatement = asUnparsedStatement.getString();
+                    DelayedTimeType dtt = DelayedTimeType.fromString(asStringType);
+                    if (dtt == null) {
+                        throw new ObjectMappingException("Null DelayedTimeType");
+                    }
+                    switch (dtt) {
+                        case QUARTZ_CRON:
+                            Cron quartzCron = this.quartzCronParser.parse(asStringStatement);
+                            return new DelayedTimeValue(DelayedTimeType.QUARTZ_CRON, quartzCron);
+                        case UNIX_CRON:
+                            Cron unixCron = this.unixCronParser.parse(asStringStatement);
+                            return new DelayedTimeValue(DelayedTimeType.UNIX_CRON, unixCron);
+                        case CRON4J_CRON:
+                            Cron javaCron = this.cronjCronParser.parse(asStringStatement);
+                            return new DelayedTimeValue(DelayedTimeType.CRON4J_CRON, javaCron);
+                        case CLOCK_TIME:
+                            ClockTime clockTime = ClockTime.fromString(asStringStatement);
+                            return new DelayedTimeValue(clockTime);
+                        case WHEN_TIME:
+                            WhenTime whenTime = WhenTime.fromString(asStringStatement);
+                            return new DelayedTimeValue(whenTime);
+                        default:
+                            throw new ObjectMappingException("Failed to find DelayedTimeType");
+                    }
+                } catch (Exception e1) {
+                    System.err.println(e1.getMessage());
+                    for (StackTraceElement ste : e1.getStackTrace()) {
+                        System.err.println(ste);
+                    }
+                    throw new ObjectMappingException(e1.getCause());
+                }
+            }
+        }
+
+        throw new ObjectMappingException("No Possible Delayed Time type.");
+    }
+
+    @Override
+    public void serialize(TypeToken<?> type, DelayedTimeValue obj, ConfigurationNode value)
+            throws ObjectMappingException {
+        value.setValue(obj.asString());
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/typeserialisers/WarningTimeListSerialiser.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/typeserialisers/WarningTimeListSerialiser.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.configurate.typeserialisers;
+
+import com.google.common.reflect.TypeToken;
+import io.github.nucleuspowered.nucleus.util.TimeValue;
+import io.github.nucleuspowered.nucleus.util.WarningTimeList;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Manages serialization of a WarningTimeList
+ */
+public class WarningTimeListSerialiser implements TypeSerializer<WarningTimeList> {
+
+    @Override
+    public WarningTimeList deserialize(TypeToken<?> type, ConfigurationNode value) throws ObjectMappingException {
+        if (value.getValue() instanceof String) {
+            String node = value.getString();
+            if (node.trim().isEmpty()) {
+                return new WarningTimeList();
+            }
+            if (!node.contains(",")) {
+                throw new ObjectMappingException("Cannot find split character for WarningTimeList");
+            }
+            String[] split = node.split(",");
+            List<TimeValue> timeValues = new ArrayList<>();
+            for (String potentialTimeValue : split) {
+                try {
+                    TimeValue tv = TimeValue.fromString(potentialTimeValue);
+                    timeValues.add(tv);
+                } catch (Exception e1) { }
+            }
+            return new WarningTimeList(timeValues);
+        }
+
+        if (value.getValue() instanceof List) {
+            List<String> asList = value.getList(new TypeToken<String>() {});
+            List<TimeValue> timeValues = new ArrayList<>();
+            asList.forEach((potentialTimeValue) -> {
+                try {
+                    TimeValue tv = TimeValue.fromString(potentialTimeValue);
+                    timeValues.add(tv);
+                } catch (Exception e1) { }
+            });
+            return new WarningTimeList(timeValues);
+        }
+
+        throw new ObjectMappingException("No valid type to parse warning list from");
+    }
+
+    @Override
+    public void serialize(TypeToken<?> type, WarningTimeList obj, ConfigurationNode value) throws ObjectMappingException {
+        List<String> toStore = obj.asList();
+        if (toStore != null) {
+            value.setValue(toStore);
+        } else {
+            value.setValue("");
+        }
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/scheduled/ScheduledTask.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/scheduled/ScheduledTask.java
@@ -1,0 +1,137 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.internal.scheduled;
+
+import com.cronutils.model.time.ExecutionTime;
+import io.github.nucleuspowered.nucleus.util.DelayedTimeValue;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.scheduler.Scheduler;
+import org.spongepowered.api.scheduler.Task;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * A ScheduledTask, used to help in scenarios of "Real World Time" where the interval isn't constant
+ */
+public abstract class ScheduledTask implements Consumer<Task> {
+
+    @Nullable
+    protected DelayedTimeValue delayedTimeValue;
+    protected boolean isCancelled;
+    protected String name;
+
+    /**
+     * Creates a ScheduledTask
+     *
+     * @param name
+     *  The name of this scheduled task, should be unique
+     * @param delayedTimeValue
+     *  The potential delayed time value for this scheduled task
+     */
+    public ScheduledTask(@Nonnull String name, @Nullable DelayedTimeValue delayedTimeValue) {
+        this.delayedTimeValue = delayedTimeValue;
+        this.isCancelled = false;
+        this.name = name;
+    }
+
+    /**
+     * @return
+     *  The name of this scheduled task
+     */
+    public String getName() {
+        return this.name;
+    }
+
+    /**
+     * Sets the cancelled state
+     *
+     * @param state
+     *  The state to set cancelled too
+     */
+    public void setCancelled(boolean state) {
+        this.isCancelled = state;
+    }
+
+    /**
+     * @return
+     *  If this job is cancelled
+     */
+    public boolean isCancelled() {
+        return this.isCancelled;
+    }
+
+    /**
+     * Runs the actual scheduled task
+     *
+     * @param task
+     *  The task object
+     */
+    protected abstract void runScheduledTask(Task task);
+
+    /**
+     * Requeues the particular task
+     *
+     * @param task
+     *  The task to requeue
+     */
+    void requeue(Task task) {
+        if (task.getInterval() <= 0 && this.delayedTimeValue != null) {
+            if (this.delayedTimeValue.isSingle()) {
+                return;
+            }
+            try {
+                Scheduler scheduler = Sponge.getScheduler();
+                Task.Builder builder = scheduler.createTaskBuilder().execute(this);
+                ExecutionTime et = ExecutionTime.forCron(this.delayedTimeValue.getAsCron());
+                Duration timeToNextExecution = et.timeToNextExecution(ZonedDateTime.now());
+                builder.delay(timeToNextExecution.toMillis(), TimeUnit.MILLISECONDS).name(task.getName());
+
+                if (task.isAsynchronous()) {
+                    builder.async();
+                }
+
+                builder.submit(task.getOwner());
+            } catch (Exception e1) {
+                // No possible requeue time.
+            }
+        }
+    }
+
+    /**
+     * @return
+     *  The initial delay to wait for queueing
+     *  Allows us to have things like ScheduledTasks with warnings before
+     */
+    public long getInitialDelay() {
+        if (this.delayedTimeValue != null) {
+            try {
+                ExecutionTime et = ExecutionTime.forCron(this.delayedTimeValue.getAsCron());
+                Duration timeToNextExecution = et.timeToNextExecution(ZonedDateTime.now());
+                return timeToNextExecution.toMillis();
+            } catch (Exception e1) {
+                //No Next Queue time.
+            }
+        }
+        return -1;
+    }
+
+    @Override
+    public void accept(Task task) {
+        if (this.isCancelled) {
+            if (task.getInterval() > 0) {
+                task.cancel();
+            }
+            return;
+        }
+        this.runScheduledTask(task);
+        this.requeue(task);
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/scheduled/WarnedScheduledTask.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/scheduled/WarnedScheduledTask.java
@@ -1,0 +1,153 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.internal.scheduled;
+
+import com.cronutils.model.time.ExecutionTime;
+import io.github.nucleuspowered.nucleus.util.DelayedTimeValue;
+import io.github.nucleuspowered.nucleus.util.TimeValue;
+import io.github.nucleuspowered.nucleus.util.WarningTimeList;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.scheduler.Scheduler;
+import org.spongepowered.api.scheduler.Task;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Create a Scheduled Task with a warning before
+ */
+public abstract class WarnedScheduledTask extends ScheduledTask {
+
+    private WarningTimeList warningTimes;
+    private int warningsGiven;
+    private boolean shouldRunCode;
+
+    /**
+     * Construct a Scheduled Task with a Warning
+     *
+     * @param name
+     *  The name of this task
+     * @param warningTimes
+     *  The list of warning times to warn beforehand
+     * @param delayedTimeValue
+     *  The delayed time value to schedule on
+     */
+    public WarnedScheduledTask(@Nonnull String name, @Nonnull WarningTimeList warningTimes,
+                               @Nonnull DelayedTimeValue delayedTimeValue) {
+        super(name, delayedTimeValue);
+        this.warningTimes = warningTimes;
+        this.warningsGiven = 0;
+        this.shouldRunCode = false;
+    }
+
+    abstract void runWarning(Task task, long timeToNextExecution);
+
+    /**
+     * Custom Requeue logic for WarnedScheduledTask. For warnings _we must_ control the requeue logic here
+     *
+     * @param task
+     *  The task to requeue
+     */
+    @Override
+    void requeue(Task task) {
+        if (task.getInterval() != 0) {
+            // We have to control requeues for warning.
+            task.cancel();
+        }
+        // Zero-Indexed Array, when the sizes are equal, we've run the last warning.
+        if (this.warningsGiven == this.warningTimes.getAmountOfWarnings()) {
+            if (!shouldRunCode) {
+                this.shouldRunCode = true;
+                this.queueWithDelayMillis(this.timeToNextExecution(), task);
+            } else {
+                this.warningsGiven = 0;
+                this.shouldRunCode = false;
+                this.queueWithDelayMillis(this.getInitialDelay(), task);
+            }
+        }
+        TimeValue timeToWarnBefore = this.warningTimes.getWarningTimeAt(this.warningsGiven);
+        this.warningsGiven++;
+        this.queueWithDelayMillis(this.timeToNextExecution() - timeToWarnBefore.getAsMillis(), task);
+    }
+
+    /**
+     * Helper method to queue a job with a specific millis delay
+     *
+     * @param delay
+     *  The millis to delay
+     * @param task
+     *  The task to queue
+     */
+    private void queueWithDelayMillis(long delay, Task task) {
+        Scheduler scheduler = Sponge.getScheduler();
+        Task.Builder builder = scheduler.createTaskBuilder()
+                .execute(this).delay(delay, TimeUnit.MILLISECONDS).name(task.getName());
+
+        if (task.isAsynchronous()) {
+            builder.async();
+        }
+
+        builder.submit(task.getOwner());
+    }
+
+    /**
+     * @return
+     *  The raw time to next execution from the cron without any warning times attached
+     */
+    private long timeToNextExecution() {
+        Duration timeToNextExecution;
+        try {
+            ExecutionTime et = ExecutionTime.forCron(this.delayedTimeValue.getAsCron());
+            timeToNextExecution = et.timeToNextExecution(ZonedDateTime.now());
+        } catch (Exception e1) {
+            return -1;
+        }
+        return timeToNextExecution.toMillis();
+    }
+
+    /**
+     * @return
+     *  The initial delay for this job
+     */
+    @Override
+    public long getInitialDelay() {
+        long timeToNextExecution = timeToNextExecution();
+        if (timeToNextExecution == -1) {
+            return -1;
+        }
+        long maxDelayTime = this.warningTimes.getWarningTimeAt(this.warningTimes.getAmountOfWarnings() - 1)
+                .getAsMillis();
+        long hopingToReturn = timeToNextExecution - maxDelayTime;
+        if (hopingToReturn < 0) {
+            hopingToReturn = 0;
+        }
+        return hopingToReturn;
+    }
+
+    /**
+     * Run the jobs "cycle" e.g. run a warning, passing in the time to next execution, or run the task
+     *
+     * @param task
+     *  The task to run
+     */
+    @Override
+    public void accept(Task task) {
+        if (this.isCancelled) {
+            if (task.getInterval() > 0) {
+                task.cancel();
+            }
+            return;
+        }
+        if (this.shouldRunCode) {
+            this.runScheduledTask(task);
+        } else {
+            this.runWarning(task, this.timeToNextExecution());
+        }
+        this.requeue(task);
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/services/ScheduledManager.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/services/ScheduledManager.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.internal.services;
+
+import io.github.nucleuspowered.nucleus.NucleusPlugin;
+import io.github.nucleuspowered.nucleus.api.service.NucleusScheduledManagerService;
+import io.github.nucleuspowered.nucleus.internal.scheduled.ScheduledTask;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.scheduler.Task;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * The scheduled manager
+ */
+@ThreadSafe
+public class ScheduledManager implements NucleusScheduledManagerService {
+
+    private Map<String, ScheduledTask> tasks;
+    private NucleusPlugin plugin;
+
+    /**
+     * Construct a Scheduled Manager
+     *
+     * @param plugin
+     *  The nucleus plugin to inject scheduled tasks
+     */
+    public ScheduledManager(NucleusPlugin plugin) {
+        this.tasks = new ConcurrentHashMap<>();
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void addScheduledTask(ScheduledTask task) throws IllegalArgumentException {
+        this.addScheduledTask(task, true);
+    }
+
+    @Override
+    public void addScheduledTask(ScheduledTask task, boolean async) throws IllegalArgumentException {
+        if (this.tasks.containsKey(task.getName())) {
+            throw new IllegalArgumentException("Task already exists");
+        }
+        plugin.getInjector().injectMembers(task);
+        this.tasks.put(task.getName(), task);
+        Task.Builder builder = Sponge.getScheduler().createTaskBuilder().execute(task)
+                .delay(task.getInitialDelay(), TimeUnit.MILLISECONDS).name(task.getName());
+        if (async) {
+            builder.async();
+        }
+        builder.submit(plugin);
+    }
+
+    @Override
+    public List<ScheduledTask> getScheduledTasks() {
+        return this.tasks.values().stream().collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<ScheduledTask> getTaskByName(String name) {
+        return Optional.ofNullable(this.tasks.get(name));
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/scheduled/ScheduledModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/scheduled/ScheduledModule.java
@@ -22,9 +22,9 @@ public class ScheduledModule extends ConfigurableModule<ScheduledConfigAdapter> 
     public static final String ID = "scheduled";
 
     @Override
-    public ScheduledConfigAdapter getAdapter() {
-    return new ScheduledConfigAdapter();
-  }
+    public ScheduledConfigAdapter createAdapter() {
+        return new ScheduledConfigAdapter();
+    }
 
     @Override
     protected void performPreTasks() throws Exception {

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/scheduled/ScheduledModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/scheduled/ScheduledModule.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.scheduled;
+
+
+import uk.co.drnaylor.quickstart.annotations.ModuleData;
+
+import java.time.ZonedDateTime;
+
+import io.github.nucleuspowered.nucleus.internal.qsml.module.ConfigurableModule;
+import io.github.nucleuspowered.nucleus.internal.services.ScheduledManager;
+import io.github.nucleuspowered.nucleus.modules.scheduled.config.ScheduledConfig;
+import io.github.nucleuspowered.nucleus.modules.scheduled.config.ScheduledConfigAdapter;
+import io.github.nucleuspowered.nucleus.modules.scheduled.tasks.BroadcastTask;
+import io.github.nucleuspowered.nucleus.modules.scheduled.tasks.CommandTask;
+
+@ModuleData(id = ScheduledModule.ID, name = "Scheduler")
+public class ScheduledModule extends ConfigurableModule<ScheduledConfigAdapter> {
+
+    public static final String ID = "scheduled";
+
+    @Override
+    public ScheduledConfigAdapter getAdapter() {
+    return new ScheduledConfigAdapter();
+  }
+
+    @Override
+    protected void performPreTasks() throws Exception {
+        super.performPreTasks();
+        this.plugin.getLogger().info(String.format("Starting Scheduled Tasks, Current Time Zone is: [ %s ].",
+                ZonedDateTime.now().getOffset().getId()));
+    }
+
+    @Override
+    public void onEnable() {
+        super.onEnable();
+        ScheduledConfigAdapter sca = (ScheduledConfigAdapter) this.getConfigAdapter().get();
+        this.plugin.getLogger().info("Registering Scheduled Tasks.");
+        ScheduledConfig config = sca.getNodeOrDefault();
+        ScheduledManager scheduledManager = this.plugin.getScheduledManager();
+        config.getScheduledBroadcasts().forEach((scheduledBroadcast -> {
+            scheduledManager.addScheduledTask(
+                    new BroadcastTask(scheduledBroadcast.getName(),
+                        scheduledBroadcast.getMessageToBroadcast(),
+                        scheduledBroadcast.getScheduledTaskConfig().getDelayedTimeValue())
+            );
+        }));
+        config.getScheduledCommands().forEach((scheduledCommand -> {
+            scheduledManager.addScheduledTask(
+                    new CommandTask(scheduledCommand.getName(),
+                            scheduledCommand.getCommandToRun(),
+                            scheduledCommand.getScheduledTaskConfig().getDelayedTimeValue())
+            );
+        }));
+        this.plugin.getLogger().info("Registered Scheduled Tasks.");
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/scheduled/config/ScheduledBroadcast.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/scheduled/config/ScheduledBroadcast.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.scheduled.config;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+@ConfigSerializable
+public class ScheduledBroadcast {
+
+    @Setting(value = "name", comment = "loc:config.scheduled.broadcast.name")
+    private String name;
+
+    @Setting(value = "message", comment = "loc:config.scheduled.broadcast.message")
+    private String messageToBroadcast = "This is a broadcast message!";
+
+    @Setting(value = "task-config")
+    private ScheduledTaskConfig taskConfig;
+
+    @Nullable
+    public String getName() {
+        return this.name;
+    }
+
+    @Nonnull
+    public String getMessageToBroadcast() {
+        return this.messageToBroadcast;
+    }
+
+    public ScheduledTaskConfig getScheduledTaskConfig() {
+        return this.taskConfig;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/scheduled/config/ScheduledCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/scheduled/config/ScheduledCommand.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.scheduled.config;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+@ConfigSerializable
+public class ScheduledCommand {
+
+    @Setting(value = "name", comment = "loc:config.scheduled.command.name")
+    private String name;
+
+    @Setting(value = "command", comment = "loc:config.scheduled.command.command")
+    private String commandToRun = "/sponge plugins";
+
+    @Setting(value = "task-config")
+    private ScheduledTaskConfig taskConfig;
+
+    @Nullable
+    public String getName() {
+        return this.name;
+    }
+
+    @Nonnull
+    public String getCommandToRun() {
+        return this.commandToRun;
+    }
+
+    public ScheduledTaskConfig getScheduledTaskConfig() {
+        return this.taskConfig;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/scheduled/config/ScheduledConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/scheduled/config/ScheduledConfig.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.scheduled.config;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ConfigSerializable
+public class ScheduledConfig {
+
+    @Setting(value = "scheduled-broadcasts", comment = "loc:config.scheduled.broadcasts")
+    private List<ScheduledBroadcast> broadcasts = new ArrayList<>();
+
+    @Setting(value = "scheduled-commands", comment = "loc:config.scheduled.commands")
+    private List<ScheduledCommand> commands = new ArrayList<>();
+
+    public List<ScheduledBroadcast> getScheduledBroadcasts() {
+        return this.broadcasts;
+    }
+
+    public List<ScheduledCommand> getScheduledCommands() {
+        return this.commands;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/scheduled/config/ScheduledConfigAdapter.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/scheduled/config/ScheduledConfigAdapter.java
@@ -1,0 +1,14 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.scheduled.config;
+
+import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
+
+public class ScheduledConfigAdapter extends NucleusConfigAdapter.StandardWithSimpleDefault<ScheduledConfig> {
+
+    public ScheduledConfigAdapter() {
+        super(ScheduledConfig.class);
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/scheduled/config/ScheduledTaskConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/scheduled/config/ScheduledTaskConfig.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.scheduled.config;
+
+import io.github.nucleuspowered.nucleus.util.DelayedTimeValue;
+import io.github.nucleuspowered.nucleus.util.WarningTimeList;
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+import javax.annotation.Nullable;
+
+@ConfigSerializable
+public class ScheduledTaskConfig {
+
+    @Setting(value = "use-warning", comment = "loc:config.scheduled.task.usewarning")
+    private boolean useWarning = false;
+
+    @Setting(value = "warning-time-list", comment = "loc:config.scheduled.task.warningtimelist")
+    private WarningTimeList warningTimeList = new WarningTimeList();
+
+    @Setting(value = "delayed-time-value", comment = "loc:config.scheduled.task.delayedtimevalue")
+    private DelayedTimeValue delayedTimeValue = null;
+
+    public boolean useWarning() {
+        return this.useWarning;
+    }
+
+    public WarningTimeList getWarnings() {
+        return this.warningTimeList;
+    }
+
+    @Nullable
+    public DelayedTimeValue getDelayedTimeValue() {
+        return this.delayedTimeValue;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/scheduled/tasks/BroadcastTask.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/scheduled/tasks/BroadcastTask.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.scheduled.tasks;
+
+import com.google.common.collect.Lists;
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.ChatUtil;
+import io.github.nucleuspowered.nucleus.internal.scheduled.ScheduledTask;
+import io.github.nucleuspowered.nucleus.modules.admin.config.AdminConfigAdapter;
+import io.github.nucleuspowered.nucleus.modules.admin.config.BroadcastConfig;
+import io.github.nucleuspowered.nucleus.util.DelayedTimeValue;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.command.source.ConsoleSource;
+import org.spongepowered.api.scheduler.Task;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.channel.MessageChannel;
+
+import java.util.List;
+
+public class BroadcastTask extends ScheduledTask {
+
+    private String messageToBroadcast;
+    @Inject
+    private Game game;
+    @Inject
+    private AdminConfigAdapter adminConfigAdapter;
+    @Inject
+    private ChatUtil chatUtil;
+
+    public BroadcastTask(String name, String messageToBroadcast, DelayedTimeValue delayedTimeValue) {
+        super(name, delayedTimeValue);
+        this.messageToBroadcast = messageToBroadcast;
+    }
+
+    @Override
+    protected void runScheduledTask(Task task) {
+        BroadcastConfig bc = adminConfigAdapter.getNodeOrDefault().getBroadcastMessage();
+        ConsoleSource console = game.getServer().getConsole();
+        List<Text> messages = Lists.newArrayList();
+        ChatUtil.StyleTuple cst = ChatUtil.EMPTY;
+
+        String prefix = bc.getPrefix();
+        if (!prefix.trim().isEmpty()) {
+            messages.add(chatUtil.getMessageFromTemplate(prefix, console, true));
+        }
+
+        messages.add(Text.of(cst.colour, cst.style, chatUtil.
+                addUrlsToAmpersandFormattedString(this.messageToBroadcast)));
+
+        String suffix = bc.getSuffix();
+        if (!suffix.trim().isEmpty()) {
+            messages.add(Text.of(cst.colour, cst.style,
+                    chatUtil.getMessageFromTemplate(suffix, console, true)));
+        }
+
+        MessageChannel.TO_ALL.send(Text.joinWith(Text.of(" "), messages));
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/scheduled/tasks/CommandTask.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/scheduled/tasks/CommandTask.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.scheduled.tasks;
+
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.internal.scheduled.ScheduledTask;
+import io.github.nucleuspowered.nucleus.util.DelayedTimeValue;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.scheduler.Task;
+
+public class CommandTask extends ScheduledTask {
+
+    private String commandToRun;
+    @Inject
+    private Game game;
+
+    public CommandTask(String name, String commandToRun, DelayedTimeValue requeueValue) {
+        super(name, requeueValue);
+        this.commandToRun = commandToRun;
+    }
+
+    @Override
+    protected void runScheduledTask(Task task) {
+        Sponge.getCommandManager().process(game.getServer().getConsole(), commandToRun);
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/util/ClockTime.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/util/ClockTime.java
@@ -1,0 +1,207 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.util;
+
+import com.cronutils.builder.CronBuilder;
+import com.cronutils.model.Cron;
+import com.cronutils.model.CronType;
+import com.cronutils.model.definition.CronDefinitionBuilder;
+import com.cronutils.model.field.expression.FieldExpressionFactory;
+import com.cronutils.utils.Preconditions;
+
+/**
+ * <p>
+ * A Variable Time Format. An alternative syntax to cron that can be expressed like:
+ * </p>
+ *
+ * <pre>
+ * 10:30
+ * 10:30:30
+ * </pre>
+ *
+ * <p>
+ * This is fairly simple time format, and automatically assumes every year/month/day.
+ * Internally ClockTime is backed by a Cron so we can have one Single handling case for delayed
+ * tasks, and don't have to jump through hoops.
+ * </p>
+ */
+public class ClockTime {
+
+    private int hours;
+    private int minutes;
+    private int seconds;
+    private boolean isSingle;
+    private Cron backingCron;
+
+    /**
+     * Constructs a clock time that has been formatted as: `HH:MM`
+     *
+     * @param hours
+     *  The Hours
+     * @param minutes
+     *  The Minutes
+     */
+    public ClockTime(int hours, int minutes) {
+        this.hours = hours;
+        this.minutes = minutes;
+        this.seconds = -1;
+        CronBuilder cronBuilder = CronBuilder.cron(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
+        cronBuilder.withYear(FieldExpressionFactory.always())
+                .withDoM(FieldExpressionFactory.always())
+                .withDoW(FieldExpressionFactory.questionMark())
+                .withMonth(FieldExpressionFactory.always())
+                .withHour(FieldExpressionFactory.on(this.hours))
+                .withMinute(FieldExpressionFactory.on(this.minutes))
+                .withSecond(FieldExpressionFactory.on(0));
+        this.backingCron = cronBuilder.instance();
+        this.isSingle = false;
+    }
+
+    /**
+     * Constructs a clock time that has been formatted as: `HH:MM:SS`
+     *
+     * @param hours
+     *  The Hours
+     * @param minutes
+     *  The Minutes
+     * @param seconds
+     *  The Seconds
+     */
+    public ClockTime(int hours, int minutes, int seconds) {
+        this.hours = hours;
+        this.minutes = minutes;
+        this.seconds = seconds;
+        CronBuilder cronBuilder = CronBuilder.cron(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
+        cronBuilder.withYear(FieldExpressionFactory.always())
+                .withDoM(FieldExpressionFactory.always())
+                .withDoW(FieldExpressionFactory.questionMark())
+                .withMonth(FieldExpressionFactory.always())
+                .withHour(FieldExpressionFactory.on(this.hours))
+                .withMinute(FieldExpressionFactory.on(this.minutes))
+                .withSecond(FieldExpressionFactory.on(this.seconds));
+        this.backingCron = cronBuilder.instance();
+        this.isSingle = false;
+    }
+
+    /**
+     * Constructs a clock time in `HH:MM` while manually specifying isSingle
+     *
+     * @param hours
+     *  The hours
+     * @param minutes
+     *  The minutes
+     * @param isSingle
+     *  If this job should only be run once
+     */
+    public ClockTime(int hours, int minutes, boolean isSingle) {
+        this(hours, minutes);
+        this.isSingle = isSingle;
+    }
+
+    /**
+     * Constructs a clock time in `HH:MM:SS` while manually specifying isSingle
+     *
+     * @param hours
+     *  The hours
+     * @param minutes
+     *  The minutes
+     * @param seconds
+     *  The seconds
+     * @param isSingle
+     *  If this job should only be run once
+     */
+    public ClockTime(int hours, int minutes, int seconds, boolean isSingle) {
+        this(hours, minutes, seconds);
+        this.isSingle = isSingle;
+    }
+
+    /**
+     * @return
+     *  Whether the user only wanted this to run once
+     */
+    public boolean isSingle() {
+        return this.isSingle;
+    }
+
+    /**
+     * @return
+     *  The backing cron instance
+     */
+    public Cron getBackingCron() {
+        return this.backingCron;
+    }
+
+    /**
+     * Convert this ClockTime to a String
+     *
+     * @return
+     *  The ClockTime as a String
+     */
+    public String asString() {
+        if (!this.isSingle) {
+            if (this.seconds == -1) {
+                return String.format("%02d:%02d", this.hours, this.minutes);
+            } else {
+                return String.format("%02d:%02d:%02d", this.hours, this.minutes, this.seconds);
+            }
+        } else {
+            if (this.seconds == -1) {
+                return String.format("at %02d:%02d", this.hours, this.minutes);
+            } else {
+                return String.format("at %02d:%02d:%02d", this.hours, this.minutes, this.seconds);
+            }
+        }
+    }
+
+    /**
+     * Create a ClockTime from a String
+     *
+     * @param string
+     *  The string to create the ClockTime from
+     * @return
+     *  The ClockTime
+     * @throws NullPointerException
+     *  Throws a NullPointerException if the string is null
+     * @throws IllegalArgumentException
+     *  Throws an IllegalArgumentException if we can't parse the ClockTime
+     */
+    public static ClockTime fromString(String string) throws NullPointerException, IllegalArgumentException {
+        Preconditions.checkNotNull(string);
+        String stringFrd;
+        boolean isSingle = false;
+        if (string.contains(" ")) {
+            isSingle = true;
+            String[] splitFirst = string.split(" ");
+            if (splitFirst.length != 2) {
+                throw new IllegalArgumentException("Expression has too many spaces!");
+            }
+            if (!splitFirst[0].equalsIgnoreCase("at")) {
+                throw new IllegalArgumentException("Expression has unknown starting directive.");
+            }
+            stringFrd = splitFirst[1];
+        } else {
+            stringFrd = string;
+        }
+        if (!stringFrd.contains(":")) {
+            throw new IllegalArgumentException("Expression doesn't have the split character.");
+        }
+        String[] split = stringFrd.split(":");
+        if (split.length > 3 || split.length < 2) {
+            throw new IllegalArgumentException("Expression doesn't have the right amount of numbers.");
+        }
+        try {
+            int hours = Integer.parseInt(split[0]);
+            int minutes = Integer.parseInt(split[1]);
+            if (split.length == 3) {
+                int seconds = Integer.parseInt(split[2]);
+                return new ClockTime(hours, minutes, seconds, isSingle);
+            } else {
+                return new ClockTime(hours, minutes, isSingle);
+            }
+        } catch (Exception e1) {
+            throw new IllegalArgumentException(e1.getCause());
+        }
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/util/DelayedTimeType.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/util/DelayedTimeType.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.util;
+
+import javax.annotation.Nullable;
+
+/**
+ * A Type of Delayed Time. E.g. is the timing a cron, HH:MM, or?
+ */
+public enum DelayedTimeType {
+    UNIX_CRON,
+    QUARTZ_CRON,
+    CRON4J_CRON,
+    WHEN_TIME,
+    CLOCK_TIME;
+
+    @Nullable
+    public static DelayedTimeType fromString(String value) {
+        if (value.equalsIgnoreCase("unix_cron") || value.equalsIgnoreCase("unix-cron") ||
+                value.equalsIgnoreCase("unix")) {
+            return DelayedTimeType.UNIX_CRON;
+        }
+        if (value.equalsIgnoreCase("quartz_cron") || value.equalsIgnoreCase("quartz-cron") ||
+                value.equalsIgnoreCase("quartz")) {
+            return DelayedTimeType.QUARTZ_CRON;
+        }
+        if (value.equalsIgnoreCase("cron4j_cron") || value.equalsIgnoreCase("cron4j-cron") ||
+                value.equalsIgnoreCase("cron4j")) {
+            return DelayedTimeType.CRON4J_CRON;
+        }
+        if (value.equalsIgnoreCase("when_time") || value.equalsIgnoreCase("when-time") ||
+                value.equalsIgnoreCase("when")) {
+            return DelayedTimeType.WHEN_TIME;
+        }
+        if (value.equalsIgnoreCase("clock_time") || value.equalsIgnoreCase("clock-time") ||
+                value.equalsIgnoreCase("clock")) {
+            return DelayedTimeType.CLOCK_TIME;
+        }
+        return null;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/util/DelayedTimeValue.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/util/DelayedTimeValue.java
@@ -1,0 +1,149 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.util;
+
+import com.cronutils.model.Cron;
+
+import java.util.Optional;
+
+/**
+ * Used for serialization purposes inside configs. Provides one interface
+ * for multiple delayed time types (cron, when time, etc.)
+ */
+public class DelayedTimeValue {
+
+    private DelayedTimeType type;
+    private Optional<Cron> asCron;
+    private Optional<WhenTime> asWhenTime;
+    private Optional<ClockTime> asClockTime;
+
+    /**
+     * Creates a DelayedTimeValue from a Cron. This is a special Cosntructor that takes a DelayedTimeType
+     * because there are multiple types of cron that we support
+     *
+     * @param type
+     *  The DelayedTimeType should be a type of a cron
+     * @param cron
+     *  The underlying Cron instance
+     * @throws IllegalArgumentException
+     *  Throws an IllegalArgumentException if the DelayedTimeType isn't a possible Cron type
+     */
+    public DelayedTimeValue(DelayedTimeType type, Cron cron) throws IllegalArgumentException {
+        switch (type) {
+            case CRON4J_CRON:
+            case QUARTZ_CRON:
+            case UNIX_CRON:
+                this.type = type;
+                this.asCron = Optional.of(cron);
+                this.asWhenTime = Optional.empty();
+                this.asClockTime = Optional.empty();
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid Delayed Time Type.");
+        }
+    }
+
+    /**
+     * Creates a DelayedTimeValue from a "WhenTime" instance
+     *
+     * @param whenTime
+     *  The underlying whenTime
+     */
+    public DelayedTimeValue(WhenTime whenTime) {
+        this.type = DelayedTimeType.WHEN_TIME;
+        this.asWhenTime = Optional.of(whenTime);
+        this.asCron = Optional.empty();
+        this.asClockTime = Optional.empty();
+    }
+
+    /**
+     * Creates a DelayedTimeValue from a "ClockTime" instance
+     *
+     * @param clockTime
+     *  The underlying ClockTime
+     */
+    public DelayedTimeValue(ClockTime clockTime) {
+        this.type = DelayedTimeType.CLOCK_TIME;
+        this.asClockTime = Optional.of(clockTime);
+        this.asWhenTime = Optional.empty();
+        this.asCron = Optional.empty();
+    }
+
+    /**
+     * @return
+     *  The underlying Cron instance regardless of the actual type of delayed time value
+     */
+    public Cron getAsCron() {
+        switch(this.type) {
+            case CRON4J_CRON:
+            case QUARTZ_CRON:
+            case UNIX_CRON:
+                return this.asCron.get();
+            case WHEN_TIME:
+                return this.asWhenTime.get().getBackingCronInstance();
+            case CLOCK_TIME:
+                return this.asClockTime.get().getBackingCron();
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * @return
+     *  If the user specified to only run this once
+     */
+    public boolean isSingle() {
+        if (this.type == DelayedTimeType.WHEN_TIME) {
+            return this.asWhenTime.get().isSingle();
+        }
+        if (this.type == DelayedTimeType.CLOCK_TIME) {
+            return this.asClockTime.get().isSingle();
+        }
+        return false;
+    }
+
+    /**
+     * @return
+     *  The potential Underlying Cron instance
+     */
+    public Optional<Cron> getUnderlyingCron() {
+        return this.asCron;
+    }
+
+    /**
+     * @return
+     *  The potential Underlying WhenTime instance
+     */
+    public Optional<WhenTime> getUnderlyingWhenTime() {
+        return this.asWhenTime;
+    }
+
+    /**
+     * @return
+     *  The potential Underlying ClockTime instance
+     */
+    public Optional<ClockTime> getUnderlyingClockTime() {
+        return this.asClockTime;
+    }
+
+    /**
+     * @return
+     *  The DelayedTime as a String
+     */
+    public String asString() {
+        switch (this.type) {
+            case CRON4J_CRON:
+            case QUARTZ_CRON:
+            case UNIX_CRON:
+                return this.asCron.get().asString();
+            case WHEN_TIME:
+                return this.asWhenTime.get().asString();
+            case CLOCK_TIME:
+                return this.asClockTime.get().asString();
+            default:
+                return null;
+        }
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/util/QuartzTimeUnit.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/util/QuartzTimeUnit.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.util;
+
+import javax.annotation.Nullable;
+
+public enum QuartzTimeUnit {
+    DAY_OF_WEEK,
+    DAY_OF_MONTH,
+    MONTHS,
+    HOURS,
+    MINUTES,
+    SECONDS;
+
+    /**
+     * An alternative method to valueOf accounting for multiple spellings of an enum value
+     *
+     * @param asString
+     *  The value as a String
+     * @return
+     *  The QuartzTimeUnit or null if we couldn't find an acceptable match
+     */
+    @Nullable
+    public static QuartzTimeUnit fromString(String asString) {
+        if (asString.equalsIgnoreCase("dow") || asString.equalsIgnoreCase("day_of_week") ||
+                asString.equalsIgnoreCase("day-of-week") || asString.equalsIgnoreCase("days_of_the_week") ||
+                asString.equalsIgnoreCase("days-of-the-week")) {
+            return QuartzTimeUnit.DAY_OF_WEEK;
+        }
+        if (asString.equalsIgnoreCase("dom") || asString.equalsIgnoreCase("day_of_month") ||
+                asString.equalsIgnoreCase("day-of-month") || asString.equalsIgnoreCase("days_of_the_month") ||
+                asString.equalsIgnoreCase("days-of-the-month")) {
+            return QuartzTimeUnit.DAY_OF_MONTH;
+        }
+        if (asString.equalsIgnoreCase("months") || asString.equalsIgnoreCase("month")) {
+            return QuartzTimeUnit.MONTHS;
+        }
+        if (asString.equalsIgnoreCase("hours") || asString.equalsIgnoreCase("hour")) {
+            return QuartzTimeUnit.HOURS;
+        }
+        if (asString.equalsIgnoreCase("minutes") || asString.equalsIgnoreCase("minute")) {
+            return QuartzTimeUnit.MINUTES;
+        }
+        if (asString.equalsIgnoreCase("seconds") || asString.equalsIgnoreCase("second")) {
+            return QuartzTimeUnit.SECONDS;
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/util/TimeValue.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/util/TimeValue.java
@@ -1,0 +1,116 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.util;
+
+import com.google.common.base.Preconditions;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A Time value represents a unit of time. E.g. 4 seconds, 3 hours, 2 minutes, 1 year, etc.
+ */
+public class TimeValue implements Comparable<TimeValue> {
+
+    private long value;
+    private TimeUnit unit;
+
+    /**
+     * Construct a TimeValue
+     *
+     * @param value
+     *  The value of time
+     * @param unit
+     *  The unit to use
+     */
+    public TimeValue(long value, TimeUnit unit) {
+        this.value = value;
+        this.unit = unit;
+    }
+
+    /**
+     * @return
+     *  The time unit as milliseconds
+     */
+    public long getAsMillis() {
+        return this.unit.toMillis(this.value);
+    }
+
+    /**
+     * @return
+     *  The original passed in value
+     */
+    public long getValue() {
+        return this.value;
+    }
+
+    /**
+     * @return
+     *  The unit of time
+     */
+    public TimeUnit getUnitOfMeasurement() {
+        return this.unit;
+    }
+
+    /**
+     * Compare this TimeValue to another TimeValue
+     *
+     * @param timeValue
+     *  The other TimeValue to compare this too
+     * @return
+     *  The comparison
+     */
+    @Override
+    public int compareTo(@Nonnull TimeValue timeValue) {
+        Long thisAsMillis = this.getAsMillis();
+        Long otherAsMillis = timeValue.getAsMillis();
+        return thisAsMillis.compareTo(otherAsMillis);
+    }
+
+    /**
+     * @return
+     *  This TimeValue as a string
+     */
+    public String asString() {
+        return String.format("%d %s", this.value, this.unit.name().toLowerCase());
+    }
+
+    /**
+     * Converts the String to a TimeValue
+     *
+     * @param value
+     *  The String to Parse
+     * @return
+     *  The TimeValue
+     * @throws IllegalArgumentException
+     *  Throws an IllegalArgumentException if we can't parse the string
+     * @throws NullPointerException
+     *  Throws a NullPointerException if the original String is null
+     */
+    public static TimeValue fromString(String value) throws IllegalArgumentException, NullPointerException {
+        Preconditions.checkNotNull(value);
+        if (!value.contains(" ")) {
+            throw new IllegalArgumentException("No split character found!");
+        }
+        String[] split = value.split(" ");
+        if (split.length != 2) {
+            throw new IllegalArgumentException("Argument does not have the right directives!");
+        }
+        long timeValue;
+        try {
+            timeValue = Long.parseLong(split[0]);
+        } catch (Exception e1) {
+            throw new IllegalArgumentException(e1.getMessage(), e1.getCause());
+        }
+        TimeUnit unitOfMeasurement;
+        try {
+            unitOfMeasurement = TimeUnit.valueOf(split[1].toUpperCase());
+        } catch (Exception e1) {
+            throw new IllegalArgumentException(e1.getMessage(), e1.getCause());
+        }
+        return new TimeValue(timeValue, unitOfMeasurement);
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/util/WarningTimeList.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/util/WarningTimeList.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Construct a List of Warning Times
+ */
+public class WarningTimeList {
+
+    private List<TimeValue> sortedDelayTimes;
+
+    public WarningTimeList() {
+        this(new ArrayList<>());
+    }
+
+    public WarningTimeList(TimeValue ...values) {
+        this(Arrays.asList(values));
+    }
+
+    /**
+     * Constructs a list of sorted warning times
+     *
+     * @param values
+     *  The list of time values to warn at
+     */
+    public WarningTimeList(List<TimeValue> values) {
+        this.sortedDelayTimes = values.parallelStream().sorted(Comparator.reverseOrder())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Gets a specific warning time
+     *
+     * @param place
+     *  The index of the warning time to get
+     * @return
+     *  The warning time at a particular index
+     */
+    public TimeValue getWarningTimeAt(int place) {
+        return this.sortedDelayTimes.get(place);
+    }
+
+    /**
+     * @return
+     *  the amount of warning times
+     */
+    public int getAmountOfWarnings() {
+        return this.sortedDelayTimes.size();
+    }
+
+    /**
+     * @return
+     *  This WarningTimeList as a regular sorted list
+     */
+    public List<String> asList() {
+        List<String> finalized = new ArrayList<>();
+        this.sortedDelayTimes.forEach((timeValue -> finalized.add(timeValue.asString())));
+        return finalized;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/util/WhenTime.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/util/WhenTime.java
@@ -1,0 +1,199 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.util;
+
+import com.cronutils.builder.CronBuilder;
+import com.cronutils.model.Cron;
+import com.cronutils.model.CronType;
+import com.cronutils.model.definition.CronDefinitionBuilder;
+import com.cronutils.model.field.expression.FieldExpressionFactory;
+import com.cronutils.utils.Preconditions;
+
+/**
+ * <p>
+ * A Variable Time Format. An alternative to Cron syntax that can be expressed like:
+ * </p>
+ *
+ * <pre>
+ * every 15 minutes
+ * every hour
+ * </pre>
+ *
+ * <p>
+ * This is a fairly simple syntax loosely based off the Whenjobs time parsing format.
+ * Internally the WhenTime is backed by a Cron so we can have one Single handling case for delayed
+ * tasks, and don't have to jump through hoops.
+ * </p>
+ */
+public class WhenTime {
+
+    private QuartzTimeUnit timeUnit;
+    private int every;
+    private boolean isSingle;
+    private Cron backingCronInstance;
+
+    /**
+     * Construct a Variable Time
+     *
+     * @param timeUnit
+     *  The TimeUnit of the variable. (It should be noted Days will be treated as: Days of the Week)
+     * @param every
+     *  The value of TimeUnits to wait. E.g. in "every 2 days" 2 would be the "every"
+     * @throws IllegalArgumentException
+     *  Throws an IllegalArgumentException if the TimeUnit is too granular/non-existant for a cron, and thus can't
+     *  be parsed
+     */
+    public WhenTime(QuartzTimeUnit timeUnit, int every) throws IllegalArgumentException {
+        this.timeUnit = timeUnit;
+        this.every = every;
+        CronBuilder cronBuilder = CronBuilder.cron(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
+        switch (timeUnit) {
+            case DAY_OF_WEEK:
+                cronBuilder.withDoW(FieldExpressionFactory.every(this.every))
+                        .withDoM(FieldExpressionFactory.questionMark())
+                        .withYear(FieldExpressionFactory.always())
+                        .withMonth(FieldExpressionFactory.always())
+                        .withHour(FieldExpressionFactory.on(0))
+                        .withMinute(FieldExpressionFactory.on(0))
+                        .withSecond(FieldExpressionFactory.on(0));
+                break;
+            case DAY_OF_MONTH:
+                cronBuilder.withDoM(FieldExpressionFactory.every(this.every))
+                        .withDoW(FieldExpressionFactory.questionMark())
+                        .withYear(FieldExpressionFactory.always())
+                        .withMonth(FieldExpressionFactory.always())
+                        .withHour(FieldExpressionFactory.on(0))
+                        .withMinute(FieldExpressionFactory.on(0))
+                        .withSecond(FieldExpressionFactory.on(0));
+                break;
+            case MONTHS:
+                cronBuilder.withDoM(FieldExpressionFactory.on(1))
+                        .withDoW(FieldExpressionFactory.questionMark())
+                        .withYear(FieldExpressionFactory.always())
+                        .withMonth(FieldExpressionFactory.every(this.every))
+                        .withHour(FieldExpressionFactory.on(0))
+                        .withMinute(FieldExpressionFactory.on(0))
+                        .withSecond(FieldExpressionFactory.on(0));
+                break;
+            case HOURS:
+                cronBuilder.withDoM(FieldExpressionFactory.always())
+                        .withDoW(FieldExpressionFactory.questionMark())
+                        .withYear(FieldExpressionFactory.always())
+                        .withMonth(FieldExpressionFactory.always())
+                        .withHour(FieldExpressionFactory.every(this.every))
+                        .withMinute(FieldExpressionFactory.on(0))
+                        .withSecond(FieldExpressionFactory.on(0));
+                break;
+            case MINUTES:
+                cronBuilder.withDoM(FieldExpressionFactory.always())
+                        .withDoW(FieldExpressionFactory.questionMark())
+                        .withYear(FieldExpressionFactory.always())
+                        .withMonth(FieldExpressionFactory.always())
+                        .withHour(FieldExpressionFactory.on(0))
+                        .withMinute(FieldExpressionFactory.every(this.every))
+                        .withSecond(FieldExpressionFactory.on(0));
+                break;
+            case SECONDS:
+                cronBuilder.withDoM(FieldExpressionFactory.always())
+                        .withDoW(FieldExpressionFactory.questionMark())
+                        .withYear(FieldExpressionFactory.always())
+                        .withMonth(FieldExpressionFactory.always())
+                        .withHour(FieldExpressionFactory.on(0))
+                        .withMinute(FieldExpressionFactory.on(0))
+                        .withSecond(FieldExpressionFactory.every(this.every));
+                break;
+            default:
+                throw new IllegalArgumentException("Time Unit is not supported by Quartz CRON.");
+        }
+        this.isSingle = false;
+        this.backingCronInstance = cronBuilder.instance();
+    }
+
+    public WhenTime(QuartzTimeUnit timeUnit, int every, boolean isSingle) throws IllegalArgumentException {
+        this(timeUnit, every);
+        this.isSingle = isSingle;
+    }
+
+    /**
+     * @return
+     *  If the user specified to only run this once
+     */
+    public boolean isSingle() {
+        return this.isSingle;
+    }
+
+    /**
+     * Grab the backing cron instance for this WhenTime
+     *
+     * @return
+     *  The backing cron instance
+     */
+    public Cron getBackingCronInstance() {
+        return this.backingCronInstance;
+    }
+
+    /**
+     * Converts the WhenTime to a String
+     *
+     * @return
+     *  The WhenTime as a String
+     */
+    public String asString() {
+        if (!this.isSingle) {
+            if (this.every == 1) {
+                return String.format("every %s", this.timeUnit.name().toLowerCase());
+            } else {
+                return String.format("every %d %s", this.every, this.timeUnit.name().toLowerCase());
+            }
+        } else {
+            if (this.every == 1) {
+                return String.format("in %s", this.timeUnit.name().toLowerCase());
+            } else {
+                return String.format("in %d %s", this.every, this.timeUnit.name().toLowerCase());
+            }
+        }
+    }
+
+    /**
+     * Parses a WhenTime from a String
+     *
+     * @param string
+     *  The String to parse
+     * @return
+     *  The WhenTime represented by the String
+     * @throws IllegalArgumentException
+     *  Throws an IllegalArgumentException if we could not parse the string
+     * @throws NullPointerException
+     *  Throws a NullPointerException if the String is null
+     */
+    public static WhenTime fromString(String string) throws IllegalArgumentException, NullPointerException {
+        Preconditions.checkNotNull(string);
+        if (!string.contains(" ")) {
+            throw new IllegalArgumentException("Expression doesn't have the split character.");
+        }
+        String[] split = string.split(" ");
+        if (split.length > 3 || split.length < 2) {
+            throw new IllegalArgumentException("Expression doesn't has to many directives.");
+        }
+        if (!split[0].equalsIgnoreCase("every") && !split[0].equalsIgnoreCase("in")) {
+            throw new IllegalArgumentException("Unknown Starting Expression");
+        }
+        String possibleTimeUnit = split[split.length - 1];
+        QuartzTimeUnit timeUnit = QuartzTimeUnit.fromString(possibleTimeUnit);
+        if (timeUnit == null) {
+            throw new IllegalArgumentException("Expression doesn't have a valid time unit.");
+        }
+        int every = 1;
+        if (split.length == 3) {
+            String toParseTime = split[1];
+            try {
+                every = Integer.parseInt(toParseTime);
+            } catch (Exception e1) {
+                throw new IllegalArgumentException("Expression doesn't have a valid time for every.");
+            }
+        }
+        return new WhenTime(timeUnit, every, split[0].equalsIgnoreCase("in"));
+    }
+}

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -334,6 +334,19 @@ config.gamemode.separate=If true, then changing gamemode using the /gm command r
 config.protection.disablecrop=Disables crop trampling.
 config.protection.mobgriefing.flag=If true, mob griefing will be disabled except for the entities listed in the whitelist (which should be done by mob ID).
 
+config.scheduled.task.usewarning=Whether or not this has some warnings before the action.
+config.scheduled.task.warningtimelist=A list of times to warn before the action, doesn't have to be in order.
+config.scheduled.task.delayedtimevalue=The delayed time value (can be a cron, can be a whentime, or a clocktime).
+
+config.scheduled.broadcast.name=The name of this scheduled broadcast to show in nucleus.
+config.scheduled.broadcast.message=The message to actually broadcast.
+
+config.scheduled.command.name=The name of this scheduled command to show in nucleus.
+config.scheduled.command.command=The full command to run.
+
+config.scheduled.broadcasts=The list of scheduled broadcasts.
+config.scheduled.commands=The list of scheduled commands.
+
 afk.kickreason=You have been kicked for being AFK for too long.
 
 # Arguments
@@ -424,6 +437,8 @@ args.selector.noworld=&cThe world &e{0} &cdoes not exist.
 
 args.worldproperties.noexist=&cThe world &e{0}&c does not exist.
 args.worldproperties.noexistdisabled=&cThe world &e{0}&c is not a disabled world.
+
+args.delayedtimevalue.nomatch=&cWe could not find a suitable delayed time format.
 
 commandlog.message={0} ran the command: /{1} {2}
 commandlog.couldnotwrite=Could not write log entry to Nucleus command log file

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -333,6 +333,19 @@ config.gamemode.separate=If true, then changing gamemode using the /gm command r
 config.protection.disablecrop=Disables crop trampling.
 config.protection.mobgriefing.flag=If true, mob griefing will be disabled except for the entities listed in the whitelist (which should be done by mob ID).
 
+config.scheduled.task.usewarning=Whether or not this has some warnings before the action.
+config.scheduled.task.warningtimelist=A list of times to warn before the action, doesn't have to be in order.
+config.scheduled.task.delayedtimevalue=The delayed time value (can be a cron, can be a whentime, or a clocktime).
+
+config.scheduled.broadcast.name=The name of this scheduled broadcast to show in nucleus.
+config.scheduled.broadcast.message=The message to actually broadcast.
+
+config.scheduled.command.name=The name of this scheduled command to show in nucleus.
+config.scheduled.command.command=The full command to run.
+
+config.scheduled.broadcasts=The list of scheduled broadcasts.
+config.scheduled.commands=The list of scheduled commands.
+
 afk.kickreason=You have been kicked for being AFK for too long.
 
 # Arguments
@@ -423,6 +436,8 @@ args.selector.noworld=&cThe world &e{0} &cdoes not exist.
 
 args.worldproperties.noexist=&cThe world &e{0}&c does not exist.
 args.worldproperties.noexistdisabled=&cThe world &e{0}&c is not a disabled world.
+
+args.delayedtimevalue.nomatch=&cWe could not find a suitable delayed time format.
 
 commandlog.message={0} ran the command: /{1} {2}
 commandlog.couldnotwrite=Could not write log entry to Nucleus command log file

--- a/src/test/java/io/github/nucleuspowered/nucleus/tests/TestBase.java
+++ b/src/test/java/io/github/nucleuspowered/nucleus/tests/TestBase.java
@@ -17,6 +17,7 @@ import io.github.nucleuspowered.nucleus.internal.MixinConfigProxy;
 import io.github.nucleuspowered.nucleus.internal.PermissionRegistry;
 import io.github.nucleuspowered.nucleus.internal.messages.MessageProvider;
 import io.github.nucleuspowered.nucleus.internal.messages.ResourceMessageProvider;
+import io.github.nucleuspowered.nucleus.internal.services.ScheduledManager;
 import io.github.nucleuspowered.nucleus.internal.services.WarmupManager;
 import io.github.nucleuspowered.nucleus.internal.teleport.NucleusTeleportHandler;
 import org.junit.BeforeClass;
@@ -113,6 +114,11 @@ public abstract class TestBase {
         @Override
         public void saveData() {
 
+        }
+
+        @Override
+        public ScheduledManager getScheduledManager() {
+            return null;
         }
 
         @Override

--- a/src/test/java/io/github/nucleuspowered/nucleus/tests/configurate/TypeSerialiserTests.java
+++ b/src/test/java/io/github/nucleuspowered/nucleus/tests/configurate/TypeSerialiserTests.java
@@ -7,25 +7,43 @@ package io.github.nucleuspowered.nucleus.tests.configurate;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.reflect.TypeToken;
+import com.cronutils.model.Cron;
+import com.cronutils.model.CronType;
+import com.cronutils.model.definition.CronDefinitionBuilder;
+import com.cronutils.parser.CronParser;
+import io.github.nucleuspowered.nucleus.configurate.typeserialisers.DelayedTimeValueSerialiser;
 import io.github.nucleuspowered.nucleus.configurate.typeserialisers.SetTypeSerialiser;
+import io.github.nucleuspowered.nucleus.configurate.typeserialisers.WarningTimeListSerialiser;
+import io.github.nucleuspowered.nucleus.util.ClockTime;
+import io.github.nucleuspowered.nucleus.util.DelayedTimeType;
+import io.github.nucleuspowered.nucleus.util.DelayedTimeValue;
+import io.github.nucleuspowered.nucleus.util.TimeValue;
+import io.github.nucleuspowered.nucleus.util.WarningTimeList;
+import io.github.nucleuspowered.nucleus.util.WhenTime;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializerCollection;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 public class TypeSerialiserTests {
 
-    private TestConfigurationLoader getSetTestLoader() {
+    private TestConfigurationLoader getTestLoader() {
         TestConfigurationLoader.Builder tclb = TestConfigurationLoader.builder();
         TypeSerializerCollection tsc = tclb.getDefaultOptions().getSerializers();
         tsc.registerPredicate(
                 typeToken -> Set.class.isAssignableFrom(typeToken.getRawType()),
                 new SetTypeSerialiser()
         );
+        tsc.registerType(TypeToken.of(DelayedTimeValue.class), new DelayedTimeValueSerialiser());
+        tsc.registerType(TypeToken.of(WarningTimeList.class), new WarningTimeListSerialiser());
 
         tclb.setDefaultOptions(tclb.getDefaultOptions().setSerializers(tsc));
         return tclb.build();
@@ -33,7 +51,7 @@ public class TypeSerialiserTests {
 
     @Test
     public void testThatSetsCanBeSerialised() throws ObjectMappingException {
-        TestConfigurationLoader tcl = getSetTestLoader();
+        TestConfigurationLoader tcl = getTestLoader();
         ConfigurationNode cn = tcl.createEmptyNode().setValue(new TypeToken<Set<String>>() {}, Sets.newHashSet("test", "test2"));
 
         List<String> ls = cn.getList(TypeToken.of(String.class));
@@ -43,12 +61,154 @@ public class TypeSerialiserTests {
 
     @Test
     public void testThatSetsCanBeDeserialised() throws ObjectMappingException {
-        TestConfigurationLoader tcl = getSetTestLoader();
+        TestConfigurationLoader tcl = getTestLoader();
         ConfigurationNode cn = tcl.createEmptyNode().setValue(new TypeToken<List<String>>() {}, Lists.newArrayList("test", "test", "test2"));
 
         Set<String> ls = cn.getValue(new TypeToken<Set<String>>() {});
         Assert.assertEquals(2, ls.size());
         Assert.assertTrue(ls.contains("test"));
         Assert.assertTrue(ls.contains("test2"));
+    }
+
+    @Test
+    public void testDelayedTimesCanBeSerialised() throws ObjectMappingException {
+        TestConfigurationLoader tcl = getTestLoader();
+
+        CronParser unixCronParser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX));
+        CronParser quartzCronParser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
+        CronParser cron4jCronParser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.CRON4J));
+
+        Cron unixCron = unixCronParser.parse("0 0 * * *");
+        Cron quartzCron = quartzCronParser.parse("0 0 0,12 * * ?");
+        Cron cron4jCron = cron4jCronParser.parse("* 12 * * Mon");
+        WhenTime whenTime = WhenTime.fromString("every 12 hours");
+        ClockTime clockTime = ClockTime.fromString("12:30");
+
+        ConfigurationNode unixNode = tcl.createEmptyNode().setValue(TypeToken.of(DelayedTimeValue.class), new
+                DelayedTimeValue(DelayedTimeType.UNIX_CRON, unixCron));
+        ConfigurationNode quartzNode = tcl.createEmptyNode().setValue(TypeToken.of(DelayedTimeValue.class), new
+                DelayedTimeValue(DelayedTimeType.QUARTZ_CRON, quartzCron));
+        ConfigurationNode cron4JNode = tcl.createEmptyNode().setValue(TypeToken.of(DelayedTimeValue.class), new
+                DelayedTimeValue(DelayedTimeType.CRON4J_CRON, cron4jCron));
+        ConfigurationNode whenNode = tcl.createEmptyNode().setValue(TypeToken.of(DelayedTimeValue.class), new
+                DelayedTimeValue(whenTime));
+        ConfigurationNode clockNode = tcl.createEmptyNode().setValue(TypeToken.of(DelayedTimeValue.class), new
+                DelayedTimeValue(clockTime));
+
+        Assert.assertNotNull(unixNode.getString());
+        Assert.assertNotNull(quartzNode.getString());
+        Assert.assertNotNull(cron4JNode.getString());
+        Assert.assertNotNull(whenNode.getString());
+        Assert.assertNotNull(clockNode.getString());
+    }
+
+    @Test
+    public void testThatStringDelayedTimesCanBeDeserialised() throws ObjectMappingException {
+        TestConfigurationLoader tcl = getTestLoader();
+        ConfigurationNode unixNode = tcl.createEmptyNode().setValue(new TypeToken<String> () {}, "0 0 * * *");
+        ConfigurationNode quartzNode = tcl.createEmptyNode().setValue(new TypeToken<String> () {}, "0 0 0,12 * *"
+                + " ?");
+        ConfigurationNode cron4JNode = tcl.createEmptyNode().setValue(new TypeToken<String> () {}, "* 12 * * Mon");
+        ConfigurationNode whenNode = tcl.createEmptyNode().setValue(new TypeToken<String> () {}, "every 12 hours");
+        ConfigurationNode clockNode = tcl.createEmptyNode().setValue(new TypeToken<String> () {}, "12:30");
+
+        DelayedTimeValue asUnix = unixNode.getValue(TypeToken.of(DelayedTimeValue.class));
+        DelayedTimeValue asQuartz = quartzNode.getValue(TypeToken.of(DelayedTimeValue.class));
+        DelayedTimeValue asCron4J = cron4JNode.getValue(TypeToken.of(DelayedTimeValue.class));
+        DelayedTimeValue asWhen = whenNode.getValue(TypeToken.of(DelayedTimeValue.class));
+        DelayedTimeValue asClock = clockNode.getValue(TypeToken.of(DelayedTimeValue.class));
+
+        Assert.assertNotNull(asUnix);
+        Assert.assertNotNull(asQuartz);
+        Assert.assertNotNull(asCron4J);
+        Assert.assertNotNull(asWhen);
+        Assert.assertNotNull(asClock);
+    }
+
+    @Test
+    public void testThatMapDelayedTimesCanBeDeserialised() throws ObjectMappingException {
+        TestConfigurationLoader tcl = getTestLoader();
+
+        Map<String, String> unixMap = new HashMap<>();
+        unixMap.put("type", "unix");
+        unixMap.put("statement", "0 0 * * *");
+        Map<String, String> quartzMap = new HashMap<>();
+        quartzMap.put("type", "quartz");
+        quartzMap.put("statement", "0 0 0,12 * * ?");
+        Map<String, String> cron4jMap = new HashMap<>();
+        cron4jMap.put("type", "cron4j");
+        cron4jMap.put("statement", "* 12 * * Mon");
+        Map<String, String> whenMap = new HashMap<>();
+        whenMap.put("type", "when");
+        whenMap.put("statement", "every 12 hours");
+        Map<String, String> clockMap = new HashMap<>();
+        clockMap.put("type", "clock");
+        clockMap.put("statement", "12:30");
+
+        ConfigurationNode unixNode = tcl.createEmptyNode().setValue(new TypeToken<Map<String, String>> () {},
+                unixMap);
+        ConfigurationNode quartzNode = tcl.createEmptyNode().setValue(new TypeToken<Map<String, String>> () {},
+                quartzMap);
+        ConfigurationNode cron4JNode = tcl.createEmptyNode().setValue(new TypeToken<Map<String, String>> () {},
+                cron4jMap);
+        ConfigurationNode whenNode = tcl.createEmptyNode().setValue(new TypeToken<Map<String, String>> () {},
+                whenMap);
+        ConfigurationNode clockNode = tcl.createEmptyNode().setValue(new TypeToken<Map<String, String>> () {},
+                clockMap);
+
+        DelayedTimeValue asUnix = unixNode.getValue(TypeToken.of(DelayedTimeValue.class));
+        DelayedTimeValue asQuartz = quartzNode.getValue(TypeToken.of(DelayedTimeValue.class));
+        DelayedTimeValue asCron4J = cron4JNode.getValue(TypeToken.of(DelayedTimeValue.class));
+        DelayedTimeValue asWhen = whenNode.getValue(TypeToken.of(DelayedTimeValue.class));
+        DelayedTimeValue asClock = clockNode.getValue(TypeToken.of(DelayedTimeValue.class));
+
+        Assert.assertNotNull(asUnix);
+        Assert.assertNotNull(asQuartz);
+        Assert.assertNotNull(asCron4J);
+        Assert.assertNotNull(asWhen);
+        Assert.assertNotNull(asClock);
+    }
+
+    @Test
+    public void testThatWarningTimeListCanBeSerialised() throws ObjectMappingException {
+        TestConfigurationLoader tcl = getTestLoader();
+        List<TimeValue> timeValues = new ArrayList<>();
+        timeValues.add(new TimeValue(1L, TimeUnit.MILLISECONDS));
+        timeValues.add(new TimeValue(10L, TimeUnit.HOURS));
+        WarningTimeList wtl = new WarningTimeList(timeValues);
+        ConfigurationNode cn = tcl.createEmptyNode().setValue(new TypeToken<WarningTimeList> () {}, wtl);
+
+        List<String> ls = cn.getList(TypeToken.of(String.class));
+        Assert.assertEquals("10 hours", ls.get(0));
+        Assert.assertEquals("1 milliseconds", ls.get(1));
+    }
+
+    @Test
+    public void testThatWarningTimeListCanBeDeserialisedString() throws ObjectMappingException {
+        TestConfigurationLoader tcl = getTestLoader();
+        ConfigurationNode cn = tcl.createEmptyNode().setValue(TypeToken.of(String.class),
+                "1 milliseconds,10 hours,4 minutes");
+        WarningTimeList wtl = cn.getValue(TypeToken.of(WarningTimeList.class));
+
+        Assert.assertNotNull(wtl);
+        Assert.assertEquals("10 hours", wtl.getWarningTimeAt(0).asString());
+        Assert.assertEquals("4 minutes", wtl.getWarningTimeAt(1).asString());
+        Assert.assertEquals("1 milliseconds", wtl.getWarningTimeAt(2).asString());
+    }
+
+    @Test
+    public void testThatWarningTimeListCanBeDeserialisedList() throws ObjectMappingException {
+        TestConfigurationLoader tcl = getTestLoader();
+        List<String> asListYo = new ArrayList<>();
+        asListYo.add("1 milliseconds");
+        asListYo.add("4 minutes");
+        asListYo.add("2 minutes");
+        ConfigurationNode cn = tcl.createEmptyNode().setValue(asListYo);
+        WarningTimeList wtl = cn.getValue(TypeToken.of(WarningTimeList.class));
+
+        Assert.assertNotNull(wtl);
+        Assert.assertEquals("4 minutes", wtl.getWarningTimeAt(0).asString());
+        Assert.assertEquals("2 minutes", wtl.getWarningTimeAt(1).asString());
+        Assert.assertEquals("1 milliseconds", wtl.getWarningTimeAt(2).asString());
     }
 }

--- a/src/test/java/io/github/nucleuspowered/nucleus/tests/util/ClockTimeTests.java
+++ b/src/test/java/io/github/nucleuspowered/nucleus/tests/util/ClockTimeTests.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.tests.util;
+
+import com.cronutils.model.Cron;
+import io.github.nucleuspowered.nucleus.util.ClockTime;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ClockTimeTests {
+
+    @Test
+    public void testParsingHHMM() throws NullPointerException, IllegalArgumentException {
+        ClockTime clockTime = ClockTime.fromString("10:30");
+
+        Assert.assertNotNull(clockTime);
+        Assert.assertEquals("10:30", clockTime.asString());
+    }
+
+    @Test
+    public void testParsingHHMMSS() throws NullPointerException, IllegalArgumentException {
+        ClockTime clockTime = ClockTime.fromString("10:30:25");
+
+        Assert.assertNotNull(clockTime);
+        Assert.assertEquals("10:30:25", clockTime.asString());
+    }
+
+    @Test
+    public void testFormattingWithTwoChars() throws NullPointerException, IllegalArgumentException {
+        ClockTime first = ClockTime.fromString("09:25");
+        ClockTime second = ClockTime.fromString("10:09:09");
+
+        Assert.assertNotNull(first);
+        Assert.assertNotNull(second);
+        Assert.assertEquals("09:25", first.asString());
+        Assert.assertEquals("10:09:09", second.asString());
+    }
+
+    @Test
+    public void testBackingCronFormat() throws NullPointerException, IllegalArgumentException {
+        ClockTime asClockTime = ClockTime.fromString("09:09:09");
+        Assert.assertNotNull(asClockTime);
+        Cron cron = asClockTime.getBackingCron();
+
+        Assert.assertNotNull(cron);
+        Assert.assertEquals("9 9 9 * * ? *", cron.asString());
+    }
+}

--- a/src/test/java/io/github/nucleuspowered/nucleus/tests/util/TimeValueTests.java
+++ b/src/test/java/io/github/nucleuspowered/nucleus/tests/util/TimeValueTests.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.tests.util;
+
+import io.github.nucleuspowered.nucleus.util.TimeValue;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class TimeValueTests {
+
+    @Test
+    public void testCanParseTimeValue() throws IllegalArgumentException, NullPointerException {
+        TimeValue tv = TimeValue.fromString("1 days");
+
+        Assert.assertNotNull(tv);
+        Assert.assertEquals(1, tv.getValue());
+        Assert.assertEquals(TimeUnit.DAYS, tv.getUnitOfMeasurement());
+    }
+
+    @Test
+    public void testCanSerializeTimeValue() throws IllegalArgumentException, NullPointerException {
+        TimeValue tv = TimeValue.fromString("1 days");
+        String asString = tv.asString();
+
+        Assert.assertNotNull(asString);
+        Assert.assertEquals("1 days", asString);
+    }
+
+    @Test
+    public void testCompareTo() throws IllegalArgumentException, NullPointerException {
+        TimeValue tv = TimeValue.fromString("1 days");
+        TimeValue otherTimeValue = TimeValue.fromString("10 days");
+        int comparisonResult = tv.compareTo(otherTimeValue);
+
+        Assert.assertEquals(-1, comparisonResult);
+    }
+}

--- a/src/test/java/io/github/nucleuspowered/nucleus/tests/util/WhenTimeTests.java
+++ b/src/test/java/io/github/nucleuspowered/nucleus/tests/util/WhenTimeTests.java
@@ -1,0 +1,115 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.tests.util;
+
+import com.cronutils.model.Cron;
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.github.nucleuspowered.nucleus.util.WhenTime;
+
+public class WhenTimeTests {
+
+    @Test
+    public void testThreeArgumentParsing() throws IllegalArgumentException, NullPointerException {
+        WhenTime wtDow = WhenTime.fromString("every 4 dow");
+        WhenTime wtDom = WhenTime.fromString("every 5 days-of-the-month");
+        WhenTime wtMonths = WhenTime.fromString("every 11 months");
+        WhenTime wtHours = WhenTime.fromString("every 14 hour");
+        WhenTime wtMinutes = WhenTime.fromString("every 5 minute");
+        WhenTime wtSeconds = WhenTime.fromString("every 10 seconds");
+
+        Assert.assertNotNull(wtDow);
+        Assert.assertNotNull(wtDom);
+        Assert.assertNotNull(wtMonths);
+        Assert.assertNotNull(wtHours);
+        Assert.assertNotNull(wtMinutes);
+        Assert.assertNotNull(wtSeconds);
+    }
+
+    @Test
+    public void testTwoArgumentParsing() throws IllegalArgumentException, NullPointerException {
+        WhenTime wtDow = WhenTime.fromString("every dow");
+        WhenTime wtDom = WhenTime.fromString("every days-of-the-month");
+        WhenTime wtMonths = WhenTime.fromString("every months");
+        WhenTime wtHours = WhenTime.fromString("every hour");
+        WhenTime wtMinutes = WhenTime.fromString("every minute");
+        WhenTime wtSeconds = WhenTime.fromString("every seconds");
+
+        Assert.assertNotNull(wtDow);
+        Assert.assertNotNull(wtDom);
+        //Assert.assertNotNull(wtYears);
+        Assert.assertNotNull(wtMonths);
+        Assert.assertNotNull(wtHours);
+        Assert.assertNotNull(wtMinutes);
+        Assert.assertNotNull(wtSeconds);
+    }
+
+    @Test
+    public void testAsStringThreeArguments() throws IllegalArgumentException, NullPointerException {
+        WhenTime wtDow = WhenTime.fromString("every 4 dow");
+        WhenTime wtDom = WhenTime.fromString("every 5 days-of-the-month");
+        WhenTime wtMonths = WhenTime.fromString("every 11 months");
+        WhenTime wtHours = WhenTime.fromString("every 14 hour");
+        WhenTime wtMinutes = WhenTime.fromString("every 5 minute");
+        WhenTime wtSeconds = WhenTime.fromString("every 10 seconds");
+
+        Assert.assertEquals("every 4 day_of_week", wtDow.asString());
+        Assert.assertEquals("every 5 day_of_month", wtDom.asString());
+        Assert.assertEquals("every 11 months", wtMonths.asString());
+        Assert.assertEquals("every 14 hours", wtHours.asString());
+        Assert.assertEquals("every 5 minutes", wtMinutes.asString());
+        Assert.assertEquals("every 10 seconds", wtSeconds.asString());
+    }
+
+    @Test
+    public void testAsStringTwoArguments() throws IllegalArgumentException, NullPointerException {
+        WhenTime wtDow = WhenTime.fromString("every dow");
+        WhenTime wtDom = WhenTime.fromString("every days-of-the-month");
+        WhenTime wtMonths = WhenTime.fromString("every months");
+        WhenTime wtHours = WhenTime.fromString("every hour");
+        WhenTime wtMinutes = WhenTime.fromString("every minute");
+        WhenTime wtSeconds = WhenTime.fromString("every seconds");
+
+        Assert.assertEquals("every day_of_week", wtDow.asString());
+        Assert.assertEquals("every day_of_month", wtDom.asString());
+        Assert.assertEquals("every months", wtMonths.asString());
+        Assert.assertEquals("every hours", wtHours.asString());
+        Assert.assertEquals("every minutes", wtMinutes.asString());
+        Assert.assertEquals("every seconds", wtSeconds.asString());
+    }
+
+    @Test
+    public void underlyingCronInstance() throws IllegalArgumentException, NullPointerException {
+        WhenTime wtDow = WhenTime.fromString("every dow");
+        WhenTime wtDom = WhenTime.fromString("every days-of-the-month");
+        WhenTime wtMonths = WhenTime.fromString("every months");
+        WhenTime wtHours = WhenTime.fromString("every hour");
+        WhenTime wtMinutes = WhenTime.fromString("every minute");
+        WhenTime wtSeconds = WhenTime.fromString("every seconds");
+
+        Cron cronDow = wtDow.getBackingCronInstance();
+        Cron cronDom = wtDom.getBackingCronInstance();
+        //Cron cronYears = wtYears.getBackingCronInstance();
+        Cron cronMonths = wtMonths.getBackingCronInstance();
+        Cron cronHours = wtHours.getBackingCronInstance();
+        Cron cronMinutes = wtMinutes.getBackingCronInstance();
+        Cron cronSeconds = wtSeconds.getBackingCronInstance();
+
+        Assert.assertNotNull(cronDow);
+        Assert.assertNotNull(cronDom);
+        Assert.assertNotNull(cronMonths);
+        Assert.assertNotNull(cronHours);
+        Assert.assertNotNull(cronMinutes);
+        Assert.assertNotNull(cronSeconds);
+
+        Assert.assertEquals("0 0 0 ? * * *", cronDow.asString());
+        Assert.assertEquals("0 0 0 * * ? *", cronDom.asString());
+        Assert.assertEquals("0 0 0 1 * ? *", cronMonths.asString());
+        Assert.assertEquals("0 0 * * * ? *", cronHours.asString());
+        Assert.assertEquals("0 * 0 * * ? *", cronMinutes.asString());
+        Assert.assertEquals("* 0 0 * * ? *", cronSeconds.asString());
+    }
+}


### PR DESCRIPTION
*TL;DR; TL;DR;*

Implement Scheduled Tasks to run things "every 15 minutes", "at 10:30", or based on a CRON.

*TL;DR;*

Implement Scheduled Tasks as a separate abstraction from TaskBase because of timezones, and time muck. Use a cron to back all Scheduled Tasks so we can work on queueing/managing one time format instead of trying to manage multiple. Don't create a manager/watcher that has to watch every second/tick for execution for perf reasons.

---

***Proposing a "Scheduled Task Interface"***

This PR proposes a separate interface to the SpongeScheduler, called ScheduledTasks. This is _different_ than a scheduled task, because it has to be (see below). ScheduledTasks should be thought of as an ***alternative*** to a standard sponge task. They aren't the same, yet they both fulfill a similar purpose. Running a potentially repeating task, with a variable amount of time inbetween executions.

---

***The in-adequate interface for "Real World Time" In Sponge Scheduler***

First off, I think it's clear we should try to use the Sponge Scheduler as much, as possible. Building out our own scheduler that runs parallel to the Sponge Scheduler just seems like an obscene amount of work, for really no benefit what so ever.

The Sponge scheduler is built really well, but lets look at the api it exposes for delaying a task/running at an interval:

```
delay(long delay, TimeUnit unit);
delayTicks(long ticks);
interval(long interval, TimeUnit unit);
intervalTicks(long ticks);
```

The first things first. We can immediately throw out ticks for any real-world scheduled action. Ticks are not constant, infact _they're very variable_. Influenced by a lot, trying to bash together a real world time solution, with something that is variable would create a messy interface, that would probably be prone to bugs.

Next let's look at interval. For this "Real World Time" solution we'll need to repeat our tasks, using the default sponge interface would be cool. And hey it provides a TimeUnit! However the problem with this interval approach is: it's a constant interval. Once you pass it in once, you can't set it again. It _has_ to run something everytime the interval fires.

The problem with this is "Real World" we sometimes have things that don't fit this cozy model of everything having a constant interval, for example:

- Run something every 31st day (what about months without 31 days?)
- Run something every year (what about leap years?)
- Run something every hour (what if the time zone changes?)

These albeit are some rather pointed examples I thought of when originally trying to build the system, but these scenarios shouldn't just be forgotten, and there are probably more scenarios that I'm not thinking of that would break this constant interval model as well.

In which case the `interval` is completely unusable to us. However, remember we don't want to create our own scheduler because the cost there would be very high, and the maintenance cost would be even higher.

So instead we create `ScheduledTask`. A scheduled task is compatible with the SpongeScheduler, and allows us to have dynamic intervals. It also allows us to handle the refreshing of the Systems TimeZone. The way ScheduledTask works is similar to how a normal delayed task would work.

We queue ourselves using delay: `delay(long delay, TimeUnit unit)` for the initial delay (the time to  first execution). However we set no `interval` to run at. Instead when the task gets called to run, we  run the task, and then before fading into the nether we go ahead, and re-queue ourselves by dynamically figuring out our next time to execution. This allows us to still offload most of the work onto the Sponge 
Scheduler, and allows us to have this dynamic system that works for all the scenarios above (and all the others I didn't think of!).

This has a couple implications:
- There's no process Nucleus controls on when these jobs run. They're essentially self-sufficient. This  means for `@Inject`'d content we can really only inject when they start running (and we hand off to the  sponge scheduler). This may not be the best solution because it means a scheduled task has to wait to be queued.
- This is not compatible with `TaskBase`. Think of it like a fork in the road. You have something that  you need to run in a delayed fashion, which case do you need it to be? Do you need it to be based on real world time? If so go with a ScheduledTask, if not go for your own TaskBase, it's probably better suited.

***Getting Time Formats to Play Nice With ScheduledTask***

There's a lot of potential ways people could input when they want their scheduled tasks to run. We don't want to build out a unique scheduling case for each one of these because it could get really messy, really fast. The proposed way to handle this is `DelayedTimeValue`.

A DelayedTimeValue wraps multiple types: `Cron`, `WhenTime`, `ClockTime` all of these values are compatible with a Cron syntax. To explain this when you enter a clock time such as: `10:30`, what really happens is we parse that into a cron that runs everyday at 10:30. This allows us to build our scheduling logic around one interface. The Cron. This makes the implementation logic easier, while still allowing us to have nice looking inputs such as: `every 16 minutes`, `in 10 hours`,  `at 10:30`, etc.

Really we can add any parsing that we want too, and all it has to do is be compatible with one type of  cron, whether that be Quartz, Unix, or Cron4J. 


***Things that still need to be implemented***

- List Running Tasks: Easily grabbed through ScheduledManager, and Cron + WhenTime + ClockTime all support human friendly output.
- Shutdown Task w/ optional warning: Implement w/ WarnedScheduledTask (get logic out of stop command).
- Add a way to have one off delayed commands: Should be a fairly easy command to implement, create a scheduled task, parse as DelayedTimeValue, submit to ScheduledManager.

***Things that can be improved***

- Injection support? Right now we inject once the task gets scheduled, it'd be cool to inject right  before running too.
- Optional Config Values. It'd be cool to make the "WarningList", and "UseWarning" optional so we could have one config type for everything, but not make users type out `isWarning = false`, `warningList = ""` for every single scheduled item.

---

***What about reactive events, e.g. when a player number is higher than n?***

This was the last "bonus" item for Implementing Scheduled Events. I see the value in this, and think this should be done. However I think bashing it into this ScheduledTask buisness would be super messy, and not look or work well at all.

This should probably be in it's own module called "Reactive" or something similar.