### PR TITLE
Fix up Sponge API 7 permission changes

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/NucleusPlugin.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/NucleusPlugin.java
@@ -758,19 +758,17 @@ public class NucleusPlugin extends Nucleus {
     @Override protected void registerPermissions() {
         Optional<PermissionService> ops = Sponge.getServiceManager().provide(PermissionService.class);
         if (ops.isPresent()) {
-            Optional<PermissionDescription.Builder> opdb = ops.get().newDescriptionBuilder(this);
-            if (opdb.isPresent()) {
+            PermissionDescription.Builder opdb = ops.get().newDescriptionBuilder(this);
                 Map<String, PermissionInformation> m = this.getPermissionRegistry().getPermissions();
                 m.entrySet().stream().filter(x -> x.getValue().level == SuggestedLevel.ADMIN)
                         .filter(x -> x.getValue().isNormal)
-                        .forEach(k -> ops.get().newDescriptionBuilder(this).get().assign(PermissionDescription.ROLE_ADMIN, true).description(k.getValue().description).id(k.getKey()).register());
+                        .forEach(k -> ops.get().newDescriptionBuilder(this).assign(PermissionDescription.ROLE_ADMIN, true).description(k.getValue().description).id(k.getKey()).register());
                 m.entrySet().stream().filter(x -> x.getValue().level == SuggestedLevel.MOD)
                         .filter(x -> x.getValue().isNormal)
-                        .forEach(k -> ops.get().newDescriptionBuilder(this).get().assign(PermissionDescription.ROLE_STAFF, true).description(k.getValue().description).id(k.getKey()).register());
+                        .forEach(k -> ops.get().newDescriptionBuilder(this).assign(PermissionDescription.ROLE_STAFF, true).description(k.getValue().description).id(k.getKey()).register());
                 m.entrySet().stream().filter(x -> x.getValue().level == SuggestedLevel.USER)
                         .filter(x -> x.getValue().isNormal)
-                        .forEach(k -> ops.get().newDescriptionBuilder(this).get().assign(PermissionDescription.ROLE_USER, true).description(k.getValue().description).id(k.getKey()).register());
-            }
+                        .forEach(k -> ops.get().newDescriptionBuilder(this).assign(PermissionDescription.ROLE_USER, true).description(k.getValue().description).id(k.getKey()).register());
         }
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/Util.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/Util.java
@@ -73,9 +73,11 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -511,7 +513,17 @@ public class Util {
             // Try to cache already known values
             Function<Subject, Integer> subjectIntegerFunction = subject -> subjects.computeIfAbsent(subject, k -> k.getParents(contextSet).size());
 
+            // TODO: Make all completable futures - API 7 (seriously)
             return pl.getParents(contextSet).stream().distinct()
+                    .map(x -> {
+                        try {
+                            return x.resolve().get();
+                        } catch (InterruptedException | ExecutionException e) {
+                            e.printStackTrace();
+                            return null;
+                        }
+                    })
+                    .filter(Objects::nonNull)
                     .sorted(Comparator.comparingInt(subjectIntegerFunction::apply))
                     .collect(Collectors.toList());
         } catch (Exception e) {

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/permissions/SubjectPermissionCache.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/permissions/SubjectPermissionCache.java
@@ -10,6 +10,7 @@ import org.spongepowered.api.service.context.Context;
 import org.spongepowered.api.service.permission.Subject;
 import org.spongepowered.api.service.permission.SubjectCollection;
 import org.spongepowered.api.service.permission.SubjectData;
+import org.spongepowered.api.service.permission.SubjectReference;
 import org.spongepowered.api.util.Tristate;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 
@@ -23,6 +24,7 @@ import java.util.Set;
  *
  * @param <S> The type of {@link Subject}
  */
+// TODO: Remove when we go API 7+ only.
 @NonnullByDefault
 public class SubjectPermissionCache<S extends Subject> implements Subject {
 
@@ -61,6 +63,14 @@ public class SubjectPermissionCache<S extends Subject> implements Subject {
         return this.subject.getContainingCollection();
     }
 
+    @Override public SubjectReference asSubjectReference() {
+        return this.subject.asSubjectReference();
+    }
+
+    @Override public boolean isSubjectDataPersisted() {
+        return this.subject.isSubjectDataPersisted();
+    }
+
     @Override public SubjectData getSubjectData() {
         return this.subject.getSubjectData();
     }
@@ -79,12 +89,12 @@ public class SubjectPermissionCache<S extends Subject> implements Subject {
                 ? Tristate.TRUE : Tristate.FALSE;
     }
 
-    @Override public boolean isChildOf(Set<Context> contexts, Subject parent) {
-        return subject.isChildOf(contexts, parent);
+    @Override public boolean isChildOf(Set<Context> contexts, SubjectReference parent) {
+        return false;
     }
 
-    @Override public List<Subject> getParents(Set<Context> contexts) {
-        return subject.getParents(contexts);
+    @Override public List<SubjectReference> getParents(Set<Context> contexts) {
+        return this.subject.getParents(contexts);
     }
 
     @Override public Optional<String> getOption(Set<Context> contexts, String key) {

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/StaffChatMessageChannel.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/StaffChatMessageChannel.java
@@ -14,11 +14,10 @@ import io.github.nucleuspowered.nucleus.modules.staffchat.config.StaffChatConfig
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.source.ProxySource;
-import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.service.context.Context;
-import org.spongepowered.api.service.permission.Subject;
 import org.spongepowered.api.service.permission.SubjectCollection;
 import org.spongepowered.api.service.permission.SubjectData;
+import org.spongepowered.api.service.permission.SubjectReference;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.channel.MessageChannel;
 import org.spongepowered.api.text.channel.MessageReceiver;
@@ -130,6 +129,16 @@ public class StaffChatMessageChannel implements NucleusChatChannel.StaffChat {
         }
 
         @Override
+        public SubjectReference asSubjectReference() {
+            return getOriginalSource().asSubjectReference();
+        }
+
+        @Override
+        public boolean isSubjectDataPersisted() {
+            return getOriginalSource().isSubjectDataPersisted();
+        }
+
+        @Override
         public SubjectData getSubjectData() {
             return getOriginalSource().getSubjectData();
         }
@@ -145,12 +154,12 @@ public class StaffChatMessageChannel implements NucleusChatChannel.StaffChat {
         }
 
         @Override
-        public boolean isChildOf(Set<Context> contexts, Subject parent) {
+        public boolean isChildOf(Set<Context> contexts, SubjectReference parent) {
             return getOriginalSource().isChildOf(contexts, parent);
         }
 
         @Override
-        public List<Subject> getParents(Set<Context> contexts) {
+        public List<SubjectReference> getParents(Set<Context> contexts) {
             return getOriginalSource().getParents();
         }
 

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -583,6 +583,7 @@ args.gameprofile.format=&cThe name is not of the right format.
 
 args.permissiongroup.noservice=&cNo permissions plugin is installed.
 args.permissiongroup.nogroup=&cThe group "{0}" does not exist.
+args.permissiongroup.failed=&cCould not obtain a list of permission groups.
 
 args.info.noinfo=&cThere is no info page with the name "{0}".
 
@@ -1346,6 +1347,7 @@ command.delnick.success.other=&e{0}&a''s nickname was removed.
 
 command.list.playercount.base=&eThere are {0}/{1} players online.
 command.list.playercount.hidden=&eThere are {0}/{1} players online. {2} are hidden.
+command.list.permission.failed=&cCould not get permission groups, cannot list players.
 
 command.speed.negative=&cThe speed cannot be negative.
 command.speed.max=&cThe speed cannot be larger than {0}.

--- a/src/test/java/io/github/nucleuspowered/nucleus/tests/misc/ListGroupTests.java
+++ b/src/test/java/io/github/nucleuspowered/nucleus/tests/misc/ListGroupTests.java
@@ -14,11 +14,13 @@ import org.mockito.Mockito;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.service.context.Context;
 import org.spongepowered.api.service.permission.Subject;
+import org.spongepowered.api.service.permission.SubjectReference;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 @SuppressWarnings("SameParameterValue")
@@ -146,8 +148,9 @@ public class ListGroupTests {
         // The player is in both groups. Also, order is important.
         List<Subject> parents = Lists.newArrayList(admin, ace);
         Player player = Mockito.mock(Player.class);
-        Mockito.when(player.getParents()).thenReturn(parents);
-        Mockito.when(player.getParents(Mockito.anySet())).thenReturn(parents);
+        List<SubjectReference> lsr = getSubjectReferences(parents);
+        Mockito.when(player.getParents()).thenReturn(lsr);
+        Mockito.when(player.getParents(Mockito.anySet())).thenReturn(lsr);
 
         // Create our map.
         Map<Player, List<String>> map = Maps.newHashMap();
@@ -180,8 +183,9 @@ public class ListGroupTests {
         // The player is in both groups.
         List<Subject> parents = Lists.newArrayList(ace, admin);
         Player player = Mockito.mock(Player.class);
-        Mockito.when(player.getParents()).thenReturn(parents);
-        Mockito.when(player.getParents(Mockito.anySet())).thenReturn(parents);
+        List<SubjectReference> lsr = getSubjectReferences(parents);
+        Mockito.when(player.getParents()).thenReturn(lsr);
+        Mockito.when(player.getParents(Mockito.anySet())).thenReturn(lsr);
 
         // Create our map.
         Map<Player, List<String>> map = Maps.newHashMap();
@@ -228,8 +232,9 @@ public class ListGroupTests {
         // The player is in both groups. Also, order is important.
         List<Subject> parents = Lists.newArrayList(admin, ace);
         Player player = Mockito.mock(Player.class);
-        Mockito.when(player.getParents()).thenReturn(parents);
-        Mockito.when(player.getParents(Mockito.anySet())).thenReturn(parents);
+        List<SubjectReference> lsr = getSubjectReferences(parents);
+        Mockito.when(player.getParents()).thenReturn(lsr);
+        Mockito.when(player.getParents(Mockito.anySet())).thenReturn(lsr);
 
         // Create our map.
         Map<Player, List<String>> map = Maps.newHashMap();
@@ -262,8 +267,9 @@ public class ListGroupTests {
         List<Subject> parents = Lists.newArrayList(admin, ace);
         Player player = Mockito.mock(Player.class);
         Player player2 = Mockito.mock(Player.class);
-        Mockito.when(player.getParents()).thenReturn(parents);
-        Mockito.when(player.getParents(Mockito.anySet())).thenReturn(parents);
+        List<SubjectReference> lsr = getSubjectReferences(parents);
+        Mockito.when(player.getParents()).thenReturn(lsr);
+        Mockito.when(player.getParents(Mockito.anySet())).thenReturn(lsr);
         Mockito.when(player2.getParents()).thenReturn(Lists.newArrayList());
         Mockito.when(player2.getParents(Mockito.anySet())).thenReturn(Lists.newArrayList());
 
@@ -310,8 +316,9 @@ public class ListGroupTests {
             .then(x -> ls.stream().map(y -> y.getOption("nucleus.list.weight")).filter(Optional::isPresent).findFirst().orElse(Optional.empty()));
         Mockito.when(subject.getOption(Mockito.eq("nucleus.list.weight")))
             .then(x -> ls.stream().map(y -> y.getOption("nucleus.list.weight")).filter(Optional::isPresent).findFirst().orElse(Optional.empty()));
-        Mockito.when(subject.getParents()).thenReturn(Arrays.asList(parents));
-        Mockito.when(subject.getParents(Mockito.anySetOf(Context.class))).thenReturn(Arrays.asList(parents));
+        List<SubjectReference> lsr = getSubjectReferences(Arrays.asList(parents));
+        Mockito.when(subject.getParents()).thenReturn(lsr);
+        Mockito.when(subject.getParents(Mockito.anySetOf(Context.class))).thenReturn(lsr);
         return subject;
     }
 
@@ -321,8 +328,22 @@ public class ListGroupTests {
         Mockito.when(subject.getOption(Mockito.anySetOf(Context.class), Mockito.eq("nucleus.list.weight")))
             .thenReturn(Optional.of(String.valueOf(weight)));
         Mockito.when(subject.getOption(Mockito.eq("nucleus.list.weight"))).thenReturn(Optional.of(String.valueOf(weight)));
-        Mockito.when(subject.getParents()).thenReturn(Arrays.asList(parents));
-        Mockito.when(subject.getParents(Mockito.anySetOf(Context.class))).thenReturn(Arrays.asList(parents));
+        List<SubjectReference> lsr = getSubjectReferences(Arrays.asList(parents));
+        Mockito.when(subject.getParents()).thenReturn(lsr);
+        Mockito.when(subject.getParents(Mockito.anySetOf(Context.class))).thenReturn(lsr);
         return subject;
+    }
+
+    private static List<SubjectReference> getSubjectReferences(List<Subject> ls) {
+        return ls.stream().map(x -> {
+            SubjectReference srmock = Mockito.mock(SubjectReference.class);
+            Mockito.when(srmock.resolve()).then(y -> {
+                CompletableFuture<Subject> c = new CompletableFuture<>();
+                c.complete(x);
+                return c;
+            });
+
+            return srmock;
+        }).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Mostly so I can see the diff clearly. This is currently minimal changes to make this work, more extensive changes will come later.

As a result of the large changes to come in API 7 (and 8), API 5 and 6 will transition to LTS only from 1.1 - while it wasn't the plan to move LTS to 1.1, it will be too much work otherwise.