### PR TITLE
[WIP] Add display names and descriptions to warps and categories.

### DIFF
--- a/nucleus-api/src/main/java/io/github/nucleuspowered/nucleus/api/nucleusdata/Warp.java
+++ b/nucleus-api/src/main/java/io/github/nucleuspowered/nucleus/api/nucleusdata/Warp.java
@@ -5,6 +5,7 @@
 package io.github.nucleuspowered.nucleus.api.nucleusdata;
 
 import io.github.nucleuspowered.nucleus.api.Stable;
+import org.spongepowered.api.text.Text;
 
 import java.util.Optional;
 
@@ -27,4 +28,11 @@ public interface Warp extends NamedLocation {
      * @return The cost.
      */
     Optional<Double> getCost();
+
+    /**
+     * Gets the description for the warp.
+     *
+     * @return The {@link Text} description, if available.
+     */
+    Optional<Text> getDescription();
 }

--- a/nucleus-api/src/main/java/io/github/nucleuspowered/nucleus/api/nucleusdata/WarpCategory.java
+++ b/nucleus-api/src/main/java/io/github/nucleuspowered/nucleus/api/nucleusdata/WarpCategory.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.api.nucleusdata;
+
+import io.github.nucleuspowered.nucleus.api.Stable;
+import org.spongepowered.api.text.Text;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * Defines a warp category.
+ */
+@Stable
+public interface WarpCategory {
+
+    /**
+     * Gets the ID of the category.
+     *
+     * @return The ID.
+     */
+    String getId();
+
+    /**
+     * Gets the display name of the category. Defaults to the category name.
+     *
+     * @return The display name.
+     */
+    Text getDisplayName();
+
+    /**
+     * Gets the defined description of the category, if available.
+     *
+     * @return An {@link Optional} that might contain a description.
+     */
+    Optional<Text> getDescription();
+
+    /**
+     * Gets the warps associated with this category.
+     *
+     * @return The warps.
+     */
+    Collection<Warp> getWarps();
+}

--- a/nucleus-api/src/main/java/io/github/nucleuspowered/nucleus/api/service/NucleusWarpService.java
+++ b/nucleus-api/src/main/java/io/github/nucleuspowered/nucleus/api/service/NucleusWarpService.java
@@ -7,6 +7,8 @@ package io.github.nucleuspowered.nucleus.api.service;
 import com.flowpowered.math.vector.Vector3d;
 import io.github.nucleuspowered.nucleus.api.Stable;
 import io.github.nucleuspowered.nucleus.api.nucleusdata.Warp;
