### PR TITLE
Require config to use nucleus.socialspy.force

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/message/config/MessageConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/message/config/MessageConfig.java
@@ -43,6 +43,10 @@ public class MessageConfig {
         return socialSpy.messageSocialSpyPrefix;
     }
 
+    public boolean isSocialSpyAllowForced() {
+        return socialSpy.allowForced;
+    }
+
     public boolean isSocialSpyLevels() {
         return socialSpy.socialSpyLevels;
     }
@@ -76,6 +80,9 @@ public class MessageConfig {
         @Setting(value = "msg-prefix", comment = "config.message.socialspy.prefix")
         @Default(value = "&7[SocialSpy] [{{fromDisplay}}&7 -> {{toDisplay}}&7]: &r", saveDefaultIfNull = true)
         private NucleusTextTemplateImpl messageSocialSpyPrefix;
+
+        @Setting(value = "allow-forced", comment = "config.message.socialspy.force")
+        private boolean allowForced = false;
 
         @Setting(value = "use-levels", comment = "config.message.socialspy.levels")
         private boolean socialSpyLevels = false;

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/message/handlers/MessageHandler.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/message/handlers/MessageHandler.java
@@ -113,7 +113,7 @@ public class MessageHandler implements NucleusPrivateMessagingService {
     }
 
     @Override public Tristate forcedSocialSpyState(User user) {
-        if (socialspypermissions.testSuffix(user, "base")) {
+        if (messageConfig.isSocialSpyAllowForced() && socialspypermissions.testSuffix(user, "base")) {
             if (socialspypermissions.testSuffix(user, "force")) {
                 return Tristate.TRUE;
             }

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -273,6 +273,7 @@ config.message.receiver.prefix='The prefix for received messages. This is displa
 config.message.socialspy.mutedshow=If true, show messages that players try to send and are cancelled (usually due to being muted).
 config.message.socialspy.mutedtag=The tag to show at the beginning of a Social Spy message when a player is muted (or otherwise has the message cancelled).
 config.message.socialspy.playeronly=If true, only messages sent by players will be visible via Social Spy.
+config.message.socialspy.force=If true, Nucleus will check the "nucleus.socialspy.force" permission on the subject to disallow disabling Social Spy.
 config.message.socialspy.levels=If true, Nucleus will check the "nucleus.socialspy.level" option on the subject for an integer level. A level can see their messages from and to players with levels below their own, \n\
 unless "same-levels-can-see-each-other" is set to true, in which case, social spies can see messages from their own level. Players have a default level of 0.
 config.message.socialspy.serverlevels=Sets the social spy level of the server and any custom message targets.


### PR DESCRIPTION
This should prevent Nucleus users from accidentally using this potentially false-bug report generating feature/