### PR TITLE
Update /list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ group 'io.github.nucleuspowered'
 version '0.21.0-5.0-SNAPSHOT'
 
 def mixinversion = '0.15.0-5.0'
-def qsmlDep = "uk.co.drnaylor:quickstart-moduleloader:0.4.2"
+def qsmlDep = "uk.co.drnaylor:quickstart-moduleloader:0.4.3"
 def geoIpDep = 'com.maxmind.geoip2:geoip2:2.8.0'
 def mixinDep = "io.github.nucleuspowered:NucleusMixins:" + mixinversion
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/command/CommandBuilder.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/command/CommandBuilder.java
@@ -80,6 +80,10 @@ public class CommandBuilder {
                 }
             }
 
+            if (c instanceof StandardAbstractCommand.Reloadable) {
+                plugin.registerReloadable(((StandardAbstractCommand.Reloadable) c)::onReload);
+            }
+
             return Optional.of(c);
         }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/command/StandardAbstractCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/command/StandardAbstractCommand.java
@@ -1098,4 +1098,15 @@ public abstract class StandardAbstractCommand<T extends CommandSource> implement
             return Text.EMPTY;
         }
     }
+
+    /**
+     * If this is implemented, signifies that this command should be run on reload.
+     */
+    public interface Reloadable {
+
+        /**
+         * To run on reload.
+         */
+        void onReload();
+    }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/playerinfo/config/ListConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/playerinfo/config/ListConfig.java
@@ -4,34 +4,72 @@
  */
 package io.github.nucleuspowered.nucleus.modules.playerinfo.config;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @ConfigSerializable
 public class ListConfig {
 
-    @Setting(value = "group-by-permission-groups", comment = "loc:config.playerinfo.list.groups")
-    private boolean groupByPermissionGroup = false;
-
-    @Setting(value = "default-group-name", comment = "loc:config.playerinfo.list.defaultname")
-    private String defaultGroupName = "Default";
+    @Setting("list-grouping-by-permission")
+    private GroupConfig groupByPermissionGroup = new GroupConfig();
 
     @Setting(value = "multicraft-compatibility", comment = "loc:config.playerinfo.list.multicraft")
     private boolean multicraftCompatibility = false;
 
     public boolean isGroupByPermissionGroup() {
-        return groupByPermissionGroup;
+        return groupByPermissionGroup.enabled;
+    }
+
+    public Map<String, String> getAliases() {
+        return ImmutableMap.copyOf(groupByPermissionGroup.groupAliasing);
+    }
+
+    public List<String> getOrder() {
+        return ImmutableList.copyOf(groupByPermissionGroup.groupPriority);
     }
 
     public String getDefaultGroupName() {
-        if (defaultGroupName.isEmpty()) {
+        if (groupByPermissionGroup.defaultGroupName.isEmpty()) {
             return "Default";
         }
 
-        return defaultGroupName;
+        return groupByPermissionGroup.defaultGroupName;
+    }
+
+    public boolean isUseAliasOnly() {
+        return groupByPermissionGroup.useAliasOnly;
     }
 
     public boolean isMulticraftCompatibility() {
         return multicraftCompatibility;
+    }
+
+    @ConfigSerializable
+    public static class GroupConfig {
+
+        @Setting(value = "enabled", comment = "loc:config.playerinfo.list.groups")
+        private boolean enabled = false;
+
+        @Setting(value = "use-aliases-only", comment = "loc:config.playerinfo.list.aliasonly")
+        private boolean useAliasOnly = false;
+
+        @Setting(value = "group-aliases", comment = "loc:config.playerinfo.list.groupaliases")
+        private Map<String, String> groupAliasing = new HashMap<String, String>() {{
+            put("example-default-group", "Default Group");
+            put("example-default-group-2", "Default Group");
+        }};
+
+        @Setting(value = "group-order", comment = "loc:config.playerinfo.list.grouporder")
+        private List<String> groupPriority = Lists.newArrayList();
+
+        @Setting(value = "default-group-name", comment = "loc:config.playerinfo.list.defaultname")
+        private String defaultGroupName = "Default";
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/playerinfo/config/PlayerInfoConfigAdapter.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/playerinfo/config/PlayerInfoConfigAdapter.java
@@ -4,9 +4,19 @@
  */
 package io.github.nucleuspowered.nucleus.modules.playerinfo.config;
 
+import com.google.common.collect.Lists;
 import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
 
+import java.util.List;
+
 public class PlayerInfoConfigAdapter extends NucleusConfigAdapter.StandardWithSimpleDefault<PlayerInfoConfig> {
+
+    @Override protected List<Transformation> getTransformations() {
+        return Lists.newArrayList(
+            Transformation.moveFrom("list", "group-by-permission-groups").to("list", "list-grouping-by-permission", "enabled"),
+            Transformation.moveFrom("list", "default-group-name").to("list", "list-grouping-by-permission", "default-group-name")
+        );
+    }
 
     public PlayerInfoConfigAdapter() {
         super(PlayerInfoConfig.class);

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -198,6 +198,10 @@ config.debugmode=Enables debug mode, which will cause stack traces from commands
 
 config.playerinfo.list.groups=If enabled, list players by their groups.
 config.playerinfo.list.defaultname=If listing by groups is enabled, the group name to display when a player is not in a group.
+config.playerinfo.list.groupaliases=If listing by groups is enabled, then any group listed here (on the left side of an equals sign) will be given the display name on \
+the right hand side.\nMultiple groups can be given the same alias, they will be grouped together.
+config.playerinfo.list.aliasonly=If true, if an alias hasn''t been defined for a group in the `group-aliases` section, it''s considered as part of the `default` group.
+config.playerinfo.list.grouporder=Any group aliases in this list will be listed in this order, above all other groups, which will be displayed in alphabetical order below.
 config.playerinfo.list.multicraft=Enable this if you are using Multicraft. This will run /minecraft:list when /list is run on the console.
 config.playerinfo.seen.extended=If true, the permission "nucleus.seen.extended" is required for all information that comes from modules. If false, information will be displayed \
 based on the command permissions a player has (so, a player with check ban rights can see banning information).


### PR DESCRIPTION
* Groups can have a weight, determining which one is used as a display group if a player has more than one group. Controlled by permission options on the group: `nucleus.list.weight`
* Groups can be given an alias, and multiple groups can have the same alias.
* Group ordering can be defined.
* Option to only display a group if it has an explicit alias, else collapse into the default group.
* Add reloadable subinterface for commands.
* Bump QSML to 0.4.3

Fixes #594

<!--
    When submitting a PR, please include the following:

    * Use case
    * A list of changes
    * Any related changes/issues

    If your PR is not finished but you're seeking a review on it, mark it with [WIP].
-->