+import io.github.nucleuspowered.nucleus.api.nucleusdata.WarpCategory;
+import org.spongepowered.api.text.Text;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
@@ -16,6 +18,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -82,10 +85,38 @@ public interface NucleusWarpService {
     /**
      * Gets all warps that have categories.
      *
+     * @deprecated Use {@link #getWarpsWithCategories()} instead.
      * @return The warps.
      */
     @Stable
-    Map<String, List<Warp>> getCategorisedWarps();
+    @Deprecated
+    default Map<String, List<Warp>> getCategorisedWarps() {
+        return getWarpsWithCategories(x -> true).entrySet().stream().collect(Collectors.toMap(k -> k.getKey().getId(), Map.Entry::getValue));
+    }
+
+    /**
+     * Gets all warps that have categories.
+     *
+     * @param warpDataPredicate The filtering predicate to return the subset of warps required.
+     * @return The warps.
+     * @deprecated Use {@link #getWarpsWithCategories()} instead.
+     */
+
+    @Stable
+    @Deprecated
+    default Map<String, List<Warp>> getCategorisedWarps(Predicate<Warp> warpDataPredicate) {
+        return getWarpsWithCategories(warpDataPredicate).entrySet().stream().collect(Collectors.toMap(k -> k.getKey().getId(), Map.Entry::getValue));
+    }
+
+    /**
+     * Gets all warps that have categories.
+     *
+     * @return The warps.
+     */
+    @Stable
+    default Map<WarpCategory, List<Warp>> getWarpsWithCategories() {
+        return getWarpsWithCategories(x -> true);
+    }
 
     /**
      * Gets all warps that have categories.
@@ -93,10 +124,15 @@ public interface NucleusWarpService {
      * @param warpDataPredicate The filtering predicate to return the subset of warps required.
      * @return The warps.
      */
-
     @Stable
-    Map<String, List<Warp>> getCategorisedWarps(Predicate<Warp> warpDataPredicate);
+    Map<WarpCategory, List<Warp>> getWarpsWithCategories(Predicate<Warp> warpDataPredicate);
 
+    /**
+     * Removes the cost of a warp.
+     *
+     * @param warpName The name of the warp to remove the cost from.
+     * @return <code>true</code> if the cost removal succeeds.
+     */
     boolean removeWarpCost(String warpName);
 
     /**
@@ -117,6 +153,16 @@ public interface NucleusWarpService {
      */
     boolean setWarpCategory(String warpName, @Nullable String category);
 
+
+    /**
+     * Sets a warp's description.
+     *
+     * @param warpName The name of the warp.
+     * @param description The description, or <code>null</code> to clear.
+     * @return {@code true} if successful
+     */
+    boolean setWarpDescription(String warpName, @Nullable Text description);
+
     /**
      * Gets the names of all the warp that are available.
      *
@@ -135,4 +181,30 @@ public interface NucleusWarpService {
     default boolean warpExists(String name) {
         return getWarp(name).isPresent();
     }
+
+    /**
+     * Gets the data associated with a warp category.
+     *
+     * @param category The name of the category to get.
+     * @return An {@link Optional} containing the category, if it exists.
+     */
+    Optional<WarpCategory> getWarpCategory(String category);
+
+    /**
+     * Sets the display name of a warp category.
+     *
+     * @param category The name of the category.
+     * @param displayName The display name. Set to null to revert to the category name.
+     * @return <code>true</code> if the category exists and this is successful.
+     */
+    boolean setWarpCategoryDisplayName(String category, @Nullable Text displayName);
+
+    /**
+     * Sets the description of a warp category.
+     *
+     * @param category The name of the category.
+     * @param description The description. Set to null to remove the description.
+     * @return <code>true</code> if the category exists and this is successful.
+     */
+    boolean setWarpCategoryDescription(String category, @Nullable Text description);
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/RemainingStringsArgument.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/RemainingStringsArgument.java
@@ -27,6 +27,8 @@ public class RemainingStringsArgument extends CommandElement {
     }
 
     @Nullable @Override protected Object parseValue(CommandSource source, CommandArgs args) throws ArgumentParseException {
+        // ignored.
+        args.nextIfPresent();
         return args.getRaw().substring(args.getRawPosition()).trim();
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/WarpCategoryArgument.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/WarpCategoryArgument.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.argumentparsers;
+
+import io.github.nucleuspowered.nucleus.Nucleus;
+import io.github.nucleuspowered.nucleus.api.nucleusdata.WarpCategory;
+import io.github.nucleuspowered.nucleus.modules.warp.handlers.WarpHandler;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.ArgumentParseException;
+import org.spongepowered.api.command.args.CommandArgs;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.text.Text;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class WarpCategoryArgument extends CommandElement {
+
+    private final WarpHandler handler;
+
+    public WarpCategoryArgument(@Nullable Text key, WarpHandler handler) {
+        super(key);
+        this.handler = handler;
+    }
+
+    @Nullable @Override protected Object parseValue(@Nonnull CommandSource source, @Nonnull CommandArgs args) throws ArgumentParseException {
+        String arg = args.next();
+        return handler.getWarpsWithCategories().keySet().stream().filter(Objects::nonNull).filter(x -> x.getId().equals(arg)).findFirst()
+                .orElseThrow(() -> args.createError(
+                    Nucleus.getNucleus().getMessageProvider().getTextMessageWithFormat("args.warpcategory.noexist", arg)));
+    }
+
+    @Nonnull @Override public List<String> complete(@Nonnull CommandSource src, @Nonnull CommandArgs args, @Nonnull CommandContext context) {
+        return handler.getWarpsWithCategories().keySet().stream().filter(Objects::isNull).map(WarpCategory::getId).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/datatypes/WarpCategoryDataNode.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/datatypes/WarpCategoryDataNode.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.configurate.datatypes;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+@ConfigSerializable
+public class WarpCategoryDataNode {
+
+    public WarpCategoryDataNode() {
+    }
+
+    public WarpCategoryDataNode(@Nullable String displayName, @Nullable String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    @Setting
+    @Nullable
+    private String displayName = null;
+
+    @Setting
+    @Nullable
+    private String description = null;
+
+    public Optional<String> getDisplayName() {
+        return Optional.ofNullable(displayName);
+    }
+
+    public void setDisplayName(@Nullable String displayName) {
+        this.displayName = displayName;
+    }
+
+    public Optional<String> getDescription() {
+        return Optional.ofNullable(description);
+    }
+
+    public void setDescription(@Nullable String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/datatypes/WarpNode.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/datatypes/WarpNode.java
@@ -7,6 +7,7 @@ package io.github.nucleuspowered.nucleus.configurate.datatypes;
 import com.flowpowered.math.vector.Vector3d;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+import org.spongepowered.api.text.Text;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
@@ -22,6 +23,9 @@ public class WarpNode extends LocationNode {
 
     @Setting("category")
     private String category = null;
+
+    @Setting("description")
+    private Text description = null;
 
     public WarpNode() {
         super();
@@ -63,5 +67,13 @@ public class WarpNode extends LocationNode {
 
     public void setCategory(@Nullable String category) {
         this.category = category;
+    }
+
+    public Text getDescription() {
+        return description;
+    }
+
+    public void setDescription(@Nullable Text description) {
+        this.description = description;
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warp/commands/CategoryCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warp/commands/CategoryCommand.java
@@ -1,0 +1,179 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.warp.commands;
+
+import com.google.common.collect.Lists;
+import com.google.inject.Inject;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.api.nucleusdata.WarpCategory;
+import io.github.nucleuspowered.nucleus.argumentparsers.WarpCategoryArgument;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoCooldown;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoCost;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoWarmup;
+import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
+import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.annotations.Scan;
+import io.github.nucleuspowered.nucleus.internal.command.AbstractCommand;
+import io.github.nucleuspowered.nucleus.modules.warp.handlers.WarpHandler;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
+import org.spongepowered.api.text.serializer.TextSerializers;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Scan
+@Permissions(prefix = "warp")
+@RegisterCommand(value = {"category"}, subcommandOf = WarpCommand.class, hasExecutor = false)
+public class CategoryCommand extends AbstractCommand<CommandSource> {
+
+    private static String key = "category";
+    private static String displayname = "displayname";
+    private static String description = "displayname";
+
+    @Override protected CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        return null;
+    }
+
+    @Permissions(prefix = "warp.category", mainOverride = "list")
+    @RunAsync
+    @NoCooldown
+    @NoCost
+    @NoWarmup
+    @RegisterCommand(value = {"list"}, subcommandOf = CategoryCommand.class)
+    public static class ListCategoryCommand extends AbstractCommand<CommandSource> {
+
+        @Inject private WarpHandler handler;
+
+        @Override protected CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+            // Get all the categories.
+            Util.getPaginationBuilder(src).contents(
+                handler.getWarpsWithCategories().keySet().stream().filter(Objects::nonNull)
+                    .sorted(Comparator.comparing(WarpCategory::getId)).map(x -> {
+                List<Text> t = Lists.newArrayList();
+                t.add(plugin.getMessageProvider().getTextMessageWithTextFormat("command.warp.category.listitem.simple",
+                        Text.of(x.getId()), x.getDisplayName()));
+                x.getDescription().ifPresent(y ->
+                        t.add(plugin.getMessageProvider().getTextMessageWithTextFormat("command.warp.category.listitem.description", y)));
+                return t;
+            }).flatMap(Collection::stream).collect(Collectors.toList()))
+            .title(plugin.getMessageProvider().getTextMessageWithFormat("command.warp.category.listitem.title"))
+            .padding(Text.of("-", TextColors.GREEN))
+            .sendTo(src);
+
+            return CommandResult.success();
+        }
+    }
+
+    @Permissions(prefix = "warp.category", mainOverride = "displayname")
+    @RunAsync
+    @NoCooldown
+    @NoCost
+    @NoWarmup
+    @RegisterCommand(value = {"setdisplayname"}, subcommandOf = CategoryCommand.class)
+    public static class CategoryDisplayNameCommand extends AbstractCommand<CommandSource> {
+
+        @Inject private WarpHandler handler;
+
+        @Override public CommandElement[] getArguments() {
+            return new CommandElement[] {
+                    new WarpCategoryArgument(Text.of(key), handler),
+                    GenericArguments.onlyOne(GenericArguments.string(Text.of(displayname)))
+            };
+        }
+
+        @Override protected CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+            WarpCategory category = args.<WarpCategory>getOne(key).get();
+            String displayName = args.<String>getOne(displayname).get();
+            handler.setWarpCategoryDisplayName(category.getId(), TextSerializers.FORMATTING_CODE.deserialize(args.<String>getOne(displayname).get()));
+            src.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat("command.warp.category.displayname.set", category.getId(),
+                    displayName));
+            return CommandResult.success();
+        }
+    }
+
+    @Permissions(prefix = "warp.category", mainOverride = "displayname")
+    @RunAsync
+    @NoCooldown
+    @NoCost
+    @NoWarmup
+    @RegisterCommand(value = {"removedisplayname"}, subcommandOf = CategoryCommand.class)
+    public static class CategoryRemoveDisplayNameCommand extends AbstractCommand<CommandSource> {
+
+        @Inject private WarpHandler handler;
+
+        @Override public CommandElement[] getArguments() {
+            return new CommandElement[] {
+                    new WarpCategoryArgument(Text.of(key), handler)
+            };
+        }
+
+        @Override protected CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+            WarpCategory category = args.<WarpCategory>getOne(key).get();
+            handler.setWarpCategoryDisplayName(category.getId(), null);
+            src.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat("command.warp.category.displayname.removed", category.getId()));
+            return CommandResult.success();
+        }
+    }
+
+    @Permissions(prefix = "warp.category", mainOverride = "description")
+    @RunAsync
+    @NoCooldown
+    @NoCost
+    @NoWarmup
+    @RegisterCommand(value = {"setdescription"}, subcommandOf = CategoryCommand.class)
+    public static class CategoryDescriptionCommand extends AbstractCommand<CommandSource> {
+
+        @Inject private WarpHandler handler;
+
+        @Override public CommandElement[] getArguments() {
+            return new CommandElement[] {
+                    new WarpCategoryArgument(Text.of(key), handler),
+                    GenericArguments.onlyOne(GenericArguments.string(Text.of(description)))
+            };
+        }
+
+        @Override protected CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+            WarpCategory category = args.<WarpCategory>getOne(key).get();
+            String d = args.<String>getOne(description).get();
+            handler.setWarpCategoryDescription(category.getId(), TextSerializers.FORMATTING_CODE.deserialize(d));
+            src.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat("command.warp.category.description.set", category.getId(), d));
+            return CommandResult.success();
+        }
+    }
+
+    @Permissions(prefix = "warp.category", mainOverride = "description")
+    @RunAsync
+    @NoCooldown
+    @NoCost
+    @NoWarmup
+    @RegisterCommand(value = {"removedescription"}, subcommandOf = CategoryCommand.class)
+    public static class CategoryRemoveDescriptionCommand extends AbstractCommand<CommandSource> {
+
+        @Inject private WarpHandler handler;
+
+        @Override public CommandElement[] getArguments() {
+            return new CommandElement[] {
+                    new WarpCategoryArgument(Text.of(key), handler)
+            };
+        }
+
+        @Override protected CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+            WarpCategory category = args.<WarpCategory>getOne(key).get();
+            handler.setWarpCategoryDescription(category.getId(), null);
+            src.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat("command.warp.category.description.removed", category.getId()));
+            return CommandResult.success();
+        }
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warp/commands/SetDescriptionCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warp/commands/SetDescriptionCommand.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.warp.commands;
+
+import io.github.nucleuspowered.nucleus.api.nucleusdata.Warp;
+import io.github.nucleuspowered.nucleus.argumentparsers.RemainingStringsArgument;
+import io.github.nucleuspowered.nucleus.argumentparsers.WarpArgument;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoCooldown;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoCost;
+import io.github.nucleuspowered.nucleus.internal.annotations.NoWarmup;
+import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
+import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.command.AbstractCommand;
+import io.github.nucleuspowered.nucleus.internal.command.ReturnMessageException;
+import io.github.nucleuspowered.nucleus.modules.warp.config.WarpConfigAdapter;
+import io.github.nucleuspowered.nucleus.modules.warp.handlers.WarpHandler;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.serializer.TextSerializers;
+
+import javax.inject.Inject;
+
+@RunAsync
+@NoCost
+@NoCooldown
+@NoWarmup
+@Permissions(prefix = "warp")
+@RegisterCommand(value = {"setdescription"}, subcommandOf = WarpCommand.class)
+public class SetDescriptionCommand extends AbstractCommand<CommandSource> {
+
+    private final String warpKey = "warp";
+    private final String descriptionKey = "description";
+    @Inject private WarpConfigAdapter warpConfigAdapter;
+    @Inject private WarpHandler handler;
+
+    @Override public CommandElement[] getArguments() {
+        return new CommandElement[] {
+            GenericArguments.flags().flag("r", "-remove", "-delete").buildWith(
+                GenericArguments.seq(
+                    new WarpArgument(Text.of(warpKey), warpConfigAdapter, false, false),
+                    GenericArguments.optional(new RemainingStringsArgument(Text.of(descriptionKey)))
+                )
+            )
+        };
+    }
+
+    @Override public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
+        String warpName = args.<Warp>getOne(warpKey).get().getName();
+        if (args.hasAny("r")) {
+            // Remove the desc.
+            if (handler.setWarpDescription(warpName, null)) {
+                src.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat("command.warp.description.removed", warpName));
+                return CommandResult.success();
+            }
+
+            throw new ReturnMessageException(plugin.getMessageProvider().getTextMessageWithFormat("command.warp.description.noremove", warpName));
+        }
+
+        // Add the category.
+        Text message = TextSerializers.FORMATTING_CODE.deserialize(args.<String>getOne(descriptionKey).get());
+        if (handler.setWarpDescription(warpName, message)) {
+            src.sendMessage(plugin.getMessageProvider().getTextMessageWithTextFormat("command.warp.description.added", message, Text.of(warpName)));
+            return CommandResult.success();
+        }
+
+        throw new ReturnMessageException(plugin.getMessageProvider().getTextMessageWithTextFormat("command.warp.description.couldnotadd",
+                Text.of(warpName)));
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/warp/datamodules/WarpGeneralDataModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/warp/datamodules/WarpGeneralDataModule.java
@@ -9,28 +9,38 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.nucleusdata.Warp;
+import io.github.nucleuspowered.nucleus.api.nucleusdata.WarpCategory;
+import io.github.nucleuspowered.nucleus.configurate.datatypes.WarpCategoryDataNode;
 import io.github.nucleuspowered.nucleus.configurate.datatypes.WarpNode;
 import io.github.nucleuspowered.nucleus.dataservices.modular.DataKey;
 import io.github.nucleuspowered.nucleus.dataservices.modular.LocationDataModule;
 import io.github.nucleuspowered.nucleus.dataservices.modular.ModularGeneralService;
 import io.github.nucleuspowered.nucleus.internal.LocationData;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.serializer.TextSerializers;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
 public class WarpGeneralDataModule extends LocationDataModule<ModularGeneralService> {
 
     private final BiFunction<String, WarpNode, Warp> getWarpLocation = (s, l) ->
-            new WarpData(s, l.getWorld(), l.getPosition(), l.getRotation(), l.getCost(), l.getCategory().orElse(null));
+            new WarpData(s, l.getWorld(), l.getPosition(), l.getRotation(), l.getCost(), l.getCategory().orElse(null), l.getDescription());
 
     @DataKey("warps")
     private Map<String, WarpNode> warps = Maps.newHashMap();
+
+    @DataKey("warpCategories")
+    private Map<String, WarpCategoryDataNode> warpCategories = Maps.newHashMap();
 
     public Optional<Warp> getWarpLocation(String name) {
         return get(warps, getWarpLocation, name);
@@ -61,11 +71,26 @@ public class WarpGeneralDataModule extends LocationDataModule<ModularGeneralServ
         return false;
     }
 
-    public boolean setWarpCategory(String name, @Nullable String category) {
+    public boolean setWarpsWarpCategory(String name, String category) {
         Optional<WarpNode> os = Util.getValueIgnoreCase(warps, name);
         if (os.isPresent()) {
             // No need to put it back - it's saved automatically.
             os.get().setCategory(category);
+            if (category != null) {
+                warpCategories.putIfAbsent(category.toLowerCase(), new WarpCategoryDataNode());
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public boolean setWarpDescription(String name, @Nullable Text description) {
+        Optional<WarpNode> os = Util.getValueIgnoreCase(warps, name);
+        if (os.isPresent()) {
+            // No need to put it back - it's saved automatically.
+            os.get().setDescription(description);
             return true;
         }
 
@@ -82,15 +107,55 @@ public class WarpGeneralDataModule extends LocationDataModule<ModularGeneralServ
         return false;
     }
 
+    public WarpCategory getWarpCategoryOrDefault(String category) {
+        return getWarpCategory(category).orElseGet(() -> new WarpCategoryData(
+                category,
+                Text.of(category),
+                null,
+                () -> getWarps().values().stream().filter(x -> x.getCategory().map(y -> y.equals(category)).orElse(false))
+                        .collect(Collectors.toList())));
+    }
+
+    public Optional<WarpCategory> getWarpCategory(String category) {
+        Preconditions.checkArgument(category != null && !category.isEmpty());
+        if (warps.values().stream().noneMatch(x -> x.getCategory().orElse("").equalsIgnoreCase(category))) {
+            return Optional.empty();
+        }
+
+        WarpCategoryDataNode w = warpCategories.get(category);
+        if (w == null) {
+            w = new WarpCategoryDataNode();
+            updateOrSetWarpCategory(category.toLowerCase(), null, null);
+        }
+
+        return Optional.of(new WarpCategoryData(
+            category,
+            w.getDisplayName().map(TextSerializers.JSON::deserialize).orElse(Text.of(category)),
+            w.getDescription().map(TextSerializers.JSON::deserialize).orElse(null),
+            () -> getWarps().values().stream().filter(x -> x.getCategory().map(y -> y.equals(category)).orElse(false)).collect(Collectors.toList())
+        ));
+    }
+
+    public void updateOrSetWarpCategory(String category, @Nullable Text displayName, @Nullable Text description) {
+        warpCategories.put(category,
+            new WarpCategoryDataNode(
+                TextSerializers.JSON.serialize(displayName != null ? displayName : Text.of(category)),
+                description != null ? TextSerializers.JSON.serialize(description) : null
+            ));
+    }
+
     private static class WarpData extends LocationData implements Warp {
 
         private final double cost;
-        private final String category;
+        @Nullable private final String category;
+        @Nullable private final Text description;
 
-        private WarpData(String name, UUID world, Vector3d position, Vector3d rotation, double cost, @Nullable String category) {
+        private WarpData(String name, UUID world, Vector3d position, Vector3d rotation, double cost, @Nullable String category,
+                @Nullable Text description) {
             super(name, world, position, rotation);
             this.cost = Math.max(-1, cost);
             this.category = category;
+            this.description = description;
         }
 
         public Optional<Double> getCost() {
@@ -101,6 +166,10 @@ public class WarpGeneralDataModule extends LocationDataModule<ModularGeneralServ
             return Optional.empty();
         }
 
+        @Override public Optional<Text> getDescription() {
+            return Optional.ofNullable(description);
+        }
+
         public Optional<String> getCategory() {
             return Optional.ofNullable(category);
         }
@@ -108,6 +177,54 @@ public class WarpGeneralDataModule extends LocationDataModule<ModularGeneralServ
         @Override
         public String toString() {
             return super.toString() + "category: " + this.category + ", cost: " + this.cost;
+        }
+    }
+
+    private static class WarpCategoryData implements WarpCategory {
+
+        private final String name;
+        private final Text displayName;
+        @Nullable private final Text description;
+        private final Supplier<Collection<Warp>> getWarps;
+
+        public WarpCategoryData(String name, Text displayName, @Nullable Text description, Supplier<Collection<Warp>> getWarps) {
+            this.name = Preconditions.checkNotNull(name);
+            this.displayName = Preconditions.checkNotNull(displayName);
+            this.description = description;
+            this.getWarps = getWarps;
+        }
+
+        @Override public String getId() {
+            return this.name;
+        }
+
+        @Override public Text getDisplayName() {
+            return this.displayName;
+        }
+
+        @Override public Optional<Text> getDescription() {
+            return Optional.ofNullable(this.description);
+        }
+
+        @Override public Collection<Warp> getWarps() {
+            return getWarps.get();
+        }
+
+        @Override public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            WarpCategoryData that = (WarpCategoryData) o;
+
+            return name.equals(that.name);
+        }
+
+        @Override public int hashCode() {
+            return name.hashCode();
         }
     }
 }

--- a/src/main/resources/assets/nucleus/commands.properties
+++ b/src/main/resources/assets/nucleus/commands.properties
@@ -248,6 +248,15 @@ There are two important flags to be aware of:\n\
 this may catch it.\n\
 * -r/--remove: Remove the category on the warp, move it back to the default "Uncategorised" group.
 
+warp.setdescription.desc=Sets or removes (with -r) the description for the warp.
+
+warp.category.desc=Base command for category management.
+warp.category.list.desc=Lists all the warp categories in use on the server.
+warp.category.setdisplayname.desc=Sets a display name for a category.
+warp.category.removedisplayname.desc=Removes the display name for a category.
+warp.category.setdescription.desc=Sets the description for a category.
+warp.category.removedescription.desc=Removes the description for a category.
+
 world.desc=Parent command for all other world commands.
 world.create.desc=Creates a world with the specified name and options.
 world.create.extended=Creates a game world with the provided name, required. All other options in this command are optional, and are specified by flags. Each flag requires an argument after their names. \

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -382,6 +382,8 @@ config.vanish.connectionmessages=If true, players who leave or join the server u
 afk.kickreason=You have been kicked for being AFK for too long.
 
 # Arguments
+args.warpcategory.noexist=&cThe warp category {0} does not exist.
+
 args.catalogtype.nomatch=&c{0} is not a valid argument.
 
 args.itemarg.orphanedarg=&cThe alias "{0}" points to the item id "{1}" which is no longer present on the server.
@@ -637,12 +639,25 @@ command.warp.cost.alt=&aor add "-y" to your command.
 command.warp.cost.nomoney=&cThe warp &e{0}&c costs &e{1} &cto use, but you do not have the money to pay this amount.
 command.warp.cost.charged=&aYou were charged &e{0} &ato use this warp.
 
+command.warp.category.listitem.simple=&e{0} &a- Display Name: &f{1}
+command.warp.category.listitem.description=&aDescription: &f{0}
+command.warp.category.listitem.title=&aWarp Categories
+
 command.warp.category.removed=&aRemoved the category for the warp &e{0}&a.
 command.warp.category.noremove=&cCould not remove the category for the warp &e{0}&c.
 command.warp.category.requirenew=&cThe category &e{0}&c does not exist yet. Click here (or use -n in the command) if you want to create this category.
 command.warp.category.added=&aThe category &e{0}&a was added to the warp &e{1}&a.
 command.warp.category.couldnotadd=&cThe category &e{0}&c could not be added to the warp &e{1}&c.
 command.warp.category.required=&cA warp category is required.
+command.warp.category.displayname.set=&aThe category &e{0} &ahas been given the display name &f{1}.
+command.warp.category.displayname.removed=&aThe category &e{0} &ahas had its display name removed.
+command.warp.category.description.set=&aThe category &e{0} &ahas been given the description &f{1}.
+command.warp.category.description.removed=&aThe category &e{0} &ahas had its description removed.
+
+command.warp.description.removed=&aRemoved the description for the warp &e{0}&a.
+command.warp.description.noremove=&cCould not remove the description for the warp &e{0}&c.
+command.warp.description.added=&aThe description "&r{0}&a" was added to the warp &e{1}&a.
+command.warp.description.couldnotadd=&cThe description could not be added to the warp &e{0}&c.
 
 command.world.player=&cYou must be a player or specify a world name.
 


### PR DESCRIPTION
This PR adds the following:

`/warp category list` - lists all categories
`/warp category setdisplayname [category] [& encoded name]` - sets a display name for a category.
`/warp category setdescription [category] [& encoded name]` - sets a description for a category.
`/warp category removedisplayname [category]` - removes the display name for a category.
`/warp category removedescription [category]` - removes the description for a category.

About to add

`/warp setdescription [-r] [warp] [& encoded description]`

Fixes #657
