### PR TITLE
Try to fix not setting the rotation during some respawning instances.

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/api/service/NucleusWorldLoaderService.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/api/service/NucleusWorldLoaderService.java
@@ -5,10 +5,8 @@
 package io.github.nucleuspowered.nucleus.api.service;
 
 import io.github.nucleuspowered.nucleus.api.data.NucleusWorld;
-import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import org.spongepowered.api.world.World;
 
-import java.io.IOException;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -20,20 +18,16 @@ public interface NucleusWorldLoaderService {
     /**
      * Gets the world associated with the provided UUID.
      * @param uuid The {@link UUID} of the world to load.
-     * @return The {@link NucleusWorld} that contains the Essenence data for the world.
+     * @return The {@link NucleusWorld} that contains the Nucleus data for the world.
      */
     Optional<NucleusWorld> getWorld(UUID uuid);
 
     /**
      * Gets the world associated with the provided UUID.
      * @param world The {@link World} to load.
-     * @return The {@link NucleusWorld} that contains the Essenence data for the world.
-     *
-     * @throws IOException If the data file could not be read
-     * @throws ObjectMappingException If the data file is malformed.
-     * @throws Exception For any other reason
+     * @return The {@link NucleusWorld} that contains the Nucleus data for the world.
      */
-    Optional<NucleusWorld> getWorld(World world) throws Exception;
+    Optional<NucleusWorld> getWorld(World world);
 
     /**
      * Saves all world data.

--- a/src/main/java/io/github/nucleuspowered/nucleus/dataservices/loaders/WorldDataManager.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/dataservices/loaders/WorldDataManager.java
@@ -54,7 +54,7 @@ public class WorldDataManager extends DataManager<UUID, WorldDataNode, WorldServ
     }
 
     @Override
-    public Optional<NucleusWorld> getWorld(World world) throws Exception {
+    public Optional<NucleusWorld> getWorld(World world) {
         Preconditions.checkNotNull(world);
         return getWorld(world.getUniqueId());
     }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/TeleportWorldCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/TeleportWorldCommand.java
@@ -5,6 +5,7 @@
 package io.github.nucleuspowered.nucleus.modules.world.commands;
 
 import io.github.nucleuspowered.nucleus.argumentparsers.NucleusWorldPropertiesArgument;
+import io.github.nucleuspowered.nucleus.dataservices.loaders.WorldDataManager;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.command.AbstractCommand;
@@ -23,12 +24,17 @@ import org.spongepowered.api.world.storage.WorldProperties;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.inject.Inject;
+
 @Permissions(prefix = "world", suggestedLevel = SuggestedLevel.ADMIN)
 @RegisterCommand(value = {"teleport", "tp"}, subcommandOf = WorldCommand.class)
 public class TeleportWorldCommand extends AbstractCommand<CommandSource> {
 
     private final String world = "world";
     private final String playerKey = "player";
+
+    @Inject
+    private WorldDataManager worldDataManager;
 
     @Override
     protected Map<String, PermissionInformation> permissionSuffixesToRegister() {
@@ -59,6 +65,8 @@ public class TeleportWorldCommand extends AbstractCommand<CommandSource> {
             throw new ReturnMessageException(plugin.getMessageProvider().getTextMessageWithFormat("command.world.teleport.failed", worldProperties.getWorldName()));
         }
 
+        // Rotate.
+        worldDataManager.getWorld(worldProperties.getUniqueId()).ifPresent(x -> x.getSpawnRotation().ifPresent(player::setRotation));
         if (src instanceof Player && ((Player) src).getUniqueId().equals(player.getUniqueId())) {
             src.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat("command.world.teleport.success", worldProperties.getWorldName()));
         } else {


### PR DESCRIPTION
From the forums:

> The /setspawn /world setspawn command sets the XYZ properly, when you use /spawn you teleport to spawn and retain your toons orientation at the new location, very precisely at the exact angle. When you die or load the world for the first time you are always facing south, in my case this has the unfortunate effect of placing the players back to a very carefully designed spawn info center that they could possibly miss with this current configuration.