### PR TITLE
Add Nucleus teleportation events and hook up the Jail system to use them.

### DIFF
--- a/nucleus-api/src/main/java/io/github/nucleuspowered/nucleus/api/events/NucleusTeleportEvent.java
+++ b/nucleus-api/src/main/java/io/github/nucleuspowered/nucleus/api/events/NucleusTeleportEvent.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.api.events;
+
+import org.spongepowered.api.entity.Transform;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.entity.MoveEntityEvent;
+import org.spongepowered.api.event.entity.living.humanoid.player.TargetPlayerEvent;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.api.world.World;
+
+/**
+ * These events are fired <em>before</em> teleportation actually happens.
+ */
+@NonnullByDefault
+public interface NucleusTeleportEvent extends TargetPlayerEvent, CancelMessage {
+
+    /**
+     * Indicates that a teleport request (such as through <code>/tpa</code>) is being sent.
+     */
+    interface Request extends NucleusTeleportEvent {
+
+        /**
+         * The recipient of the request.
+         *
+         * @return The {@link Player} in question.
+         */
+        @Override Player getTargetEntity();
+
+        /**
+         * Called when the root cause wants to teleport to the target player (like /tpa).
+         */
+        interface CauseToPlayer extends Request {}
+
+        /**
+         * Called when the root cause wants the target player to teleport to them (like /tpahere).
+         */
+        interface PlayerToCause extends Request {}
+    }
+
+    /**
+     * Called when a player is about to be teleported through the Nucleus system.
+     */
+    interface AboutToTeleport extends NucleusTeleportEvent {
+
+        /**
+         * Gets the proposed location of the entity that will be teleported.
+         *
+         * @return The {@link Transform} that the player would teleport to. Note that for {@link Request}, this might change when the
+         * teleportation gets underway - any changes should be made during the {@link MoveEntityEvent.Teleport} event.
+         */
+        Transform<World> getToTransform();
+
+        /**
+         * The {@link Player} to be teleported.
+         *
+         * @return The {@link Player} in question.
+         */
+        @Override Player getTargetEntity();
+    }
+
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/NucleusPlugin.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/NucleusPlugin.java
@@ -257,7 +257,7 @@ public class NucleusPlugin extends Nucleus {
         try {
             Sponge.getEventManager().post(new BaseModuleEvent.AboutToConstructEvent(this));
             logger.info(messageProvider.getMessageWithFormat("startup.moduleloading", PluginInfo.NAME));
-            moduleContainer.loadModules(false);
+            moduleContainer.loadModules(true);
 
             if (moduleContainer.getConfigAdapterForModule("core", CoreConfigAdapter.class).getNodeOrDefault().isErrorOnStartup()) {
                 throw new IllegalStateException("In main.conf, core.simulate-error-on-startup is set to TRUE. Remove this config entry to allow Nucleus to start. Simulating error and disabling Nucleus.");

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/commands/JailCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/commands/JailCommand.java
@@ -12,7 +12,6 @@ import io.github.nucleuspowered.nucleus.argumentparsers.SelectorWrapperArgument;
 import io.github.nucleuspowered.nucleus.argumentparsers.TimespanArgument;
 import io.github.nucleuspowered.nucleus.iapi.data.JailData;
 import io.github.nucleuspowered.nucleus.internal.LocationData;
-import io.github.nucleuspowered.nucleus.internal.PermissionRegistry;
 import io.github.nucleuspowered.nucleus.internal.annotations.NoCooldown;
 import io.github.nucleuspowered.nucleus.internal.annotations.NoCost;
 import io.github.nucleuspowered.nucleus.internal.annotations.NoWarmup;
@@ -46,8 +45,6 @@ import java.util.Optional;
 @RegisterCommand({"jail", "unjail", "togglejail"})
 public class JailCommand extends AbstractCommand<CommandSource> {
 
-    public static final String notifyPermission = PermissionRegistry.PERMISSIONS_PREFIX + "jail.notify";
-
     @Inject private JailHandler handler;
     private final String playerKey = "subject";
     private final String jailKey = "jail";
@@ -55,16 +52,12 @@ public class JailCommand extends AbstractCommand<CommandSource> {
     private final String reasonKey = "reason";
 
     @Override
-    public Map<String, PermissionInformation> permissionsToRegister() {
-        Map<String, PermissionInformation> m = new HashMap<>();
-        m.put(notifyPermission, PermissionInformation.getWithTranslation("permission.jail.notify", SuggestedLevel.MOD));
-        return m;
-    }
-
-    @Override
     public Map<String, PermissionInformation> permissionSuffixesToRegister() {
         Map<String, PermissionInformation> m = new HashMap<>();
+        m.put("notify", PermissionInformation.getWithTranslation("permission.jail.notify", SuggestedLevel.MOD));
         m.put("offline", PermissionInformation.getWithTranslation("permission.jail.offline", SuggestedLevel.MOD));
+        m.put("teleportjailed", PermissionInformation.getWithTranslation("permission.jail.teleportjailed", SuggestedLevel.ADMIN));
+        m.put("teleporttojailed", PermissionInformation.getWithTranslation("permission.jail.teleporttojailed", SuggestedLevel.ADMIN));
         return m;
     }
 
@@ -135,7 +128,7 @@ public class JailCommand extends AbstractCommand<CommandSource> {
         }
 
         if (handler.jailPlayer(user, jd)) {
-            MutableMessageChannel mc = MessageChannel.permission(notifyPermission).asMutable();
+            MutableMessageChannel mc = MessageChannel.permission(permissions.getPermissionWithSuffix("notify")).asMutable();
             mc.addMember(src);
             mc.send(message);
             mc.send(plugin.getMessageProvider().getTextMessageWithFormat("standard.reason", reason));

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/handlers/JailHandler.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/handlers/JailHandler.java
@@ -20,6 +20,8 @@ import io.github.nucleuspowered.nucleus.modules.jail.datamodules.JailUserDataMod
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.NamedCause;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
@@ -104,7 +106,7 @@ public class JailHandler implements NucleusJailService {
             Sponge.getScheduler().createSyncExecutor(plugin).execute(() -> {
                 Player player = user.getPlayer().get();
                 plugin.getTeleportHandler().teleportPlayer(player, owl.get().getLocation().get(), owl.get().getRotation(),
-                    NucleusTeleportHandler.TeleportMode.NO_CHECK);
+                    NucleusTeleportHandler.TeleportMode.NO_CHECK, Cause.of(NamedCause.owner(plugin)));
                 modularUserService.get(FlyUserDataModule.class).setFlying(false);
             });
         } else {

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportAskCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportAskCommand.java
@@ -11,16 +11,21 @@ import io.github.nucleuspowered.nucleus.internal.annotations.NotifyIfAFK;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.command.ReturnMessageException;
 import io.github.nucleuspowered.nucleus.internal.command.StandardAbstractCommand;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SubjectPermissionCache;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import io.github.nucleuspowered.nucleus.modules.teleport.events.RequestEvent;
 import io.github.nucleuspowered.nucleus.modules.teleport.handlers.TeleportHandler;
+import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.args.CommandElement;
 import org.spongepowered.api.command.args.GenericArguments;
 import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.NamedCause;
 import org.spongepowered.api.text.Text;
 
 import java.time.Instant;
@@ -73,6 +78,13 @@ public class TeleportAskCommand extends StandardAbstractCommand<Player> {
         if (src.equals(target)) {
             src.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat("command.teleport.self"));
             return CommandResult.empty();
+        }
+
+        // Before we do all this, check the event.
+        RequestEvent.CauseToPlayer event = new RequestEvent.CauseToPlayer(Cause.of(NamedCause.owner(cache.getSubject())), target);
+        if (Sponge.getEventManager().post(event)) {
+            throw new ReturnMessageException(
+                    event.getCancelMessage().orElseGet(() -> plugin.getMessageProvider().getTextMessageWithFormat("command.tpa.eventfailed")));
         }
 
         TeleportHandler.TeleportBuilder tb = tpHandler.getBuilder().setFrom(src).setTo(target).setSafe(!args.<Boolean>getOne("f").orElse(false));

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportAskHereCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/commands/TeleportAskHereCommand.java
@@ -13,16 +13,21 @@ import io.github.nucleuspowered.nucleus.internal.annotations.NotifyIfAFK;
 import io.github.nucleuspowered.nucleus.internal.annotations.Permissions;
 import io.github.nucleuspowered.nucleus.internal.annotations.RegisterCommand;
 import io.github.nucleuspowered.nucleus.internal.annotations.RunAsync;
+import io.github.nucleuspowered.nucleus.internal.command.ReturnMessageException;
 import io.github.nucleuspowered.nucleus.internal.command.StandardAbstractCommand;
 import io.github.nucleuspowered.nucleus.internal.permissions.PermissionInformation;
 import io.github.nucleuspowered.nucleus.internal.permissions.SubjectPermissionCache;
 import io.github.nucleuspowered.nucleus.internal.permissions.SuggestedLevel;
+import io.github.nucleuspowered.nucleus.modules.teleport.events.RequestEvent;
 import io.github.nucleuspowered.nucleus.modules.teleport.handlers.TeleportHandler;
+import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.args.CommandElement;
 import org.spongepowered.api.command.args.GenericArguments;
 import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.NamedCause;
 import org.spongepowered.api.text.Text;
 
 import java.time.Instant;
@@ -72,6 +77,13 @@ public class TeleportAskHereCommand extends StandardAbstractCommand<Player> {
         if (src.equals(target)) {
             src.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat("command.teleport.self"));
             return CommandResult.empty();
+        }
+
+        // Before we do all this, check the event.
+        RequestEvent.PlayerToCause event = new RequestEvent.PlayerToCause(Cause.of(NamedCause.owner(cache.getSubject())), target);
+        if (Sponge.getEventManager().post(event)) {
+            throw new ReturnMessageException(
+                    event.getCancelMessage().orElseGet(() -> plugin.getMessageProvider().getTextMessageWithFormat("command.tpa.eventfailed")));
         }
 
         SubjectPermissionCache<Player> targetCache = new SubjectPermissionCache<>(target);

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/events/AboutToTeleportEvent.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/events/AboutToTeleportEvent.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.teleport.events;
+
+import io.github.nucleuspowered.nucleus.api.events.NucleusTeleportEvent;
+import org.spongepowered.api.entity.Transform;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.impl.AbstractEvent;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.api.world.World;
+
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+@NonnullByDefault
+public class AboutToTeleportEvent extends AbstractEvent implements NucleusTeleportEvent.AboutToTeleport {
+
+    @Nullable private Text cancelMessage;
+    private boolean isCancelled = false;
+
+    private final Cause cause;
+    private final Transform<World> toTransform;
+    private final Player teleportingEntity;
+
+    public AboutToTeleportEvent(Cause cause, Transform<World> toTransform, Player teleportingEntity) {
+        this.cause = cause;
+        this.toTransform = toTransform;
+        this.teleportingEntity = teleportingEntity;
+    }
+
+    @Override public Optional<Text> getCancelMessage() {
+        return Optional.ofNullable(cancelMessage);
+    }
+
+    @Override public void setCancelMessage(@Nullable Text message) {
+        this.cancelMessage = message;
+    }
+
+    @Override public Transform<World> getToTransform() {
+        return toTransform;
+    }
+
+    @Override public Player getTargetEntity() {
+        return teleportingEntity;
+    }
+
+    @Override public boolean isCancelled() {
+        return isCancelled;
+    }
+
+    @Override public void setCancelled(boolean cancel) {
+        this.isCancelled = cancel;
+    }
+
+    @Override public Cause getCause() {
+        return this.cause;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/events/RequestEvent.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/events/RequestEvent.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.teleport.events;
+
+import io.github.nucleuspowered.nucleus.api.events.NucleusTeleportEvent;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.impl.AbstractEvent;
+import org.spongepowered.api.text.Text;
+
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+public abstract class RequestEvent extends AbstractEvent implements NucleusTeleportEvent.Request {
+
+    @Nullable private Text cancelMessage;
+    private boolean isCancelled = false;
+
+    private final Cause cause;
+    private final Player targetEntity;
+
+    private RequestEvent(Cause cause, Player targetEntity) {
+        this.cause = cause;
+        this.targetEntity = targetEntity;
+    }
+
+    @Override public Optional<Text> getCancelMessage() {
+        return Optional.ofNullable(cancelMessage);
+    }
+
+    @Override public void setCancelMessage(@Nullable Text message) {
+        this.cancelMessage = message;
+    }
+
+    @Override public Player getTargetEntity() {
+        return targetEntity;
+    }
+
+    @Override public boolean isCancelled() {
+        return this.isCancelled;
+    }
+
+    @Override public void setCancelled(boolean cancel) {
+        this.isCancelled = cancel;
+    }
+
+    @Override public Cause getCause() {
+        return this.cause;
+    }
+
+    public static class CauseToPlayer extends RequestEvent implements NucleusTeleportEvent.Request.CauseToPlayer {
+
+        public CauseToPlayer(Cause cause, Player targetEntity) {
+            super(cause, targetEntity);
+        }
+    }
+
+    public static class PlayerToCause extends RequestEvent implements NucleusTeleportEvent.Request.PlayerToCause {
+
+        public PlayerToCause(Cause cause, Player targetEntity) {
+            super(cause, targetEntity);
+        }
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/handlers/TeleportHandler.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/teleport/handlers/TeleportHandler.java
@@ -20,6 +20,8 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.living.player.User;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.NamedCause;
 import org.spongepowered.api.scheduler.Task;
 import org.spongepowered.api.service.permission.Subject;
 import org.spongepowered.api.text.Text;
@@ -165,7 +167,7 @@ public class TeleportHandler {
                 NucleusTeleportHandler.TeleportMode mode = safe ? tpHandler.getTeleportModeForPlayer(playerToTeleport) :
                     NucleusTeleportHandler.TeleportMode.NO_CHECK;
 
-                if (!tpHandler.teleportPlayer(playerToTeleport, playerToTeleportTo.getTransform(), mode)) {
+                if (!tpHandler.teleportPlayer(playerToTeleport, playerToTeleportTo.getTransform(), mode, Cause.of(NamedCause.owner(this.source)))) {
                     if (!silentSource) {
                         source.sendMessage(NucleusPlugin.getNucleus().getMessageProvider().getTextMessageWithFormat("teleport.nosafe"));
                     }

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -968,14 +968,16 @@ command.teleport.player.noself=&cDo not specify yourself when teleporting.
 
 command.tpall.broadcast=&e{0} &chas enforced a teleport of all players to them.
 command.tpaall.success=&aYour request to teleport everyone to you has been sent successfully.
+command.tpall.cancelled=&cThe following players did not receive a request: {0}.
 
-command.tppos.nosafe=&cCould not teleport: no safe spot was found.
+command.tppos.nosafe=&cCould not teleport: no safe spot was found or teleportation was cancelled.
 command.tppos.success.other=&aTeleportation of &e{0}&a has been completed.
 command.tppos.success.self=&aYou have been teleported.
 command.tppos.ysmall=&cThe y co-ordinate must be positive.
 command.tppos.invalid=&cThe supplied co-ordinates are invalid.
 command.tppos.worldborder=&cThe supplied co-ordinates are outside of the world border.
 command.tppos.fromchunk=&eChunk co-ordinates supplied - attempting teleport to the middle of the chunk at ({0}, {1}, {2}).
+command.tppos.cancelledevent=&cCould not teleport: teleportation was cancelled.
 
 command.tpaccept.nothing=&cThere are no teleport requests for you to accept.
 command.tpaccept.success=&aYou have accepted the teleport request.
@@ -984,6 +986,7 @@ command.tpdeny.fail=&cThere are no teleport requests for you to deny.
 
 command.tpahere.question=&e{0} has requested that you teleport to them.
 command.tpa.question=&e{0} has requested that they teleport to you.
+command.tpa.eventfailed=&cYour request was cancelled, no reason was given.
 
 command.tpask.sent=&aA teleport request was sent to &e{0}&a.
 
@@ -1426,6 +1429,10 @@ jail.playernotify.standard=&cYou are jailed and cannot interact.
 jail.playernotify.time=&cYou are jailed and cannot interact for &e{0}&c.
 jail.elapsed=&aYou have served your time and are now unjailed.
 jail.muteonchat=&cYou cannot speak whilst in jail.
+jail.teleportcause.isjailed=&cYou cannot send teleport requests because you are jailed.
+jail.teleporttarget.isjailed=&cYou cannot send teleport requests to &f{0} &cbecause they are jailed.
+jail.abouttoteleporttarget.isjailed=&cYou cannot teleport &f{0} &cbecause they are jailed.
+jail.abouttoteleportcause.targetisjailed=&cYou cannot teleport to &f{0} &cbecause they are jailed.
 
 # Messsages
 message.noreply=&cThere is no-one for you to reply to.
@@ -1536,6 +1543,9 @@ permission.tempban.offline=Allows the user to temp ban offline users.
 permission.ban.offline=Allows the user to ban offline users.
 permission.ban.exempt.target=Exempts the user from being a target of the /ban command.
 permission.jail.offline=Allows the user to jail offline users.
+
+permission.jail.teleportjailed=Allows the player to teleport jailed players.
+permission.jail.teleporttojailed=Allows the player to teleport to jailed players.
 
 permission.nick.others=Allows the user to change other''s nicknames.
 permission.nick.colour=Allows the user to colour their nickname.


### PR DESCRIPTION
The problem is that I can't set a cause when I set a player's location, so for now, I have to do it this way.

Adds APIs:

* `NucleusTeleportEvent.Request` - for `/tpa` and `/tpahere`
* `NucleusTeleportEvent.AboutToTeleport` - for other teleport actions.

Partially works towards #679
