### PR TITLE
Add ability to use WorldArchetypes as a preset for "/world create".

### DIFF
--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -381,6 +381,8 @@ config.vanish.connectionmessages=If true, players who leave or join the server u
 afk.kickreason=You have been kicked for being AFK for too long.
 
 # Arguments
+args.catalogtype.nomatch=&c{0} is not a valid argument.
+
 args.itemarg.orphanedarg=&cThe alias "{0}" points to the item id "{1}" which is no longer present on the server.
 args.itemarg.nomatch=&cThere are no aliases or IDs named "{0}".
 


### PR DESCRIPTION
* /world create -p <archetype>

Void would be `the_void`. Skylands, `the_skylands`.

Fixes #645

<!--
    When submitting a PR, please include the following:

    * Use case
    * A list of changes
    * Any related changes/issues

    If your PR is not finished but you're seeking a review on it, mark it with [WIP].
-->
