### PR TITLE
Add the NucleusTextTemplate system.

### DIFF
--- a/nucleus-api/src/main/java/io/github/nucleuspowered/nucleus/api/exceptions/NucleusException.java
+++ b/nucleus-api/src/main/java/io/github/nucleuspowered/nucleus/api/exceptions/NucleusException.java
@@ -18,6 +18,12 @@ public class NucleusException extends TextMessageException {
         this.exceptionType = exceptionType;
     }
 
+    public NucleusException(Text message, Throwable inner, ExceptionType exceptionType) {
+        super(message, inner);
+        Preconditions.checkNotNull(exceptionType);
+        this.exceptionType = exceptionType;
+    }
+
     /**
      * Gets the basic reason for the issue.
      *

--- a/nucleus-api/src/main/java/io/github/nucleuspowered/nucleus/api/service/NucleusMessageTokenService.java
+++ b/nucleus-api/src/main/java/io/github/nucleuspowered/nucleus/api/service/NucleusMessageTokenService.java
@@ -7,7 +7,9 @@ package io.github.nucleuspowered.nucleus.api.service;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import io.github.nucleuspowered.nucleus.api.Stable;
+import io.github.nucleuspowered.nucleus.api.exceptions.NucleusException;
 import io.github.nucleuspowered.nucleus.api.exceptions.PluginAlreadyRegisteredException;
+import io.github.nucleuspowered.nucleus.api.text.NucleusTextTemplate;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.text.Text;
@@ -20,7 +22,7 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 
 /**
- * Allows plugins to register their own tokens for use in templated messages.
+ * Allows plugins to register their own tokens for use in templated messages, and to obtain {@link NucleusTextTemplate} instances.
  */
 @Stable
 public interface NucleusMessageTokenService {
@@ -163,23 +165,72 @@ public interface NucleusMessageTokenService {
     /**
      * Uses Nucleus' parser to format a string that uses Minecraft colour codes.
      *
+     * @deprecated Use {@link #createFromString(String)} instead to create a {@link NucleusTextTemplate}.
+     *
      * @param input The input.
      * @param source The {@link CommandSource} that will view the message.
-     * @return The {@link Text} that represents the output.
+     * @return The {@link Text} that represents the output, or {@link Text#EMPTY} if an error is caught.
+     *
+     * @see #createFromString(String)
      */
+    @Deprecated
     default Text formatAmpersandEncodedStringWithTokens(String input, CommandSource source) {
-        return formatAmpersandEncodedStringWithTokens(input, source, Maps.newHashMap());
+        try {
+            return createFromString(input).getForCommandSource(source, null, null);
+        } catch (NucleusException e) {
+            return Text.EMPTY;
+        }
     }
 
     /**
      * Uses Nucleus' parser to format a string that uses Minecraft colour codes.
+     *
+     * @deprecated Use {@link #createFromString(String)} instead to create a {@link NucleusTextTemplate}.
      *
      * @param input The input.
      * @param source The {@link CommandSource} that will view the message.
      * @param variables Any variables to be provided to the text.
      * @return The {@link Text} that represents the output.
      */
-    Text formatAmpersandEncodedStringWithTokens(String input, CommandSource source, Map<String, Object> variables);
+    @Deprecated
+    default Text formatAmpersandEncodedStringWithTokens(String input, CommandSource source, Map<String, Object> variables) {
+        try {
+            return createFromString(input).getForCommandSource(source, null, variables);
+        } catch (NucleusException e) {
+            return Text.EMPTY;
+        }
+    }
+
+    /**
+     * Allows users to register additional token delimiter formats. For example, if a token wanted to register {%id%} to run
+     * {{pl:blah:id}}, then they would need to run:
+     *
+     * <pre>
+     *     registerTokenFormat("{%", "%}", "pl:blah:$1")
+     * </pre>
+     * <p>
+     *     Note that the third argument contains $1. This method will replace $1 with the ID.
+     * </p>
+     * <p>
+     *     This will only apply to Ampersand formatted strings.
+     * </p>
+     *
+     * @param tokenStart The start delimiter of a token to register.
+     * @param tokenEnd The end delimiter of a token to register.
+     * @param replacement The form of the token identifier to use (without the {{,}} delimiters).
+     * @return <code>true</code> if successful.
+     * @throws IllegalArgumentException thrown if the delimiters are illegal.
+     */
+    boolean registerTokenFormat(String tokenStart, String tokenEnd, String replacement) throws IllegalArgumentException;
+
+    /**
+     * Creates a {@link NucleusTextTemplate} from a string, which could be either Json or Ampersand formatted.
+     *
+     * @param string The string to register.
+     * @return The {@link NucleusTextTemplate} that can be parsed.
+     * @throws NucleusException thrown if the string could not be parsed.
+     */
+    NucleusTextTemplate createFromString(String string) throws NucleusException;
 
     /**
      * A parser for tokens directed at a plugin. Plugins can only register ONE of these.

--- a/nucleus-api/src/main/java/io/github/nucleuspowered/nucleus/api/text/NucleusTextTemplate.java
+++ b/nucleus-api/src/main/java/io/github/nucleuspowered/nucleus/api/text/NucleusTextTemplate.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.api.text;
+
+import io.github.nucleuspowered.nucleus.api.service.NucleusMessageTokenService;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.TextRepresentable;
+import org.spongepowered.api.text.TextTemplate;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+/**
+ * Represents a wrapped {@link TextTemplate} that Nucleus uses to create texts from templates.
+ */
+public interface NucleusTextTemplate extends TextRepresentable {
+
+    /**
+     * Whether the text is empty.
+     *
+     * @return <code>true</code> if so.
+     */
+    boolean isEmpty();
+
+    /**
+     * Gets the underlying {@link TextTemplate}
+     *
+     * @return The {@link TextTemplate}
+     */
+    TextTemplate getTextTemplate();
+
+    /**
+     * Gets the {@link Text} where the tokens have been parsed from the viewpoint of the supplied {@link CommandSource}. Any unknown tokens in
+     * the parsed text will be left blank.
+     *
+     * @param source The {@link CommandSource} that will influence what is displayed by the tokens.
+     * @return The parsed {@link Text}
+     */
+    default Text getForCommandSource(CommandSource source) {
+        return getForCommandSource(source, null, null);
+    }
+
+    /**
+     * Gets the {@link Text} where the tokens have been parsed from the viewpoint of the supplied {@link CommandSource}.
+     *
+     * <p>
+     *     By supplying a token array, these token identifiers act as additional tokens that could be encountered, and will be used above standard
+     *     tokens. This is useful for having a token in a specific context, such as "displayfrom", which might only be used in a message, and is
+     *     not worth registering in a {@link NucleusMessageTokenService.TokenParser}. They must not contain the token start or end delimiters.
+     * </p>
+     * <p>
+     *     The variables are items that <em>might</em> be used by tokens, and is generally best used with your own messages and tokens.
+     *     {@link NucleusMessageTokenService.TokenParser}s are passed this map.
+     * </p>
+     *
+     * @param source The {@link CommandSource} that will influence what is displayed by the tokens.
+     * @param tokensArray The extra tokens that can be used to parse a text.
+     * @param variables The variables.
+     * @return The parsed {@link Text}
+     */
+    Text getForCommandSource(CommandSource source, @Nullable Map<String, Function<CommandSource, Optional<Text>>> tokensArray,
+            @Nullable Map<String, Object> variables);
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/ChatUtil.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/ChatUtil.java
@@ -484,7 +484,7 @@ public class ChatUtil {
             cmd = cmd + " ";
         }
 
-        final String commandToRun = cmd.replaceAll("\\{\\{player}}", user.getName());
+        final String commandToRun = cmd.replace("{{subject}}", user.getName()).replace("{{player}}", user.getName());
         Optional<HoverAction<?>> ha = name.getHoverAction();
         Text.Builder hoverAction;
         if (ha.isPresent() && (ha.get() instanceof HoverAction.ShowText)) {

--- a/src/main/java/io/github/nucleuspowered/nucleus/Nucleus.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/Nucleus.java
@@ -16,6 +16,7 @@ import io.github.nucleuspowered.nucleus.internal.messages.MessageProvider;
 import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
 import io.github.nucleuspowered.nucleus.internal.services.WarmupManager;
 import io.github.nucleuspowered.nucleus.internal.teleport.NucleusTeleportHandler;
+import io.github.nucleuspowered.nucleus.internal.text.TokenHandler;
 import io.github.nucleuspowered.nucleus.util.ThrowableAction;
 import org.slf4j.Logger;
 import uk.co.drnaylor.quickstart.modulecontainers.DiscoveryModuleContainer;
@@ -90,6 +91,8 @@ public abstract class Nucleus {
     public abstract Optional<MixinConfigProxy> getMixinConfigIfAvailable();
 
     public abstract NucleusTeleportHandler getTeleportHandler();
+
+    public abstract TokenHandler getTokenHandler();
 
     public abstract boolean isDebugMode();
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/NucleusPlugin.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/NucleusPlugin.java
@@ -505,7 +505,7 @@ public class NucleusPlugin extends Nucleus {
         return teleportHandler;
     }
 
-    public TokenHandler getTokenHandler() {
+    @Override public TokenHandler getTokenHandler() {
         return tokenHandler;
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/Util.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/Util.java
@@ -13,6 +13,7 @@ import com.google.common.collect.Maps;
 import io.github.nucleuspowered.nucleus.iapi.data.interfaces.EndTimestamp;
 import io.github.nucleuspowered.nucleus.internal.messages.MessageProvider;
 import io.github.nucleuspowered.nucleus.util.Action;
+import io.github.nucleuspowered.nucleus.util.PaginationBuilderWrapper;
 import io.github.nucleuspowered.nucleus.util.ThrownFunction;
 import org.spongepowered.api.CatalogType;
 import org.spongepowered.api.Sponge;
@@ -504,7 +505,7 @@ public class Util {
             plb.linesPerPage(-1);
         }
 
-        return plb;
+        return new PaginationBuilderWrapper(plb);
     }
 
     public static Inventory.Builder getKitInventoryBuilder() {

--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/InfoArgument.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/InfoArgument.java
@@ -6,6 +6,7 @@ package io.github.nucleuspowered.nucleus.argumentparsers;
 
 import com.google.common.base.Preconditions;
 import io.github.nucleuspowered.nucleus.Nucleus;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
 import io.github.nucleuspowered.nucleus.modules.info.handlers.InfoHandler;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.ArgumentParseException;
@@ -34,7 +35,7 @@ public class InfoArgument extends CommandElement {
     @Override
     protected Object parseValue(CommandSource source, CommandArgs args) throws ArgumentParseException {
         String a = args.next();
-        Optional<List<String>> list = handler.getSection(a);
+        Optional<List<NucleusTextTemplate>> list = handler.getSection(a);
         if (list.isPresent()) {
             return new Result(handler.getInfoSections().stream().filter(a::equalsIgnoreCase).findFirst().get(), list.get());
         }
@@ -54,9 +55,9 @@ public class InfoArgument extends CommandElement {
 
     public static class Result {
         public final String name;
-        public final List<String> text;
+        public final List<NucleusTextTemplate> text;
 
-        public Result(String name, List<String> text) {
+        public Result(String name, List<NucleusTextTemplate> text) {
             this.name = name;
             this.text = text;
         }

--- a/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/InfoArgument.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/argumentparsers/InfoArgument.java
@@ -6,7 +6,7 @@ package io.github.nucleuspowered.nucleus.argumentparsers;
 
 import com.google.common.base.Preconditions;
 import io.github.nucleuspowered.nucleus.Nucleus;
-import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplateImpl;
 import io.github.nucleuspowered.nucleus.modules.info.handlers.InfoHandler;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.ArgumentParseException;
@@ -35,7 +35,7 @@ public class InfoArgument extends CommandElement {
     @Override
     protected Object parseValue(CommandSource source, CommandArgs args) throws ArgumentParseException {
         String a = args.next();
-        Optional<List<NucleusTextTemplate>> list = handler.getSection(a);
+        Optional<List<NucleusTextTemplateImpl>> list = handler.getSection(a);
         if (list.isPresent()) {
             return new Result(handler.getInfoSections().stream().filter(a::equalsIgnoreCase).findFirst().get(), list.get());
         }
@@ -55,9 +55,9 @@ public class InfoArgument extends CommandElement {
 
     public static class Result {
         public final String name;
-        public final List<NucleusTextTemplate> text;
+        public final List<NucleusTextTemplateImpl> text;
 
-        public Result(String name, List<NucleusTextTemplate> text) {
+        public Result(String name, List<NucleusTextTemplateImpl> text) {
             this.name = name;
             this.text = text;
         }

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/ConfigurateHelper.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/ConfigurateHelper.java
@@ -13,7 +13,7 @@ import io.github.nucleuspowered.nucleus.configurate.typeserialisers.NucleusTextT
 import io.github.nucleuspowered.nucleus.configurate.typeserialisers.PatternTypeSerialiser;
 import io.github.nucleuspowered.nucleus.configurate.typeserialisers.SetTypeSerialiser;
 import io.github.nucleuspowered.nucleus.configurate.typeserialisers.Vector3dTypeSerialiser;
-import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplateImpl;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.ConfigurationOptions;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializerCollection;
@@ -55,7 +55,7 @@ public class ConfigurateHelper {
         tsc.registerType(TypeToken.of(ItemStackSnapshot.class), new ItemStackSnapshotSerialiser());
         tsc.registerType(TypeToken.of(ConfigurationNode.class), new ConfigurationNodeTypeSerialiser());
         tsc.registerType(TypeToken.of(Pattern.class), new PatternTypeSerialiser());
-        tsc.registerType(TypeToken.of(NucleusTextTemplate.class), new NucleusTextTemplateTypeSerialiser());
+        tsc.registerType(TypeToken.of(NucleusTextTemplateImpl.class), new NucleusTextTemplateTypeSerialiser());
         tsc.registerPredicate(
                 typeToken -> Set.class.isAssignableFrom(typeToken.getRawType()),
                 new SetTypeSerialiser()

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/ConfigurateHelper.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/ConfigurateHelper.java
@@ -9,9 +9,11 @@ import com.google.common.reflect.TypeToken;
 import io.github.nucleuspowered.nucleus.configurate.objectmapper.NucleusObjectMapperFactory;
 import io.github.nucleuspowered.nucleus.configurate.typeserialisers.ConfigurationNodeTypeSerialiser;
 import io.github.nucleuspowered.nucleus.configurate.typeserialisers.ItemStackSnapshotSerialiser;
+import io.github.nucleuspowered.nucleus.configurate.typeserialisers.NucleusTextTemplateTypeSerialiser;
 import io.github.nucleuspowered.nucleus.configurate.typeserialisers.PatternTypeSerialiser;
 import io.github.nucleuspowered.nucleus.configurate.typeserialisers.SetTypeSerialiser;
 import io.github.nucleuspowered.nucleus.configurate.typeserialisers.Vector3dTypeSerialiser;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.ConfigurationOptions;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializerCollection;
@@ -41,18 +43,19 @@ public class ConfigurateHelper {
         return options.setSerializers(tsc).setObjectMapperFactory(NucleusObjectMapperFactory.getInstance());
     }
 
-    public static TypeSerializerCollection getNucleusTypeSerialiserCollection(ConfigurationOptions options) {
+    private static TypeSerializerCollection getNucleusTypeSerialiserCollection(ConfigurationOptions options) {
         if (typeSerializerCollection != null) {
             return typeSerializerCollection;
         }
 
         TypeSerializerCollection tsc = options.getSerializers();
 
-        // Custom type serialisers for NucleusPlugin
+        // Custom type serialisers for Nucleus
         tsc.registerType(TypeToken.of(Vector3d.class), new Vector3dTypeSerialiser());
         tsc.registerType(TypeToken.of(ItemStackSnapshot.class), new ItemStackSnapshotSerialiser());
         tsc.registerType(TypeToken.of(ConfigurationNode.class), new ConfigurationNodeTypeSerialiser());
         tsc.registerType(TypeToken.of(Pattern.class), new PatternTypeSerialiser());
+        tsc.registerType(TypeToken.of(NucleusTextTemplate.class), new NucleusTextTemplateTypeSerialiser());
         tsc.registerPredicate(
                 typeToken -> Set.class.isAssignableFrom(typeToken.getRawType()),
                 new SetTypeSerialiser()

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/annotations/Default.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/annotations/Default.java
@@ -4,6 +4,8 @@
  */
 package io.github.nucleuspowered.nucleus.configurate.annotations;
 
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -12,11 +14,35 @@ import java.lang.annotation.Target;
 
 /**
  * If a config entry is null or empty and is decorated with this, Nucleus will attempt to parse this value instead.
+ *
+ * <p>
+ *     This annotation has another use - it's lazy loading for a field if the key is null. Rather than create a full blown object when we're likely
+ *     to just blow it away anyway, we use this to only construct the default object if the config node is <code>null</code>.
+ * </p>
  */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Default {
 
+    /**
+     * The default value of the node. This {@link String} must be parsable by the {@link TypeSerializer} of the field.
+     *
+     * @return The default value.
+     */
     String value();
+
+    /**
+     * If true, this value is also used to save the default if the node doesn't exist.
+     *
+     * @return <code>true</code> if so.
+     */
+    boolean saveDefaultIfNull() default false;
+
+    /**
+     * If true, the default is used if the node is an empty string.
+     *
+     * @return <code>true</code> to use the default if the node is empty.
+     */
+    boolean useDefaultIfEmpty() default false;
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/typeserialisers/NucleusTextTemplateTypeSerialiser.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/typeserialisers/NucleusTextTemplateTypeSerialiser.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.configurate.typeserialisers;
+
+import com.google.common.reflect.TypeToken;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
+
+public class NucleusTextTemplateTypeSerialiser implements TypeSerializer<NucleusTextTemplate> {
+
+    @Override public NucleusTextTemplate deserialize(TypeToken<?> type, ConfigurationNode value) throws ObjectMappingException {
+        try {
+            return NucleusTextTemplate.createFromString(value.getString());
+        } catch (Throwable throwable) {
+            if (throwable instanceof ObjectMappingException) {
+                throw (ObjectMappingException)throwable;
+            } else {
+                throw new ObjectMappingException(throwable);
+            }
+        }
+    }
+
+    @Override public void serialize(TypeToken<?> type, NucleusTextTemplate obj, ConfigurationNode value) throws ObjectMappingException {
+        value.setValue(obj.getRepresentation());
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/configurate/typeserialisers/NucleusTextTemplateTypeSerialiser.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/configurate/typeserialisers/NucleusTextTemplateTypeSerialiser.java
@@ -5,16 +5,17 @@
 package io.github.nucleuspowered.nucleus.configurate.typeserialisers;
 
 import com.google.common.reflect.TypeToken;
-import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplateFactory;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplateImpl;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
 
-public class NucleusTextTemplateTypeSerialiser implements TypeSerializer<NucleusTextTemplate> {
+public class NucleusTextTemplateTypeSerialiser implements TypeSerializer<NucleusTextTemplateImpl> {
 
-    @Override public NucleusTextTemplate deserialize(TypeToken<?> type, ConfigurationNode value) throws ObjectMappingException {
+    @Override public NucleusTextTemplateImpl deserialize(TypeToken<?> type, ConfigurationNode value) throws ObjectMappingException {
         try {
-            return NucleusTextTemplate.createFromString(value.getString());
+            return NucleusTextTemplateFactory.createFromString(value.getString());
         } catch (Throwable throwable) {
             if (throwable instanceof ObjectMappingException) {
                 throw (ObjectMappingException)throwable;
@@ -24,7 +25,7 @@ public class NucleusTextTemplateTypeSerialiser implements TypeSerializer<Nucleus
         }
     }
 
-    @Override public void serialize(TypeToken<?> type, NucleusTextTemplate obj, ConfigurationNode value) throws ObjectMappingException {
+    @Override public void serialize(TypeToken<?> type, NucleusTextTemplateImpl obj, ConfigurationNode value) throws ObjectMappingException {
         value.setValue(obj.getRepresentation());
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/TextFileController.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/TextFileController.java
@@ -6,6 +6,7 @@ package io.github.nucleuspowered.nucleus.internal;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
 import org.spongepowered.api.asset.Asset;
 
 import java.io.IOException;
@@ -42,6 +43,11 @@ public final class TextFileController {
      * Holds the file information.
      */
     private final List<String> fileContents = Lists.newArrayList();
+
+    /**
+     * Holds the {@link NucleusTextTemplate} information.
+     */
+    private final List<NucleusTextTemplate> textTemplates = Lists.newArrayList();
 
     private long fileTimeStamp = 0;
 
@@ -88,6 +94,7 @@ public final class TextFileController {
         this.fileTimeStamp = Files.getLastModifiedTime(fileLocation).toMillis();
         this.fileContents.clear();
         this.fileContents.addAll(fileContents);
+        this.textTemplates.clear();
     }
 
     /**
@@ -95,9 +102,13 @@ public final class TextFileController {
      *
      * @return An {@link ImmutableList} that contains the file contents.
      */
-    public ImmutableList<String> getFileContents() {
+    public ImmutableList<NucleusTextTemplate> getFileContentsAsText() {
         checkFileStamp();
-        return ImmutableList.copyOf(fileContents);
+        if (textTemplates.isEmpty()) {
+            fileContents.forEach(x -> textTemplates.add(NucleusTextTemplate.createFromAmpersandString(x)));
+        }
+
+        return ImmutableList.copyOf(textTemplates);
     }
 
     private void checkFileStamp() {

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/TextFileController.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/TextFileController.java
@@ -6,7 +6,8 @@ package io.github.nucleuspowered.nucleus.internal;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplateFactory;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplateImpl;
 import org.spongepowered.api.asset.Asset;
 
 import java.io.IOException;
@@ -45,9 +46,9 @@ public final class TextFileController {
     private final List<String> fileContents = Lists.newArrayList();
 
     /**
-     * Holds the {@link NucleusTextTemplate} information.
+     * Holds the {@link NucleusTextTemplateImpl} information.
      */
-    private final List<NucleusTextTemplate> textTemplates = Lists.newArrayList();
+    private final List<NucleusTextTemplateImpl> textTemplates = Lists.newArrayList();
 
     private long fileTimeStamp = 0;
 
@@ -102,10 +103,10 @@ public final class TextFileController {
      *
      * @return An {@link ImmutableList} that contains the file contents.
      */
-    public ImmutableList<NucleusTextTemplate> getFileContentsAsText() {
+    public ImmutableList<NucleusTextTemplateImpl> getFileContentsAsText() {
         checkFileStamp();
         if (textTemplates.isEmpty()) {
-            fileContents.forEach(x -> textTemplates.add(NucleusTextTemplate.createFromAmpersandString(x)));
+            fileContents.forEach(x -> textTemplates.add(NucleusTextTemplateFactory.createFromAmpersandString(x)));
         }
 
         return ImmutableList.copyOf(textTemplates);

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/command/StandardAbstractCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/command/StandardAbstractCommand.java
@@ -32,7 +32,7 @@ import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SubjectPermissionCache;
 import io.github.nucleuspowered.nucleus.internal.services.WarmupManager;
-import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplateImpl;
 import io.github.nucleuspowered.nucleus.modules.afk.AFKModule;
 import io.github.nucleuspowered.nucleus.modules.afk.config.AFKConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.afk.config.MessagesConfig;
@@ -1038,7 +1038,7 @@ public abstract class StandardAbstractCommand<T extends CommandSource> implement
                 messagesConfig = a.getNodeOrDefault().getMessages();
             }
 
-            NucleusTextTemplate onCommand = messagesConfig.getOnCommand();
+            NucleusTextTemplateImpl onCommand = messagesConfig.getOnCommand();
             if (!onCommand.isEmpty()) {
                 src.sendMessage(onCommand.getForCommandSource(player));
             }

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/command/StandardAbstractCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/command/StandardAbstractCommand.java
@@ -32,7 +32,10 @@ import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SubjectPermissionCache;
 import io.github.nucleuspowered.nucleus.internal.services.WarmupManager;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
+import io.github.nucleuspowered.nucleus.modules.afk.AFKModule;
 import io.github.nucleuspowered.nucleus.modules.afk.config.AFKConfigAdapter;
+import io.github.nucleuspowered.nucleus.modules.afk.config.MessagesConfig;
 import io.github.nucleuspowered.nucleus.modules.afk.handlers.AFKHandler;
 import io.github.nucleuspowered.nucleus.modules.core.config.CoreConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.core.config.WarmupConfig;
@@ -131,7 +134,9 @@ public abstract class StandardAbstractCommand<T extends CommandSource> implement
     private Optional<AFKHandler> afkHandler = null;
 
     @SuppressWarnings("all")
-    private Optional<AFKConfigAdapter> aca = null;
+    private static Optional<AFKConfigAdapter> aca = null;
+    @Nullable private static MessagesConfig messagesConfig = null;
+
     private CommandBuilder builder;
     private String module;
     private String moduleId;
@@ -207,12 +212,12 @@ public abstract class StandardAbstractCommand<T extends CommandSource> implement
         }
     }
 
-    public final void setModuleCommands(Set<Class<? extends StandardAbstractCommand<?>>> moduleCommands) {
+    final void setModuleCommands(Set<Class<? extends StandardAbstractCommand<?>>> moduleCommands) {
         Preconditions.checkState(this.moduleCommands == null);
         this.moduleCommands = moduleCommands;
     }
 
-    public final void setCommandBuilder(CommandBuilder builder) {
+    final void setCommandBuilder(CommandBuilder builder) {
         this.builder = builder;
     }
 
@@ -563,8 +568,8 @@ public abstract class StandardAbstractCommand<T extends CommandSource> implement
     }
 
     @Override
-    @NonnullByDefault
-    public final CommandResult execute(CommandSource source, CommandContext args) throws CommandException {
+    @Nonnull
+    public final CommandResult execute(@Nonnull CommandSource source, @Nonnull CommandContext args) throws CommandException {
         try {
             commandTimings.startTimingIfSync();
 
@@ -1014,9 +1019,10 @@ public abstract class StandardAbstractCommand<T extends CommandSource> implement
         }
     }
 
-    private void getAfkConfigAdapter() throws NoModuleException, IncorrectAdapterTypeException {
+    private static synchronized void getAfkConfigAdapter() throws NoModuleException, IncorrectAdapterTypeException {
         if (aca == null) {
-            aca = Optional.of(plugin.getModuleContainer().getConfigAdapterForModule("afk", AFKConfigAdapter.class));
+            aca = Optional.of(Nucleus.getNucleus().getModuleContainer().getConfigAdapterForModule(AFKModule.ID, AFKConfigAdapter.class));
+            aca.ifPresent(afkConfigAdapter -> Nucleus.getNucleus().registerReloadable(() -> messagesConfig = null));
         }
     }
 
@@ -1028,9 +1034,13 @@ public abstract class StandardAbstractCommand<T extends CommandSource> implement
         }
 
         aca.ifPresent(a -> {
-            String onCommand = a.getNodeOrDefault().getMessages().getOnCommand();
-            if (!onCommand.trim().isEmpty()) {
-                src.sendMessage(plugin.getChatUtil().getMessageFromTemplate(onCommand, player, true));
+            if (messagesConfig == null) {
+                messagesConfig = a.getNodeOrDefault().getMessages();
+            }
+
+            NucleusTextTemplate onCommand = messagesConfig.getOnCommand();
+            if (!onCommand.isEmpty()) {
+                src.sendMessage(onCommand.getForCommandSource(player));
             }
         });
     }

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/text/NucleusTextTemplate.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/text/NucleusTextTemplate.java
@@ -1,0 +1,218 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.internal.text;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.reflect.TypeToken;
+import io.github.nucleuspowered.nucleus.ChatUtil;
+import io.github.nucleuspowered.nucleus.Nucleus;
+import io.github.nucleuspowered.nucleus.Util;
+import ninja.leaping.configurate.ConfigurationOptions;
+import ninja.leaping.configurate.SimpleConfigurationNode;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.objectmapping.serialize.TypeSerializer;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.TextRepresentable;
+import org.spongepowered.api.text.TextTemplate;
+import org.spongepowered.api.util.Tuple;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nullable;
+
+@NonnullByDefault
+public abstract class NucleusTextTemplate implements TextRepresentable {
+
+    private static final Map<String, Object> emptyVariables = Maps.newHashMap();
+
+    private final String representation;
+    private final TextTemplate textTemplate;
+    private static final Map<String, Function<CommandSource, Text>> tokenMap = Maps.newHashMap();
+
+    public NucleusTextTemplate(String representation) {
+        this.representation = representation;
+        Tuple<TextTemplate, Map<String, Function<CommandSource, Text>>> t = parse(representation);
+        this.textTemplate = t.getFirst();
+
+        tokenMap.putAll(t.getSecond());
+    }
+
+    public boolean isEmpty() {
+        return false;
+    }
+
+    public String getRepresentation() {
+        return representation;
+    }
+
+    public TextTemplate getTextTemplate() {
+        return textTemplate;
+    }
+
+    abstract Tuple<TextTemplate, Map<String, Function<CommandSource, Text>>> parse(String parser) ;
+
+    public static NucleusTextTemplate createFromString(String string) throws Throwable {
+        if (string.isEmpty()) {
+            return Empty.INSTANCE;
+        }
+
+        try {
+            return new Json(string);
+        } catch (NullPointerException e) {
+            return new Ampersand(string);
+        } catch (RuntimeException e) {
+            if (e.getCause() != null && e.getCause() instanceof ObjectMappingException) {
+                return new Ampersand(string);
+            } else if (e.getCause() != null) {
+                throw e.getCause();
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    public static NucleusTextTemplate createFromAmpersandString(String string) {
+        return new Ampersand(string);
+    }
+
+    public Text getForCommandSource(CommandSource source) {
+        return getForCommandSource(source, null, null);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    public Text getForCommandSource(CommandSource source, @Nullable Map<String, Function<CommandSource, Optional<Text>>> tokensArray,
+            @Nullable Map<String, Object> variables) {
+        final Map<String, Object> variables2 = variables == null ? emptyVariables : variables;
+
+        Map<String, TextTemplate.Arg> tokens = textTemplate.getArguments();
+        Map<String, Text> finalArgs = Maps.newHashMap();
+
+        tokens.forEach((k, v) -> {
+            String key = k.toLowerCase();
+            boolean hasSpace = false;
+            if (k.endsWith(":s")) {
+                key = k.substring(0, k.length() - 2);
+                hasSpace = true;
+            }
+
+            Text t;
+            if (tokenMap.containsKey(key)) {
+                t = tokenMap.get(key).apply(source);
+            } else if (tokensArray != null && tokensArray.containsKey(key)) {
+                t = tokensArray.get(key).apply(source).orElse(null);
+            } else {
+                t = Nucleus.getNucleus().getTokenHandler().getTextFromToken(key, source, variables2).orElse(null);
+            }
+
+            if (t != null) {
+                if (hasSpace) {
+                    finalArgs.put(k, Text.join(t, Util.NOT_EMPTY));
+                } else {
+                    finalArgs.put(k, t);
+                }
+            }
+        });
+
+        return textTemplate.apply(finalArgs).build();
+    }
+
+    public Text toText() {
+        return textTemplate.toText();
+    }
+
+    /**
+     * Creates a {@link TextTemplate} from an Ampersand encoded string.
+     */
+    public static class Ampersand extends NucleusTextTemplate {
+
+        private static final Pattern pattern = Pattern.compile("(?!\\[[.]+\\]\\(/[^\\)]*?)\\{\\{(?!subject)([^\\s\\{\\}]+)}}(?![^\\(]*?\\))");
+
+        Ampersand(String representation) {
+            super(representation);
+        }
+
+        @Override Tuple<TextTemplate, Map<String, Function<CommandSource, Text>>> parse(String string) {
+            // regex!
+            Matcher mat = pattern.matcher(string);
+            List<String> map = Lists.newArrayList();
+
+            while (mat.find()) {
+                map.add(mat.group(1));
+            }
+
+            String[] s = pattern.split(string);
+
+            // Generic hell.
+            ArrayDeque<TextRepresentable> texts = new ArrayDeque<>();
+            Map<String, Function<CommandSource, Text>> tokens = Maps.newHashMap();
+
+            // ChatUtil URL parsing needed here.
+            ChatUtil cu = Nucleus.getNucleus().getChatUtil();
+            cu.createTextTemplateFragmentWithLinks(s[0]).mapIfPresent(texts::addAll, tokens::putAll);
+            for (int i = 0; i < map.size(); i++) {
+                TextTemplate.Arg.Builder arg = TextTemplate.arg(map.get(i)).optional();
+                TextRepresentable r = texts.peekLast();
+                if (r != null) {
+                    cu.getLastColourAndStyle(r, null).applyTo(st -> arg.color(st.colour).style(st.style));
+                }
+
+                texts.add(arg.build());
+                if (s.length > i + 1) {
+                    cu.createTextTemplateFragmentWithLinks(s[i + 1]).mapIfPresent(texts::addAll, tokens::putAll);
+                }
+            }
+
+            return Tuple.of(TextTemplate.of(texts.toArray(new Object[texts.size()])), tokens);
+        }
+    }
+
+    public static class Json extends NucleusTextTemplate {
+
+        @Nullable private static TypeSerializer<TextTemplate> textTemplateTypeSerializer = null;
+
+        Json(String representation) throws ObjectMappingException {
+            super(representation);
+        }
+
+        @Override Tuple<TextTemplate, Map<String, Function<CommandSource, Text>>> parse(String parser) {
+            if (textTemplateTypeSerializer == null) {
+                textTemplateTypeSerializer = ConfigurationOptions.defaults().getSerializers().get(TypeToken.of(TextTemplate.class));
+            }
+
+            try {
+                return Tuple.of(textTemplateTypeSerializer.deserialize(TypeToken.of(TextTemplate.class), SimpleConfigurationNode.root().setValue(parser)),
+                        Maps.newHashMap());
+            } catch (ObjectMappingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public static class Empty extends NucleusTextTemplate {
+
+        public static final NucleusTextTemplate INSTANCE = new Empty();
+
+        private Empty() {
+            super("");
+        }
+
+        @Override Tuple<TextTemplate, Map<String, Function<CommandSource, Text>>> parse(String parser) {
+            return Tuple.of(TextTemplate.EMPTY, Maps.newHashMap());
+        }
+
+        @Override public boolean isEmpty() {
+            return true;
+        }
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/text/NucleusTextTemplateFactory.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/text/NucleusTextTemplateFactory.java
@@ -1,0 +1,81 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.internal.text;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import org.spongepowered.api.util.Tuple;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+public class NucleusTextTemplateFactory {
+
+    public static final NucleusTextTemplateFactory INSTANCE = new NucleusTextTemplateFactory();
+
+    public static NucleusTextTemplateImpl createFromString(String string) throws Throwable {
+        return INSTANCE.create(string);
+    }
+
+    public static NucleusTextTemplateImpl createFromAmpersandString(String string) {
+        return new NucleusTextTemplateImpl.Ampersand(string);
+    }
+
+    private final Set<Tuple<String, String>> registered = Sets.newHashSet();
+    private final List<Function<String, String>> replacements = Lists.newArrayList();
+
+    private NucleusTextTemplateFactory() {}
+
+    boolean registerTokenTranslator(String tokenStart, String tokenEnd, String replacement) {
+        String s = tokenStart.trim();
+        String e = tokenEnd.trim();
+        Preconditions.checkArgument(!(s.contains("{{") || e.contains("}}")));
+        if (registered.stream().anyMatch(x -> x.getFirst().equalsIgnoreCase(s) || x.getSecond().equalsIgnoreCase(e))) {
+            return false;
+        }
+
+        // Create replacement regex.
+        String replacementRegex = Pattern.quote(tokenStart.trim()) + "([^\\s{}]+)" + Pattern.quote(tokenEnd.trim());
+        replacements.add(st -> st.replaceAll(replacementRegex, "{{" + replacement + "}}"));
+        registered.add(Tuple.of(s, e));
+        return true;
+    }
+
+    public NucleusTextTemplateImpl create(String string) throws Throwable {
+        if (string.isEmpty()) {
+            return NucleusTextTemplateImpl.Empty.INSTANCE;
+        }
+
+        try {
+            return new NucleusTextTemplateImpl.Json(string);
+        } catch (NullPointerException e) {
+            return createFromAmpersand(string);
+        } catch (RuntimeException e) {
+            if (e.getCause() != null && e.getCause() instanceof ObjectMappingException) {
+                return createFromAmpersand(string);
+            } else if (e.getCause() != null) {
+                throw e.getCause();
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    public NucleusTextTemplateImpl createFromAmpersand(String string) throws Throwable {
+        return new NucleusTextTemplateImpl.Ampersand(string);
+    }
+
+    String performReplacements(String string) {
+        for (Function<String, String> replacementFunction : replacements) {
+            string = replacementFunction.apply(string);
+        }
+
+        return string;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/text/NucleusTokenServiceImpl.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/text/NucleusTokenServiceImpl.java
@@ -6,11 +6,11 @@ package io.github.nucleuspowered.nucleus.internal.text;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
-import io.github.nucleuspowered.nucleus.Nucleus;
 import io.github.nucleuspowered.nucleus.PluginInfo;
+import io.github.nucleuspowered.nucleus.api.exceptions.NucleusException;
 import io.github.nucleuspowered.nucleus.api.exceptions.PluginAlreadyRegisteredException;
 import io.github.nucleuspowered.nucleus.api.service.NucleusMessageTokenService;
-import org.spongepowered.api.command.CommandSource;
+import io.github.nucleuspowered.nucleus.api.text.NucleusTextTemplate;
 import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.util.Tuple;
@@ -67,12 +67,16 @@ public class NucleusTokenServiceImpl implements NucleusMessageTokenService {
         return Optional.ofNullable(primaryTokenStore.get(primaryToken.toLowerCase()));
     }
 
-    @Override public Text formatAmpersandEncodedStringWithTokens(String input, CommandSource source, Map<String, Object> variables) {
-        if (variables == null) {
-            variables = Maps.newHashMap();
-        }
+    @Override public boolean registerTokenFormat(String tokenStart, String tokenEnd, String replacement) throws IllegalArgumentException {
+        return NucleusTextTemplateFactory.INSTANCE.registerTokenTranslator(tokenStart, tokenEnd, replacement);
+    }
 
-        return Nucleus.getNucleus().getChatUtil().getMessageFromTemplateWithVariables(input, source, variables);
+    @Override public NucleusTextTemplate createFromString(String string) throws NucleusException {
+        try {
+            return NucleusTextTemplateFactory.INSTANCE.create(string);
+        } catch (Throwable throwable) {
+            throw new NucleusException(Text.of("Error creating template."), throwable, NucleusException.ExceptionType.UNKNOWN_ERROR);
+        }
     }
 
     public Tokens getNucleusTokenParser() {

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/text/TokenHandler.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/text/TokenHandler.java
@@ -79,8 +79,8 @@ public class TokenHandler {
         }
     }
 
-    private Optional<Text> getTextFromPluginToken(@Nullable String pluginId, String token, CommandSource source, boolean addSpace, Map<String, Object>
-            variables) {
+    private Optional<Text> getTextFromPluginToken(@Nullable String pluginId, String token, CommandSource source, boolean addSpace,
+            Map<String, Object> variables) {
         if (service != null) {
             Optional<Text> opt =
                 pluginId == null ?

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/text/Tokens.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/text/Tokens.java
@@ -12,6 +12,7 @@ import io.github.nucleuspowered.nucleus.api.service.NucleusMessageTokenService;
 import io.github.nucleuspowered.nucleus.modules.core.datamodules.UniqueUserCountTransientModule;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.source.ConsoleSource;
 import org.spongepowered.api.command.source.RemoteSource;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.text.Text;
@@ -48,6 +49,8 @@ public final class Tokens implements NucleusMessageTokenService.TokenParser {
         translatorMap.put("ipaddress", (p, v, m) -> Optional.of(Text.of(p instanceof RemoteSource ?
             ((RemoteSource)p).getConnection().getAddress().getAddress().toString() :
             "localhost")));
+
+        translatorMap.put("subject", (p, v, m) -> Optional.of(Text.of((p instanceof ConsoleSource ? "-" : p.getName()))));
     }
 
     @Nonnull @Override public Optional<Text> parse(String tokenInput, CommandSource source, Map<String, Object> variables) {

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/config/BroadcastConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/config/BroadcastConfig.java
@@ -4,6 +4,8 @@
  */
 package io.github.nucleuspowered.nucleus.modules.admin.config;
 
+import io.github.nucleuspowered.nucleus.configurate.annotations.Default;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
@@ -11,16 +13,18 @@ import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 public class BroadcastConfig {
 
     @Setting
-    private String prefix = "&a[Broadcast]";
+    @Default(value = "&a[Broadcast] ", saveDefaultIfNull = true)
+    private NucleusTextTemplate prefix;
 
     @Setting
-    private String suffix = "";
+    @Default(value = "", saveDefaultIfNull = true)
+    private NucleusTextTemplate suffix;
 
-    public String getPrefix() {
+    public NucleusTextTemplate getPrefix() {
         return prefix;
     }
 
-    public String getSuffix() {
+    public NucleusTextTemplate getSuffix() {
         return suffix;
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/config/BroadcastConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/config/BroadcastConfig.java
@@ -5,7 +5,7 @@
 package io.github.nucleuspowered.nucleus.modules.admin.config;
 
 import io.github.nucleuspowered.nucleus.configurate.annotations.Default;
-import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplateImpl;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
@@ -14,17 +14,17 @@ public class BroadcastConfig {
 
     @Setting
     @Default(value = "&a[Broadcast] ", saveDefaultIfNull = true)
-    private NucleusTextTemplate prefix;
+    private NucleusTextTemplateImpl prefix;
 
     @Setting
     @Default(value = "", saveDefaultIfNull = true)
-    private NucleusTextTemplate suffix;
+    private NucleusTextTemplateImpl suffix;
 
-    public NucleusTextTemplate getPrefix() {
+    public NucleusTextTemplateImpl getPrefix() {
         return prefix;
     }
 
-    public NucleusTextTemplate getSuffix() {
+    public NucleusTextTemplateImpl getSuffix() {
         return suffix;
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/afk/config/MessagesConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/afk/config/MessagesConfig.java
@@ -4,6 +4,8 @@
  */
 package io.github.nucleuspowered.nucleus.modules.afk.config;
 
+import io.github.nucleuspowered.nucleus.configurate.annotations.Default;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
@@ -11,37 +13,42 @@ import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 public class MessagesConfig {
 
     @Setting("on-afk")
-    private String afkMessage = "&7*&f{{displayname}} &7has gone AFK.";
+    @Default(value = "&7*&f{{displayname}} &7has gone AFK.", saveDefaultIfNull = true)
+    private NucleusTextTemplate afkMessage;
 
     @Setting("on-return")
-    private String returnAfkMessage = "&7*&f{{displayname}} &7is no longer AFK.";
+    @Default(value = "&7*&f{{displayname}} &7is no longer AFK.", saveDefaultIfNull = true)
+    private NucleusTextTemplate returnAfkMessage;
 
     @Setting("on-command")
-    private String onCommand = "&f{{displayname}} &7is currently AFK and may not respond quickly.";
+    @Default(value = "&f{{displayname}} &7is currently AFK and may not respond quickly.", saveDefaultIfNull = true)
+    private NucleusTextTemplate onCommand;
 
     @Setting(value = "on-kick", comment = "config.afk.messagetobroadcastonkick")
-    private String onKick = "&f{{displayname}} &7has been kicked for being AFK too long.";
+    @Default(value = "&f{{displayname}} &7has been kicked for being AFK too long.", saveDefaultIfNull = true)
+    private NucleusTextTemplate onKick;
 
     @Setting(value = "kick-message-to-subject", comment = "config.afk.playerkicked")
-    private String kickMessage = "You have been kicked for being AFK for too long.";
+    @Default(value = "You have been kicked for being AFK for too long.", saveDefaultIfNull = true)
+    private NucleusTextTemplate kickMessage;
 
-    public String getAfkMessage() {
+    public NucleusTextTemplate getAfkMessage() {
         return afkMessage;
     }
 
-    public String getReturnAfkMessage() {
+    public NucleusTextTemplate getReturnAfkMessage() {
         return returnAfkMessage;
     }
 
-    public String getOnCommand() {
+    public NucleusTextTemplate getOnCommand() {
         return onCommand;
     }
 
-    public String getOnKick() {
+    public NucleusTextTemplate getOnKick() {
         return onKick;
     }
 
-    public String getKickMessage() {
+    public NucleusTextTemplate getKickMessage() {
         return kickMessage;
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/afk/config/MessagesConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/afk/config/MessagesConfig.java
@@ -5,7 +5,7 @@
 package io.github.nucleuspowered.nucleus.modules.afk.config;
 
 import io.github.nucleuspowered.nucleus.configurate.annotations.Default;
-import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplateImpl;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
@@ -14,41 +14,41 @@ public class MessagesConfig {
 
     @Setting("on-afk")
     @Default(value = "&7*&f{{displayname}} &7has gone AFK.", saveDefaultIfNull = true)
-    private NucleusTextTemplate afkMessage;
+    private NucleusTextTemplateImpl afkMessage;
 
     @Setting("on-return")
     @Default(value = "&7*&f{{displayname}} &7is no longer AFK.", saveDefaultIfNull = true)
-    private NucleusTextTemplate returnAfkMessage;
+    private NucleusTextTemplateImpl returnAfkMessage;
 
     @Setting("on-command")
     @Default(value = "&f{{displayname}} &7is currently AFK and may not respond quickly.", saveDefaultIfNull = true)
-    private NucleusTextTemplate onCommand;
+    private NucleusTextTemplateImpl onCommand;
 
     @Setting(value = "on-kick", comment = "config.afk.messagetobroadcastonkick")
     @Default(value = "&f{{displayname}} &7has been kicked for being AFK too long.", saveDefaultIfNull = true)
-    private NucleusTextTemplate onKick;
+    private NucleusTextTemplateImpl onKick;
 
     @Setting(value = "kick-message-to-subject", comment = "config.afk.playerkicked")
     @Default(value = "You have been kicked for being AFK for too long.", saveDefaultIfNull = true)
-    private NucleusTextTemplate kickMessage;
+    private NucleusTextTemplateImpl kickMessage;
 
-    public NucleusTextTemplate getAfkMessage() {
+    public NucleusTextTemplateImpl getAfkMessage() {
         return afkMessage;
     }
 
-    public NucleusTextTemplate getReturnAfkMessage() {
+    public NucleusTextTemplateImpl getReturnAfkMessage() {
         return returnAfkMessage;
     }
 
-    public NucleusTextTemplate getOnCommand() {
+    public NucleusTextTemplateImpl getOnCommand() {
         return onCommand;
     }
 
-    public NucleusTextTemplate getOnKick() {
+    public NucleusTextTemplateImpl getOnKick() {
         return onKick;
     }
 
-    public NucleusTextTemplate getKickMessage() {
+    public NucleusTextTemplateImpl getKickMessage() {
         return kickMessage;
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/afk/handlers/AFKHandler.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/afk/handlers/AFKHandler.java
@@ -11,7 +11,7 @@ import io.github.nucleuspowered.nucleus.NucleusPlugin;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.service.NucleusAFKService;
 import io.github.nucleuspowered.nucleus.internal.CommandPermissionHandler;
-import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplateImpl;
 import io.github.nucleuspowered.nucleus.modules.afk.commands.AFKCommand;
 import io.github.nucleuspowered.nucleus.modules.afk.config.AFKConfig;
 import io.github.nucleuspowered.nucleus.modules.afk.config.AFKConfigAdapter;
@@ -95,7 +95,7 @@ public class AFKHandler implements NucleusAFKService {
             if (now - e.getValue().lastActivityTime > e.getValue().timeToKick) {
                 // Kick them
                 e.getValue().willKick = true;
-                NucleusTextTemplate message = config.getMessages().getKickMessage();
+                NucleusTextTemplateImpl message = config.getMessages().getKickMessage();
                 TextRepresentable t;
                 if (message.isEmpty()) {
                     t = plugin.getMessageProvider().getTextMessageWithTextFormat("afk.kickreason");
@@ -103,7 +103,7 @@ public class AFKHandler implements NucleusAFKService {
                     t = message;
                 }
 
-                final NucleusTextTemplate messageToServer = config.getMessages().getOnKick();
+                final NucleusTextTemplateImpl messageToServer = config.getMessages().getOnKick();
 
                 Sponge.getServer().getPlayer(e.getKey()).ifPresent(player -> {
                     if (Sponge.getEventManager().post(new AFKEvents.Kick(player, Cause.of(NamedCause.owner(plugin))))) {
@@ -111,7 +111,7 @@ public class AFKHandler implements NucleusAFKService {
                         return;
                     }
 
-                    Text toSend = t instanceof NucleusTextTemplate ? ((NucleusTextTemplate) t).getForCommandSource(player) : t.toText();
+                    Text toSend = t instanceof NucleusTextTemplateImpl ? ((NucleusTextTemplateImpl) t).getForCommandSource(player) : t.toText();
                     Sponge.getScheduler().createSyncExecutor(plugin)
                         .execute(() -> player.kick(toSend));
                     if (!messageToServer.isEmpty()) {
@@ -218,7 +218,7 @@ public class AFKHandler implements NucleusAFKService {
         Sponge.getServer().getPlayer(uuid).ifPresent(player -> {
             // If we have the config set to true, or the subject is NOT invisible, send an AFK message
             if (config.isAfkOnVanish() || !player.get(Keys.VANISH).orElse(false)) {
-                NucleusTextTemplate template = isAfk ? config.getMessages().getAfkMessage() : config.getMessages().getReturnAfkMessage();
+                NucleusTextTemplateImpl template = isAfk ? config.getMessages().getAfkMessage() : config.getMessages().getReturnAfkMessage();
                 if (!template.isEmpty()) {
                     MessageChannel.TO_ALL.send(template.getForCommandSource(player));
                 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/afk/handlers/AFKHandler.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/afk/handlers/AFKHandler.java
@@ -11,6 +11,7 @@ import io.github.nucleuspowered.nucleus.NucleusPlugin;
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.service.NucleusAFKService;
 import io.github.nucleuspowered.nucleus.internal.CommandPermissionHandler;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
 import io.github.nucleuspowered.nucleus.modules.afk.commands.AFKCommand;
 import io.github.nucleuspowered.nucleus.modules.afk.config.AFKConfig;
 import io.github.nucleuspowered.nucleus.modules.afk.config.AFKConfigAdapter;
@@ -22,8 +23,9 @@ import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.NamedCause;
 import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.TextRepresentable;
 import org.spongepowered.api.text.channel.MessageChannel;
-import org.spongepowered.api.text.serializer.TextSerializers;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -93,13 +95,15 @@ public class AFKHandler implements NucleusAFKService {
             if (now - e.getValue().lastActivityTime > e.getValue().timeToKick) {
                 // Kick them
                 e.getValue().willKick = true;
-                String message = config.getMessages().getKickMessage().trim();
+                NucleusTextTemplate message = config.getMessages().getKickMessage();
+                TextRepresentable t;
                 if (message.isEmpty()) {
-                    message = plugin.getMessageProvider().getMessageWithFormat("afk.kickreason");
+                    t = plugin.getMessageProvider().getTextMessageWithTextFormat("afk.kickreason");
+                } else {
+                    t = message;
                 }
 
-                final String messageToServer = config.getMessages().getOnKick().trim();
-                final String messageToGetAroundJavaRestrictions = message;
+                final NucleusTextTemplate messageToServer = config.getMessages().getOnKick();
 
                 Sponge.getServer().getPlayer(e.getKey()).ifPresent(player -> {
                     if (Sponge.getEventManager().post(new AFKEvents.Kick(player, Cause.of(NamedCause.owner(plugin))))) {
@@ -107,8 +111,9 @@ public class AFKHandler implements NucleusAFKService {
                         return;
                     }
 
+                    Text toSend = t instanceof NucleusTextTemplate ? ((NucleusTextTemplate) t).getForCommandSource(player) : t.toText();
                     Sponge.getScheduler().createSyncExecutor(plugin)
-                        .execute(() -> player.kick(TextSerializers.FORMATTING_CODE.deserialize(messageToGetAroundJavaRestrictions)));
+                        .execute(() -> player.kick(toSend));
                     if (!messageToServer.isEmpty()) {
                         MessageChannel mc;
                         if (config.isBroadcastOnKick()) {
@@ -117,7 +122,7 @@ public class AFKHandler implements NucleusAFKService {
                             mc = MessageChannel.permission(getPermissionUtil().getPermissionWithSuffix("notify"));
                         }
 
-                        mc.send(plugin.getChatUtil().getMessageFromTemplate(messageToServer, player, true));
+                        mc.send(messageToServer.getForCommandSource(player));
                     }
                 });
             }
@@ -213,9 +218,9 @@ public class AFKHandler implements NucleusAFKService {
         Sponge.getServer().getPlayer(uuid).ifPresent(player -> {
             // If we have the config set to true, or the subject is NOT invisible, send an AFK message
             if (config.isAfkOnVanish() || !player.get(Keys.VANISH).orElse(false)) {
-                String template = isAfk ? config.getMessages().getAfkMessage().trim() : config.getMessages().getReturnAfkMessage().trim();
+                NucleusTextTemplate template = isAfk ? config.getMessages().getAfkMessage() : config.getMessages().getReturnAfkMessage();
                 if (!template.isEmpty()) {
-                    MessageChannel.TO_ALL.send(plugin.getChatUtil().getMessageFromTemplate(template, player, true));
+                    MessageChannel.TO_ALL.send(template.getForCommandSource(player));
                 }
             } else {
                 // Tell the user in question about them going AFK

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/config/ChatConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/config/ChatConfig.java
@@ -5,6 +5,8 @@
 package io.github.nucleuspowered.nucleus.modules.chat.config;
 
 import com.google.common.collect.ImmutableMap;
+import io.github.nucleuspowered.nucleus.configurate.annotations.Default;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
@@ -38,9 +40,10 @@ public class ChatConfig {
     private boolean removeBlueUnderline = true;
 
     @Setting(value = "me-prefix", comment = "config.chat.meprefix")
-    private String mePrefix = "&7* {{displayName}} ";
+    @Default(value = "&7* {{displayName}} ", saveDefaultIfNull = true)
+    private NucleusTextTemplate mePrefix;
 
-    public String getMePrefix() {
+    public NucleusTextTemplate getMePrefix() {
         return mePrefix;
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/config/ChatConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/config/ChatConfig.java
@@ -6,7 +6,7 @@ package io.github.nucleuspowered.nucleus.modules.chat.config;
 
 import com.google.common.collect.ImmutableMap;
 import io.github.nucleuspowered.nucleus.configurate.annotations.Default;
-import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplateImpl;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
@@ -41,9 +41,9 @@ public class ChatConfig {
 
     @Setting(value = "me-prefix", comment = "config.chat.meprefix")
     @Default(value = "&7* {{displayName}} ", saveDefaultIfNull = true)
-    private NucleusTextTemplate mePrefix;
+    private NucleusTextTemplateImpl mePrefix;
 
-    public NucleusTextTemplate getMePrefix() {
+    public NucleusTextTemplateImpl getMePrefix() {
         return mePrefix;
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/config/ChatTemplateConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/config/ChatTemplateConfig.java
@@ -4,6 +4,8 @@
  */
 package io.github.nucleuspowered.nucleus.modules.chat.config;
 
+import io.github.nucleuspowered.nucleus.configurate.annotations.Default;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
@@ -23,16 +25,17 @@ public class ChatTemplateConfig {
     private String namestyle = "";
 
     @Setting(comment = "config.chat.template.prefix")
-    private String prefix = "{{prefix}} {{displayname}}{{suffix}}&f: ";
+    @Default(value = "{{prefix}} {{displayname}}{{suffix}}&f: ", saveDefaultIfNull = true)
+    private NucleusTextTemplate prefix;
 
     @Setting(comment = "config.chat.template.suffix")
-    private String suffix = "";
+    private NucleusTextTemplate suffix = NucleusTextTemplate.Empty.INSTANCE;
 
-    public String getPrefix() {
+    public NucleusTextTemplate getPrefix() {
         return prefix;
     }
 
-    public String getSuffix() {
+    public NucleusTextTemplate getSuffix() {
         return suffix;
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/config/ChatTemplateConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/config/ChatTemplateConfig.java
@@ -5,7 +5,7 @@
 package io.github.nucleuspowered.nucleus.modules.chat.config;
 
 import io.github.nucleuspowered.nucleus.configurate.annotations.Default;
-import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplateImpl;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
@@ -26,16 +26,16 @@ public class ChatTemplateConfig {
 
     @Setting(comment = "config.chat.template.prefix")
     @Default(value = "{{prefix}} {{displayname}}{{suffix}}&f: ", saveDefaultIfNull = true)
-    private NucleusTextTemplate prefix;
+    private NucleusTextTemplateImpl prefix;
 
     @Setting(comment = "config.chat.template.suffix")
-    private NucleusTextTemplate suffix = NucleusTextTemplate.Empty.INSTANCE;
+    private NucleusTextTemplateImpl suffix = NucleusTextTemplateImpl.Empty.INSTANCE;
 
-    public NucleusTextTemplate getPrefix() {
+    public NucleusTextTemplateImpl getPrefix() {
         return prefix;
     }
 
-    public NucleusTextTemplate getSuffix() {
+    public NucleusTextTemplateImpl getSuffix() {
         return suffix;
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/listeners/ChatListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/listeners/ChatListener.java
@@ -98,7 +98,7 @@ public class ChatListener extends ListenerBase.Reloadable {
 
     // --- Listener Proper
     private final ChatConfigAdapter cca;
-    private ChatConfig chatConfig;
+    private ChatConfig chatConfig = null;
     private final ChatUtil chatUtil;
     private final TemplateUtil templateUtil;
 
@@ -154,9 +154,9 @@ public class ChatListener extends ListenerBase.Reloadable {
         }
 
         event.setMessage(
-                Text.join(prefix, chatUtil.getMessageFromTemplate(ctc.getPrefix(), player, true)),
-                chatConfig.isModifyMainMessage() ? useMessage(player, rawMessage, ctc) : rawMessage,
-                Text.join(footer, chatUtil.getMessageFromTemplate(ctc.getSuffix(), player, false)));
+            Text.join(prefix, ctc.getPrefix().getForCommandSource(player)),
+            chatConfig.isModifyMainMessage() ? useMessage(player, rawMessage, ctc) : rawMessage,
+            Text.join(footer, ctc.getSuffix().getForCommandSource(player)));
     }
 
     private Text useMessage(Player player, Text rawMessage, ChatTemplateConfig chatTemplateConfig) {

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/commandspy/config/CommandSpyConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/commandspy/config/CommandSpyConfig.java
@@ -7,7 +7,7 @@ package io.github.nucleuspowered.nucleus.modules.commandspy.config;
 import io.github.nucleuspowered.nucleus.configurate.annotations.Default;
 import io.github.nucleuspowered.nucleus.configurate.annotations.ProcessSetting;
 import io.github.nucleuspowered.nucleus.configurate.settingprocessor.RemoveFirstSlashIfExistsSettingProcessor;
-import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplateImpl;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
@@ -19,7 +19,7 @@ public class CommandSpyConfig {
 
     @Setting(comment = "config.commandspy.template")
     @Default(value = "&7[CS: {{name}}]: ", saveDefaultIfNull = true)
-    private NucleusTextTemplate prefix;
+    private NucleusTextTemplateImpl prefix;
 
     @Setting(value = "use-whitelist", comment = "config.commandspy.usewhitelist")
     private boolean useWhitelist = true;
@@ -29,7 +29,7 @@ public class CommandSpyConfig {
     @Setting(value = "whitelisted-commands-to-spy-on", comment = "config.commandspy.whitelist")
     private List<String> commands = new ArrayList<>();
 
-    public NucleusTextTemplate getTemplate() {
+    public NucleusTextTemplateImpl getTemplate() {
         return prefix;
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/commandspy/config/CommandSpyConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/commandspy/config/CommandSpyConfig.java
@@ -4,8 +4,10 @@
  */
 package io.github.nucleuspowered.nucleus.modules.commandspy.config;
 
+import io.github.nucleuspowered.nucleus.configurate.annotations.Default;
 import io.github.nucleuspowered.nucleus.configurate.annotations.ProcessSetting;
 import io.github.nucleuspowered.nucleus.configurate.settingprocessor.RemoveFirstSlashIfExistsSettingProcessor;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
@@ -16,7 +18,8 @@ import java.util.List;
 public class CommandSpyConfig {
 
     @Setting(comment = "config.commandspy.template")
-    private String prefix = "&7[CS: {{name}}]: ";
+    @Default(value = "&7[CS: {{name}}]: ", saveDefaultIfNull = true)
+    private NucleusTextTemplate prefix;
 
     @Setting(value = "use-whitelist", comment = "config.commandspy.usewhitelist")
     private boolean useWhitelist = true;
@@ -26,7 +29,7 @@ public class CommandSpyConfig {
     @Setting(value = "whitelisted-commands-to-spy-on", comment = "config.commandspy.whitelist")
     private List<String> commands = new ArrayList<>();
 
-    public String getTemplate() {
+    public NucleusTextTemplate getTemplate() {
         return prefix;
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/commandspy/listeners/CommandSpyListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/commandspy/listeners/CommandSpyListener.java
@@ -74,7 +74,7 @@ public class CommandSpyListener extends ListenerBase.Reloadable {
                     .collect(Collectors.toList());
 
                 if (!playerList.isEmpty()) {
-                    Text prefix = chatUtil.getMessageFromTemplate(config.getTemplate(), player, true);
+                    Text prefix = config.getTemplate().getForCommandSource(player);
                     ChatUtil.StyleTuple st = chatUtil.getLastColourAndStyle(prefix, null);
                     Text messageToSend = prefix
                         .toBuilder().append(Text.of(st.colour, st.style, "/" + event.getCommand() + " " + event.getArguments())).build();

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/connectionmessages/config/ConnectionMessagesConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/connectionmessages/config/ConnectionMessagesConfig.java
@@ -5,7 +5,7 @@
 package io.github.nucleuspowered.nucleus.modules.connectionmessages.config;
 
 import io.github.nucleuspowered.nucleus.configurate.annotations.Default;
-import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplateImpl;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
@@ -17,7 +17,7 @@ public class ConnectionMessagesConfig {
 
     @Setting(value = "first-login-message", comment = "config.connectionmessages.firsttime")
     @Default(value = "&dWelcome &f{{name}} &dto the server!",  saveDefaultIfNull = true)
-    private NucleusTextTemplate firstTimeMessage;
+    private NucleusTextTemplateImpl firstTimeMessage;
 
     @Setting(value = "modify-login-message", comment = "config.connectionmessages.enablelogin")
     private boolean modifyLoginMessage = false;
@@ -27,11 +27,11 @@ public class ConnectionMessagesConfig {
 
     @Setting(value = "login-message", comment = "config.connectionmessages.loginmessage")
     @Default(value = "&8[&a+&8] &f{{name}}", saveDefaultIfNull = true)
-    private NucleusTextTemplate loginMessage;
+    private NucleusTextTemplateImpl loginMessage;
 
     @Setting(value = "logout-message", comment = "config.connectionmessages.logoutmessage")
     @Default(value = "&8[&c-&8] &f{{name}}", saveDefaultIfNull = true)
-    private NucleusTextTemplate logoutMessage;
+    private NucleusTextTemplateImpl logoutMessage;
 
     @Setting(value = "disable-with-permission", comment = "config.connectionmessages.disablepermission")
     private boolean disableWithPermission = false;
@@ -41,13 +41,13 @@ public class ConnectionMessagesConfig {
 
     @Setting(value = "changed-name-message", comment = "config.connectionmessages.displaypriormessage")
     @Default(value = "&f{{name}} &ewas previously known by a different name - they were known as &f{{previousname}}", saveDefaultIfNull = true)
-    private NucleusTextTemplate priorNameMessage;
+    private NucleusTextTemplateImpl priorNameMessage;
 
     public boolean isShowFirstTimeMessage() {
         return showFirstTimeMessage;
     }
 
-    public NucleusTextTemplate getFirstTimeMessage() {
+    public NucleusTextTemplateImpl getFirstTimeMessage() {
         return firstTimeMessage;
     }
 
@@ -59,11 +59,11 @@ public class ConnectionMessagesConfig {
         return modifyLogoutMessage;
     }
 
-    public NucleusTextTemplate getLoginMessage() {
+    public NucleusTextTemplateImpl getLoginMessage() {
         return loginMessage;
     }
 
-    public NucleusTextTemplate getLogoutMessage() {
+    public NucleusTextTemplateImpl getLogoutMessage() {
         return logoutMessage;
     }
 
@@ -75,7 +75,7 @@ public class ConnectionMessagesConfig {
         return displayPriorName;
     }
 
-    public NucleusTextTemplate getPriorNameMessage() {
+    public NucleusTextTemplateImpl getPriorNameMessage() {
         return priorNameMessage;
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/connectionmessages/config/ConnectionMessagesConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/connectionmessages/config/ConnectionMessagesConfig.java
@@ -4,6 +4,8 @@
  */
 package io.github.nucleuspowered.nucleus.modules.connectionmessages.config;
 
+import io.github.nucleuspowered.nucleus.configurate.annotations.Default;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
@@ -14,7 +16,8 @@ public class ConnectionMessagesConfig {
     private boolean showFirstTimeMessage = true;
 
     @Setting(value = "first-login-message", comment = "config.connectionmessages.firsttime")
-    private String firstTimeMessage = "&dWelcome &f{{name}} &dto the server!";
+    @Default(value = "&dWelcome &f{{name}} &dto the server!",  saveDefaultIfNull = true)
+    private NucleusTextTemplate firstTimeMessage;
 
     @Setting(value = "modify-login-message", comment = "config.connectionmessages.enablelogin")
     private boolean modifyLoginMessage = false;
@@ -23,10 +26,12 @@ public class ConnectionMessagesConfig {
     private boolean modifyLogoutMessage = false;
 
     @Setting(value = "login-message", comment = "config.connectionmessages.loginmessage")
-    private String loginMessage = "&8[&a+&8] &f{{name}}";
+    @Default(value = "&8[&a+&8] &f{{name}}", saveDefaultIfNull = true)
+    private NucleusTextTemplate loginMessage;
 
     @Setting(value = "logout-message", comment = "config.connectionmessages.logoutmessage")
-    private String logoutMessage = "&8[&c-&8] &f{{name}}";
+    @Default(value = "&8[&c-&8] &f{{name}}", saveDefaultIfNull = true)
+    private NucleusTextTemplate logoutMessage;
 
     @Setting(value = "disable-with-permission", comment = "config.connectionmessages.disablepermission")
     private boolean disableWithPermission = false;
@@ -35,13 +40,14 @@ public class ConnectionMessagesConfig {
     private boolean displayPriorName = true;
 
     @Setting(value = "changed-name-message", comment = "config.connectionmessages.displaypriormessage")
-    private String priorNameMessage = "&f{{name}} &ewas previously known by a different name - they were known as &f{{previousname}}";
+    @Default(value = "&f{{name}} &ewas previously known by a different name - they were known as &f{{previousname}}", saveDefaultIfNull = true)
+    private NucleusTextTemplate priorNameMessage;
 
     public boolean isShowFirstTimeMessage() {
         return showFirstTimeMessage;
     }
 
-    public String getFirstTimeMessage() {
+    public NucleusTextTemplate getFirstTimeMessage() {
         return firstTimeMessage;
     }
 
@@ -53,11 +59,11 @@ public class ConnectionMessagesConfig {
         return modifyLogoutMessage;
     }
 
-    public String getLoginMessage() {
+    public NucleusTextTemplate getLoginMessage() {
         return loginMessage;
     }
 
-    public String getLogoutMessage() {
+    public NucleusTextTemplate getLogoutMessage() {
         return logoutMessage;
     }
 
@@ -69,7 +75,7 @@ public class ConnectionMessagesConfig {
         return displayPriorName;
     }
 
-    public String getPriorNameMessage() {
+    public NucleusTextTemplate getPriorNameMessage() {
         return priorNameMessage;
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/core/CoreModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/core/CoreModule.java
@@ -4,11 +4,8 @@
  */
 package io.github.nucleuspowered.nucleus.modules.core;
 
-import io.github.nucleuspowered.nucleus.api.service.NucleusMessageTokenService;
 import io.github.nucleuspowered.nucleus.internal.qsml.module.ConfigurableModule;
-import io.github.nucleuspowered.nucleus.internal.text.NucleusTokenServiceImpl;
 import io.github.nucleuspowered.nucleus.modules.core.config.CoreConfigAdapter;
-import org.spongepowered.api.Sponge;
 import uk.co.drnaylor.quickstart.annotations.ModuleData;
 
 @ModuleData(id = CoreModule.ID, name = "Core", isRequired = true)
@@ -30,11 +27,5 @@ public class CoreModule extends ConfigurableModule<CoreConfigAdapter> {
 
     @Override public void onEnable() {
         super.onEnable();
-
-        NucleusTokenServiceImpl nucleusChatService = new NucleusTokenServiceImpl();
-        plugin.getTokenHandler().register(nucleusChatService);
-        serviceManager.registerService(NucleusTokenServiceImpl.class, nucleusChatService);
-        Sponge.getServiceManager().setProvider(plugin, NucleusMessageTokenService.class, nucleusChatService);
-        plugin.getDocGenCache().ifPresent(x -> x.addTokenDocs(nucleusChatService.getNucleusTokenParser().getTokenNames()));
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/info/commands/InfoCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/info/commands/InfoCommand.java
@@ -18,7 +18,7 @@ import io.github.nucleuspowered.nucleus.internal.command.AbstractCommand;
 import io.github.nucleuspowered.nucleus.internal.command.ReturnMessageException;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
-import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplateImpl;
 import io.github.nucleuspowered.nucleus.modules.info.config.InfoConfig;
 import io.github.nucleuspowered.nucleus.modules.info.config.InfoConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.info.handlers.InfoHandler;
@@ -81,7 +81,7 @@ public class InfoCommand extends AbstractCommand<CommandSource> {
         if (infoConfig.isUseDefaultFile() && !oir.isPresent() && !args.hasAny("l")) {
             // Do we have a default?
             String def = infoConfig.getDefaultInfoSection();
-            Optional<List<NucleusTextTemplate>> list = infoHandler.getSection(def);
+            Optional<List<NucleusTextTemplateImpl>> list = infoHandler.getSection(def);
             if (list.isPresent()) {
                 oir = Optional.of(new InfoArgument.Result(infoHandler.getInfoSections().stream().filter(def::equalsIgnoreCase).findFirst().get(), list.get()));
             }
@@ -89,7 +89,7 @@ public class InfoCommand extends AbstractCommand<CommandSource> {
 
         if (oir.isPresent()) {
             // Get the list.
-            List<NucleusTextTemplate> info = oir.get().text;
+            List<NucleusTextTemplateImpl> info = oir.get().text;
             Optional<String> os = getTitle(info);
             String title;
             if (os.isPresent()) {
@@ -100,7 +100,7 @@ public class InfoCommand extends AbstractCommand<CommandSource> {
                 info.remove(0);
 
                 // Remove blank lines.
-                Iterator<NucleusTextTemplate> i = info.iterator();
+                Iterator<NucleusTextTemplateImpl> i = info.iterator();
                 while (i.hasNext()) {
                     String n = i.next().getRepresentation();
                     if (n.isEmpty() || n.matches("^\\s+$")) {
@@ -153,7 +153,7 @@ public class InfoCommand extends AbstractCommand<CommandSource> {
         return CommandResult.success();
     }
 
-    private Optional<String> getTitle(List<NucleusTextTemplate> info) {
+    private Optional<String> getTitle(List<NucleusTextTemplateImpl> info) {
         if (!info.isEmpty()) {
             String sec1 = info.get(0).getRepresentation();
             if (sec1.startsWith("#")) {

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/info/commands/MotdCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/info/commands/MotdCommand.java
@@ -44,9 +44,9 @@ public class MotdCommand extends AbstractCommand<CommandSource> {
         }
 
         if (infoConfigAdapter.getNodeOrDefault().isMotdUsePagination()) {
-            InfoHelper.sendInfo(otfc.get(), src, chatUtil, infoConfigAdapter.getNodeOrDefault().getMotdTitle());
+            InfoHelper.sendInfo(otfc.get(), src, infoConfigAdapter.getNodeOrDefault().getMotdTitle());
         } else {
-            InfoHelper.getTextFromStrings(otfc.get().getFileContents(), src, chatUtil).forEach(src::sendMessage);
+            InfoHelper.getTextFromNucleusTextTemplates(otfc.get().getFileContentsAsText(), src).forEach(src::sendMessage);
         }
 
         return CommandResult.success();

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/info/handlers/InfoHandler.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/info/handlers/InfoHandler.java
@@ -8,7 +8,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import io.github.nucleuspowered.nucleus.NucleusPlugin;
 import io.github.nucleuspowered.nucleus.internal.TextFileController;
-import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplateImpl;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.asset.AssetManager;
 
@@ -49,7 +49,7 @@ public class InfoHandler {
      * @return An {@link Optional} potentially containing the list of strings.
      *
      */
-    public Optional<List<NucleusTextTemplate>> getSection(String name) {
+    public Optional<List<NucleusTextTemplateImpl>> getSection(String name) {
         Optional<String> os = infoFiles.keySet().stream().filter(name::equalsIgnoreCase).findFirst();
         if (os.isPresent()) {
             return Optional.of(infoFiles.get(name).getFileContentsAsText());

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/info/handlers/InfoHandler.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/info/handlers/InfoHandler.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import io.github.nucleuspowered.nucleus.NucleusPlugin;
 import io.github.nucleuspowered.nucleus.internal.TextFileController;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.asset.AssetManager;
 
@@ -48,10 +49,10 @@ public class InfoHandler {
      * @return An {@link Optional} potentially containing the list of strings.
      *
      */
-    public Optional<List<String>> getSection(String name) {
+    public Optional<List<NucleusTextTemplate>> getSection(String name) {
         Optional<String> os = infoFiles.keySet().stream().filter(name::equalsIgnoreCase).findFirst();
         if (os.isPresent()) {
-            return Optional.of(infoFiles.get(name).getFileContents());
+            return Optional.of(infoFiles.get(name).getFileContentsAsText());
         }
 
         return Optional.empty();

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/info/handlers/InfoHelper.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/info/handlers/InfoHelper.java
@@ -4,12 +4,11 @@
  */
 package io.github.nucleuspowered.nucleus.modules.info.handlers;
 
-import io.github.nucleuspowered.nucleus.ChatUtil;
+import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.internal.TextFileController;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandSource;
-import org.spongepowered.api.command.source.ConsoleSource;
-import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.service.pagination.PaginationList;
 import org.spongepowered.api.service.pagination.PaginationService;
 import org.spongepowered.api.text.Text;
@@ -24,30 +23,27 @@ public class InfoHelper {
     private static final Text padding = Text.of(TextColors.GOLD, "-");
     private static final Text emptyPadding = Text.of(" ");
 
-    public static void sendInfo(TextFileController tfc, CommandSource src, ChatUtil chatUtil, String motdTitle) {
-        sendInfo(tfc.getFileContents(), src, chatUtil, motdTitle);
+    public static void sendInfo(TextFileController tfc, CommandSource src, String motdTitle) {
+        sendInfoNT(tfc.getFileContentsAsText(), src, motdTitle);
     }
 
-    public static List<Text> getTextFromStrings(List<String> tfc, CommandSource src, ChatUtil chatUtil) {
-        return chatUtil.getMessageFromTemplate(tfc, src, false).stream()
-            .map(x -> chatUtil.addLinksToText(x, src instanceof Player ? (Player)src : null)).collect(Collectors.toList());
+    public static List<Text> getTextFromNucleusTextTemplates(List<NucleusTextTemplate> textTemplates, CommandSource source) {
+        return textTemplates.stream().map(x -> x.getForCommandSource(source)).collect(Collectors.toList());
     }
 
-    public static void sendInfo(List<String> tfc, CommandSource src, ChatUtil chatUtil, String motdTitle) {
-        // Get the text.
-        List<Text> textList = getTextFromStrings(tfc, src, chatUtil);
+    public static void sendInfoNT(List<NucleusTextTemplate> tfc, CommandSource src, String motdTitle) {
+        sendInfo(getTextFromNucleusTextTemplates(tfc, src), src, motdTitle);
+    }
+
+    private static void sendInfo(List<Text> texts, CommandSource src, String motdTitle) {
 
         PaginationService ps = Sponge.getServiceManager().provideUnchecked(PaginationService.class);
-        PaginationList.Builder pb = ps.builder().contents(textList);
+        PaginationList.Builder pb = Util.getPaginationBuilder(src).contents(texts);
 
         if (!motdTitle.isEmpty()) {
             pb.title(TextSerializers.FORMATTING_CODE.deserialize(motdTitle)).padding(padding);
         } else {
             pb.padding(emptyPadding);
-        }
-
-        if (src instanceof ConsoleSource) {
-            pb.linesPerPage(-1);
         }
 
         pb.sendTo(src);

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/info/handlers/InfoHelper.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/info/handlers/InfoHelper.java
@@ -6,7 +6,7 @@ package io.github.nucleuspowered.nucleus.modules.info.handlers;
 
 import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.internal.TextFileController;
-import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplateImpl;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.service.pagination.PaginationList;
@@ -27,11 +27,11 @@ public class InfoHelper {
         sendInfoNT(tfc.getFileContentsAsText(), src, motdTitle);
     }
 
-    public static List<Text> getTextFromNucleusTextTemplates(List<NucleusTextTemplate> textTemplates, CommandSource source) {
+    public static List<Text> getTextFromNucleusTextTemplates(List<NucleusTextTemplateImpl> textTemplates, CommandSource source) {
         return textTemplates.stream().map(x -> x.getForCommandSource(source)).collect(Collectors.toList());
     }
 
-    public static void sendInfoNT(List<NucleusTextTemplate> tfc, CommandSource src, String motdTitle) {
+    public static void sendInfoNT(List<NucleusTextTemplateImpl> tfc, CommandSource src, String motdTitle) {
         sendInfo(getTextFromNucleusTextTemplates(tfc, src), src, motdTitle);
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/info/listeners/InfoListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/info/listeners/InfoListener.java
@@ -47,9 +47,9 @@ public class InfoListener extends ListenerBase.Reloadable {
                 if (player.hasPermission(getMotdPermission())) {
                     plugin.getTextFileController(InfoModule.MOTD_KEY).ifPresent(x -> {
                         if (ica.getNodeOrDefault().isMotdUsePagination()) {
-                            InfoHelper.sendInfo(x, player, chatUtil, ica.getNodeOrDefault().getMotdTitle());
+                            InfoHelper.sendInfo(x, player, ica.getNodeOrDefault().getMotdTitle());
                         } else {
-                            InfoHelper.getTextFromStrings(x.getFileContents(), player, chatUtil).forEach(player::sendMessage);
+                            InfoHelper.getTextFromNucleusTextTemplates(x.getFileContentsAsText(), player).forEach(player::sendMessage);
                         }
                     });
                 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/message/config/MessageConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/message/config/MessageConfig.java
@@ -5,7 +5,7 @@
 package io.github.nucleuspowered.nucleus.modules.message.config;
 
 import io.github.nucleuspowered.nucleus.configurate.annotations.Default;
-import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplateImpl;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
@@ -14,32 +14,32 @@ public class MessageConfig {
 
     @Setting(value = "helpop-prefix", comment = "config.message.helpop.prefix")
     @Default(value = "&7HelpOp: {{name}} &7> &r", saveDefaultIfNull = true)
-    private NucleusTextTemplate helpOpPrefix;
+    private NucleusTextTemplateImpl helpOpPrefix;
 
     @Setting(value = "msg-receiver-prefix", comment = "config.message.receiver.prefix")
     @Default(value = "&7[{{fromDisplay}}&7 -> me]: &r", saveDefaultIfNull = true)
-    private NucleusTextTemplate messageReceiverPrefix;
+    private NucleusTextTemplateImpl messageReceiverPrefix;
 
     @Setting(value = "msg-sender-prefix", comment = "config.message.sender.prefix")
     @Default(value = "&7[me -> {{toDisplay}}&7]: &r", saveDefaultIfNull = true)
-    private NucleusTextTemplate messageSenderPrefix;
+    private NucleusTextTemplateImpl messageSenderPrefix;
 
     @Setting(value = "socialspy")
     private SocialSpy socialSpy = new SocialSpy();
 
-    public NucleusTextTemplate getHelpOpPrefix() {
+    public NucleusTextTemplateImpl getHelpOpPrefix() {
         return helpOpPrefix;
     }
 
-    public NucleusTextTemplate getMessageReceiverPrefix() {
+    public NucleusTextTemplateImpl getMessageReceiverPrefix() {
         return messageReceiverPrefix;
     }
 
-    public NucleusTextTemplate getMessageSenderPrefix() {
+    public NucleusTextTemplateImpl getMessageSenderPrefix() {
         return messageSenderPrefix;
     }
 
-    public NucleusTextTemplate getMessageSocialSpyPrefix() {
+    public NucleusTextTemplateImpl getMessageSocialSpyPrefix() {
         return socialSpy.messageSocialSpyPrefix;
     }
 
@@ -71,7 +71,7 @@ public class MessageConfig {
     public static class SocialSpy {
         @Setting(value = "msg-prefix", comment = "config.message.socialspy.prefix")
         @Default(value = "&7[SocialSpy] [{{fromDisplay}}&7 -> {{toDisplay}}&7]: &r", saveDefaultIfNull = true)
-        private NucleusTextTemplate messageSocialSpyPrefix;
+        private NucleusTextTemplateImpl messageSocialSpyPrefix;
 
         @Setting(value = "use-levels", comment = "config.message.socialspy.levels")
         private boolean socialSpyLevels = false;

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/message/config/MessageConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/message/config/MessageConfig.java
@@ -4,6 +4,8 @@
  */
 package io.github.nucleuspowered.nucleus.modules.message.config;
 
+import io.github.nucleuspowered.nucleus.configurate.annotations.Default;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
@@ -11,30 +13,33 @@ import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 public class MessageConfig {
 
     @Setting(value = "helpop-prefix", comment = "config.message.helpop.prefix")
-    private String helpOpPrefix = "&7HelpOp: {{name}} &7> &r";
+    @Default(value = "&7HelpOp: {{name}} &7> &r", saveDefaultIfNull = true)
+    private NucleusTextTemplate helpOpPrefix;
 
     @Setting(value = "msg-receiver-prefix", comment = "config.message.receiver.prefix")
-    private String messageReceiverPrefix = "&7[{{fromDisplay}}&7 -> me]: &r";
+    @Default(value = "&7[{{fromDisplay}}&7 -> me]: &r", saveDefaultIfNull = true)
+    private NucleusTextTemplate messageReceiverPrefix;
 
     @Setting(value = "msg-sender-prefix", comment = "config.message.sender.prefix")
-    private String messageSenderPrefix = "&7[me -> {{toDisplay}}&7]: &r";
+    @Default(value = "&7[me -> {{toDisplay}}&7]: &r", saveDefaultIfNull = true)
+    private NucleusTextTemplate messageSenderPrefix;
 
     @Setting(value = "socialspy")
     private SocialSpy socialSpy = new SocialSpy();
 
-    public String getHelpOpPrefix() {
+    public NucleusTextTemplate getHelpOpPrefix() {
         return helpOpPrefix;
     }
 
-    public String getMessageReceiverPrefix() {
+    public NucleusTextTemplate getMessageReceiverPrefix() {
         return messageReceiverPrefix;
     }
 
-    public String getMessageSenderPrefix() {
+    public NucleusTextTemplate getMessageSenderPrefix() {
         return messageSenderPrefix;
     }
 
-    public String getMessageSocialSpyPrefix() {
+    public NucleusTextTemplate getMessageSocialSpyPrefix() {
         return socialSpy.messageSocialSpyPrefix;
     }
 
@@ -65,7 +70,8 @@ public class MessageConfig {
     @ConfigSerializable
     public static class SocialSpy {
         @Setting(value = "msg-prefix", comment = "config.message.socialspy.prefix")
-        private String messageSocialSpyPrefix = "&7[SocialSpy] [{{fromDisplay}}&7 -> {{toDisplay}}&7]: &r";
+        @Default(value = "&7[SocialSpy] [{{fromDisplay}}&7 -> {{toDisplay}}&7]: &r", saveDefaultIfNull = true)
+        private NucleusTextTemplate messageSocialSpyPrefix;
 
         @Setting(value = "use-levels", comment = "config.message.socialspy.levels")
         private boolean socialSpyLevels = false;

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/message/handlers/MessageHandler.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/message/handlers/MessageHandler.java
@@ -13,7 +13,8 @@ import io.github.nucleuspowered.nucleus.dataservices.loaders.UserDataManager;
 import io.github.nucleuspowered.nucleus.dataservices.modular.ModularUserService;
 import io.github.nucleuspowered.nucleus.iapi.service.NucleusPrivateMessagingService;
 import io.github.nucleuspowered.nucleus.internal.CommandPermissionHandler;
-import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplateFactory;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplateImpl;
 import io.github.nucleuspowered.nucleus.modules.message.MessageModule;
 import io.github.nucleuspowered.nucleus.modules.message.config.MessageConfig;
 import io.github.nucleuspowered.nucleus.modules.message.config.MessageConfigAdapter;
@@ -143,9 +144,9 @@ public class MessageHandler implements NucleusPrivateMessagingService {
             receiver.sendMessage(constructMessage(sender, tm, messageConfig.getMessageReceiverPrefix(), tokens, variables));
         }
 
-        NucleusTextTemplate prefix = messageConfig.getMessageSocialSpyPrefix();
+        NucleusTextTemplateImpl prefix = messageConfig.getMessageSocialSpyPrefix();
         if (isCancelled) {
-            prefix = NucleusTextTemplate.createFromAmpersandString(messageConfig.getMutedTag() + prefix.getRepresentation());
+            prefix = NucleusTextTemplateFactory.createFromAmpersandString(messageConfig.getMutedTag() + prefix.getRepresentation());
         }
 
         final int senderLevel = useLevels ? Util.getPositiveIntOptionFromSubject(sender, socialSpyOption)
@@ -216,7 +217,7 @@ public class MessageHandler implements NucleusPrivateMessagingService {
     }
 
     @SuppressWarnings("unchecked")
-    private Text constructMessage(CommandSource sender, Text message, NucleusTextTemplate template, Map<String, Function<CommandSource,
+    private Text constructMessage(CommandSource sender, Text message, NucleusTextTemplateImpl template, Map<String, Function<CommandSource,
             Optional<Text>>> tokens, Map<String, Object> variables) {
         return Text.of(template.getForCommandSource(sender, tokens, variables), message);
     }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/message/handlers/MessageHandler.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/message/handlers/MessageHandler.java
@@ -13,6 +13,7 @@ import io.github.nucleuspowered.nucleus.dataservices.loaders.UserDataManager;
 import io.github.nucleuspowered.nucleus.dataservices.modular.ModularUserService;
 import io.github.nucleuspowered.nucleus.iapi.service.NucleusPrivateMessagingService;
 import io.github.nucleuspowered.nucleus.internal.CommandPermissionHandler;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
 import io.github.nucleuspowered.nucleus.modules.message.MessageModule;
 import io.github.nucleuspowered.nucleus.modules.message.config.MessageConfig;
 import io.github.nucleuspowered.nucleus.modules.message.config.MessageConfigAdapter;
@@ -142,9 +143,9 @@ public class MessageHandler implements NucleusPrivateMessagingService {
             receiver.sendMessage(constructMessage(sender, tm, messageConfig.getMessageReceiverPrefix(), tokens, variables));
         }
 
-        String prefix = messageConfig.getMessageSocialSpyPrefix();
+        NucleusTextTemplate prefix = messageConfig.getMessageSocialSpyPrefix();
         if (isCancelled) {
-            prefix = messageConfig.getMutedTag() + prefix;
+            prefix = NucleusTextTemplate.createFromAmpersandString(messageConfig.getMutedTag() + prefix.getRepresentation());
         }
 
         final int senderLevel = useLevels ? Util.getPositiveIntOptionFromSubject(sender, socialSpyOption)
@@ -215,8 +216,9 @@ public class MessageHandler implements NucleusPrivateMessagingService {
     }
 
     @SuppressWarnings("unchecked")
-    private Text constructMessage(CommandSource sender, Text message, String template, Map<String, Function<CommandSource, Optional<Text>>> tokens, Map<String, Object> variables) {
-        return Text.of(chatUtil.getMessageFromTemplate(template, sender, false, tokens, variables), message);
+    private Text constructMessage(CommandSource sender, Text message, NucleusTextTemplate template, Map<String, Function<CommandSource,
+            Optional<Text>>> tokens, Map<String, Object> variables) {
+        return Text.of(template.getForCommandSource(sender, tokens, variables), message);
     }
 
     private Map<String[], Function<String, String>> createReplacements() {

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/StaffChatMessageChannel.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/StaffChatMessageChannel.java
@@ -8,7 +8,7 @@ import com.google.common.base.Preconditions;
 import io.github.nucleuspowered.nucleus.ChatUtil;
 import io.github.nucleuspowered.nucleus.NucleusPlugin;
 import io.github.nucleuspowered.nucleus.api.chat.NucleusChatChannel;
-import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplateImpl;
 import io.github.nucleuspowered.nucleus.modules.staffchat.commands.StaffChatCommand;
 import io.github.nucleuspowered.nucleus.modules.staffchat.config.StaffChatConfigAdapter;
 import org.spongepowered.api.Sponge;
@@ -40,7 +40,7 @@ public class StaffChatMessageChannel implements NucleusChatChannel.StaffChat {
     private final NucleusPlugin plugin;
     private final ChatUtil chatUtil;
     private final String basePerm;
-    private NucleusTextTemplate template;
+    private NucleusTextTemplateImpl template;
     private TextColor colour;
 
     StaffChatMessageChannel(NucleusPlugin plugin) {

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/StaffChatMessageChannel.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/StaffChatMessageChannel.java
@@ -8,8 +8,8 @@ import com.google.common.base.Preconditions;
 import io.github.nucleuspowered.nucleus.ChatUtil;
 import io.github.nucleuspowered.nucleus.NucleusPlugin;
 import io.github.nucleuspowered.nucleus.api.chat.NucleusChatChannel;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
 import io.github.nucleuspowered.nucleus.modules.staffchat.commands.StaffChatCommand;
-import io.github.nucleuspowered.nucleus.modules.staffchat.config.StaffChatConfig;
 import io.github.nucleuspowered.nucleus.modules.staffchat.config.StaffChatConfigAdapter;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandSource;
@@ -17,8 +17,7 @@ import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.channel.MessageReceiver;
 import org.spongepowered.api.text.chat.ChatType;
-import uk.co.drnaylor.quickstart.exceptions.IncorrectAdapterTypeException;
-import uk.co.drnaylor.quickstart.exceptions.NoModuleException;
+import org.spongepowered.api.text.format.TextColor;
 
 import java.util.Collection;
 import java.util.List;
@@ -40,28 +39,17 @@ public class StaffChatMessageChannel implements NucleusChatChannel.StaffChat {
 
     private final NucleusPlugin plugin;
     private final ChatUtil chatUtil;
-    private StaffChatConfigAdapter scca;
-    private String basePerm;
+    private final String basePerm;
+    private NucleusTextTemplate template;
+    private TextColor colour;
 
     StaffChatMessageChannel(NucleusPlugin plugin) {
         this.plugin = plugin;
         chatUtil = plugin.getChatUtil();
         plugin.registerReloadable(this::onReload);
+        this.onReload();
+        this.basePerm = plugin.getPermissionRegistry().getPermissionsForNucleusCommand(StaffChatCommand.class).getBase();
         INSTANCE = this;
-    }
-
-    // No injections, we have to do it the hard way!
-    private StaffChatConfig getConfig() {
-        if (scca == null) {
-            try {
-                scca = plugin.getModuleContainer().getConfigAdapterForModule(StaffChatModule.ID, StaffChatConfigAdapter.class);
-            } catch (NoModuleException | IncorrectAdapterTypeException e) {
-                e.printStackTrace();
-                return new StaffChatConfig();
-            }
-        }
-
-        return scca.getNodeOrDefault();
     }
 
     @Override
@@ -70,15 +58,14 @@ public class StaffChatMessageChannel implements NucleusChatChannel.StaffChat {
             sender = Sponge.getServer().getConsole();
         }
 
-        StaffChatConfig c = getConfig();
-        Text prefix = chatUtil.getMessageFromTemplate(c.getMessageTemplate(), (CommandSource)sender, false);
-        getMembers().forEach(x -> x.sendMessage(Text.of(prefix, c.getColour(), original)));
+        Text prefix = template.getForCommandSource((CommandSource)sender);
+        getMembers().forEach(x -> x.sendMessage(Text.of(prefix, colour, original)));
     }
 
     @Override
     @Nonnull
     public Collection<MessageReceiver> getMembers() {
-        List<MessageReceiver> c = Sponge.getServer().getOnlinePlayers().stream().filter(x -> x.hasPermission(getPermission())).collect(Collectors.toList());
+        List<MessageReceiver> c = Sponge.getServer().getOnlinePlayers().stream().filter(x -> x.hasPermission(basePerm)).collect(Collectors.toList());
         c.add(Sponge.getServer().getConsole());
         return c;
     }
@@ -89,14 +76,10 @@ public class StaffChatMessageChannel implements NucleusChatChannel.StaffChat {
 
     private void onReload() {
         plugin.getConfigAdapter(StaffChatModule.ID, StaffChatConfigAdapter.class)
-                .ifPresent(x -> this.formatting = x.getNodeOrDefault().isIncludeStandardChatFormatting());
-    }
-
-    private String getPermission() {
-        if (basePerm == null) {
-            basePerm = plugin.getPermissionRegistry().getPermissionsForNucleusCommand(StaffChatCommand.class).getBase();
-        }
-
-        return basePerm;
+                .ifPresent(x -> {
+                    this.formatting = x.getNodeOrDefault().isIncludeStandardChatFormatting();
+                    this.template = x.getNodeOrDefault().getMessageTemplate();
+                    this.colour = x.getNodeOrDefault().getColour();
+                });
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/config/StaffChatConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/config/StaffChatConfig.java
@@ -5,6 +5,8 @@
 package io.github.nucleuspowered.nucleus.modules.staffchat.config;
 
 import io.github.nucleuspowered.nucleus.NameUtil;
+import io.github.nucleuspowered.nucleus.configurate.annotations.Default;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 import org.spongepowered.api.text.format.TextColor;
@@ -16,12 +18,13 @@ public class StaffChatConfig {
     private boolean includeStandardChatFormatting = false;
 
     @Setting(value = "message-template", comment = "config.staffchat.template")
-    private String messageTemplate = "&b[STAFF] &r{{displayname}}&b: ";
+    @Default(value = "&b[STAFF] &r{{displayname}}&b: ", saveDefaultIfNull = true)
+    private NucleusTextTemplate messageTemplate;
 
     @Setting(value = "message-colour", comment = "config.staffchat.colour")
     private String messageColour = "b";
 
-    public String getMessageTemplate() {
+    public NucleusTextTemplate getMessageTemplate() {
         return messageTemplate;
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/config/StaffChatConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/config/StaffChatConfig.java
@@ -6,7 +6,7 @@ package io.github.nucleuspowered.nucleus.modules.staffchat.config;
 
 import io.github.nucleuspowered.nucleus.NameUtil;
 import io.github.nucleuspowered.nucleus.configurate.annotations.Default;
-import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplate;
+import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplateImpl;
 import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 import org.spongepowered.api.text.format.TextColor;
@@ -19,12 +19,12 @@ public class StaffChatConfig {
 
     @Setting(value = "message-template", comment = "config.staffchat.template")
     @Default(value = "&b[STAFF] &r{{displayname}}&b: ", saveDefaultIfNull = true)
-    private NucleusTextTemplate messageTemplate;
+    private NucleusTextTemplateImpl messageTemplate;
 
     @Setting(value = "message-colour", comment = "config.staffchat.colour")
     private String messageColour = "b";
 
-    public NucleusTextTemplate getMessageTemplate() {
+    public NucleusTextTemplateImpl getMessageTemplate() {
         return messageTemplate;
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/util/PaginationBuilderWrapper.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/util/PaginationBuilderWrapper.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.util;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import io.github.nucleuspowered.nucleus.Util;
+import org.spongepowered.api.service.pagination.PaginationList;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+
+import java.util.List;
+import java.util.ListIterator;
+
+import javax.annotation.Nullable;
+
+@NonnullByDefault
+public class PaginationBuilderWrapper implements PaginationList.Builder {
+
+    private final PaginationList.Builder builder;
+    @Nullable private List<Text> texts = null;
+
+    public PaginationBuilderWrapper(PaginationList.Builder builder) {
+        this.builder = builder;
+    }
+
+    @Override public PaginationList.Builder contents(Iterable<Text> contents) {
+        texts = Lists.newArrayList(contents);
+        return this;
+    }
+
+    @Override public PaginationList.Builder contents(Text... contents) {
+        texts = Lists.newArrayList(contents);
+        return this;
+    }
+
+    @Override public PaginationList.Builder title(Text title) {
+        return this.builder.title(title);
+    }
+
+    @Override public PaginationList.Builder header(@Nullable Text header) {
+        return this.builder.header(header);
+    }
+
+    @Override public PaginationList.Builder footer(@Nullable Text footer) {
+        return this.builder.footer(footer);
+    }
+
+    @Override public PaginationList.Builder padding(Text padding) {
+        return this.builder.padding(padding);
+    }
+
+    @Override public PaginationList.Builder linesPerPage(int linesPerPage) {
+        return this.builder.linesPerPage(linesPerPage);
+    }
+
+    @Override public PaginationList build() {
+        Preconditions.checkNotNull(texts);
+        ListIterator<Text> text = texts.listIterator();
+        while (text.hasNext()) {
+            Text t = text.next();
+            if (t.toPlain().isEmpty()) {
+                text.set(Util.NOT_EMPTY);
+            }
+        }
+
+        return this.builder.contents(texts).build();
+    }
+
+    @Override public PaginationList.Builder from(PaginationList value) {
+        return this.builder.from(value);
+    }
+
+    @Override public PaginationList.Builder reset() {
+        return this.builder.reset();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/util/Tuples.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/util/Tuples.java
@@ -6,6 +6,11 @@ package io.github.nucleuspowered.nucleus.util;
 
 import org.spongepowered.api.util.Tuple;
 
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import javax.annotation.Nullable;
+
 public final class Tuples {
 
     private Tuples() {}
@@ -14,12 +19,40 @@ public final class Tuples {
         return new Tuple<>(a, b);
     }
 
+    public static <A, B> NullableTuple<A, B> ofNullable(A a, B b) {
+        return new NullableTuple<>(a, b);
+    }
+
     public static <A, B, C> Tri<A, B, C> of(A a, B b, C c) {
         return new Tri<>(a, b, c);
     }
 
     public static <A, B, C, D> Quad<A, B, C, D> of(A a, B b, C c, D d) {
         return new Quad<>(a, b, c, d);
+    }
+
+    public static class NullableTuple<A, B> {
+
+        public NullableTuple(@Nullable A first, @Nullable B second) {
+            this.first = first;
+            this.second = second;
+        }
+
+        @Nullable private final A first;
+        @Nullable private final B second;
+
+        public Optional<A> getFirst() {
+            return Optional.ofNullable(first);
+        }
+
+        public Optional<B> getSecond() {
+            return Optional.ofNullable(second);
+        }
+
+        public void mapIfPresent(Consumer<A> firstConsumer, Consumer<B> secondConsumer) {
+            getFirst().ifPresent(firstConsumer);
+            getSecond().ifPresent(secondConsumer);
+        }
     }
 
     public static class Tri<A, B, C> {

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -270,7 +270,9 @@ config.blacklist.blockedactions=These are global toggles, if any are false, the 
 
 config.rules.ruleset=The server rules, displayed when /rules is run. Supports Minecraft colour codes, prefixed with ampersands (&).
 
-config.staffchat.template='The prefix to the staff chat message. Use the following tokens: {{prefix}} - prefix (set as an option in a permission plugin), {{suffix}} - suffix (set as an option in a permission plugin), {{name}} - real name, {{displayname}} - display name.'
+config.staffchat.template='The prefix to the staff chat message. Use the following tokens: {{prefix}} - prefix (set as an option in a permission \
+  plugin), {{suffix}} - suffix (set as an option in a permission plugin), {{name}} - real name, {{displayname}} - display name.'\n\
+  If "include-standard-chat-formatting" is set to "true", the formatting will be appended to this prefix.
 
 config.staffchat.colour=A Minecraft colour code the denotes the colour to display Staff Chat channel messages in.
 config.staffchat.includestd=If true, Nucleus will include all the normal chat tags in the message, in addition to the prefix.

--- a/src/test/java/io/github/nucleuspowered/nucleus/tests/TestBase.java
+++ b/src/test/java/io/github/nucleuspowered/nucleus/tests/TestBase.java
@@ -20,6 +20,7 @@ import io.github.nucleuspowered.nucleus.internal.messages.ResourceMessageProvide
 import io.github.nucleuspowered.nucleus.internal.qsml.NucleusConfigAdapter;
 import io.github.nucleuspowered.nucleus.internal.services.WarmupManager;
 import io.github.nucleuspowered.nucleus.internal.teleport.NucleusTeleportHandler;
+import io.github.nucleuspowered.nucleus.internal.text.TokenHandler;
 import io.github.nucleuspowered.nucleus.util.ThrowableAction;
 import org.junit.BeforeClass;
 import org.slf4j.Logger;
@@ -216,6 +217,10 @@ public abstract class TestBase {
 
         @Override
         public NucleusTeleportHandler getTeleportHandler() {
+            return null;
+        }
+
+        @Override public TokenHandler getTokenHandler() {
             return null;
         }
 


### PR DESCRIPTION
**Please note, this is INTERNAL, and does not affect any APIs, including the Token service**

Currently, when we build a text, we always build it from scratch. The performance of this isn't great, because there is a lot of regex involved. Thankfully, Sponge provides the handy "TextTemplate", which is really underused. So, now, when we build a string up, we can store it in here, and get the tokens dynamically, hopefully reducing the impact on the server.

No user intervention is needed, this will just work with (hopefully) improved performance.

This updates:

* /motd and /info
* /broadcast
* /afk
* Chat and /me
* Messages
* Command and Social Spy
* Connection messages
* Staff Chat

The Pagination system has a weird bug where it doesn't count empty lines when throwing out lines to the client. We now replace the empty text instances with spaces to make sure it works correctly.

I've also added a way to be able to integrate PlaceholderAPI in the future via a separate bridge plugin - see #615 for more info.

Other changes:

* Updated the Default annotation on the config: don't create a full blown NucleusTextTemplate unless we don't have anything to load in.
* Add method to join texts together and let colours/styles flow.
* Made some commands reloadable, not constructing the Config classes each time.