### PR TITLE
API Update: add primary tokens.

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/text/NucleusTokenServiceImpl.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/text/NucleusTokenServiceImpl.java
@@ -13,6 +13,7 @@ import io.github.nucleuspowered.nucleus.api.service.NucleusMessageTokenService;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.util.Tuple;
 
 import java.util.Map;
 import java.util.Optional;
@@ -20,6 +21,7 @@ import java.util.Optional;
 public class NucleusTokenServiceImpl implements NucleusMessageTokenService {
 
     private final Map<String, TokenParser> tokenStore = Maps.newHashMap();
+    private final Map<String, Tuple<TokenParser, String>> primaryTokenStore = Maps.newHashMap();
 
     @Override public void register(PluginContainer pluginContainer, TokenParser textFunction) throws PluginAlreadyRegisteredException {
         Preconditions.checkNotNull(pluginContainer);
@@ -35,12 +37,34 @@ public class NucleusTokenServiceImpl implements NucleusMessageTokenService {
     @Override public boolean unregister(PluginContainer pluginContainer) {
         Preconditions.checkNotNull(pluginContainer, "pluginContainer");
         Preconditions.checkState(!pluginContainer.getId().equalsIgnoreCase(PluginInfo.ID), "Cannot remove Nucleus tokens");
-        return tokenStore.remove(pluginContainer.getId()) != null;
+        TokenParser parser = tokenStore.remove(pluginContainer.getId());
+        if (parser != null) {
+            primaryTokenStore.entrySet().removeIf(x -> x.getValue().getFirst().equals(parser));
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override public boolean registerPrimaryToken(String primaryIdentifier, PluginContainer registeringPlugin, String identiferToMapTo) {
+        Preconditions.checkArgument(!primaryIdentifier.matches("^.*[\\s|{}:].*$"), "Token cannot contain spaces or \":|{}\"");
+        if (tokenStore.containsKey(registeringPlugin.getId()) && !primaryTokenStore.containsKey(primaryIdentifier.toLowerCase())) {
+            // Register!
+            primaryTokenStore.put(primaryIdentifier.toLowerCase(), Tuple.of(tokenStore.get(registeringPlugin.getId()),
+                    identiferToMapTo.toLowerCase()));
+            return true;
+        }
+
+        return false;
     }
 
     @Override public Optional<TokenParser> getTokenParser(String plugin) {
         Preconditions.checkNotNull(plugin, "pluginContainer");
         return Optional.ofNullable(tokenStore.get(plugin.toLowerCase()));
+    }
+
+    @Override public Optional<Tuple<TokenParser, String>> getPrimaryTokenParserAndIdentifier(String primaryToken) {
+        return Optional.ofNullable(primaryTokenStore.get(primaryToken.toLowerCase()));
     }
 
     @Override public Text formatAmpersandEncodedStringWithTokens(String input, CommandSource source, Map<String, Object> variables) {


### PR DESCRIPTION
Nucleus has allowed chat tokens in the form of `{{pl:pluginid:identifier}}`. This PR allows plugins to register aliases of these tokens like {{prefix}}, which I call a primary token! 

Plugins will need to register the tokens they want using the `NucleusMessageTokenService#registerPrimaryToken(String primaryToken, PluginContainer pluginContainer, String identifier)` method, registering the token `{{primaryToken}}` to `{{pl:pluginid:identifier}}`.

Primary tokens can add have extra arbitrary data, this must be sepeated from the token in configs etc. using a | symbol, such as `{{displayname|from}}`, where "from" is the extra data.
