### PR TITLE
Add custom context key for formatting

### DIFF
--- a/nucleus-api/src/main/java/io/github/nucleuspowered/nucleus/api/EventContexts.java
+++ b/nucleus-api/src/main/java/io/github/nucleuspowered/nucleus/api/EventContexts.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.api;
+
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.EventContextKey;
+import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
+
+/**
+ * Contexts that may appear in the {@link Cause} of some events.
+ */
+public class EventContexts {
+
+    private EventContexts() {}
+
+    /**
+     * A context that indicates whether the Nucleus chat events will perform its own formatting.
+     *
+     * <p>
+     *     For the ID, see {@link Identifiers#SHOULD_FORMAT_CHANNEL}
+     * </p>
+     */
+    public static final EventContextKey<Boolean> SHOULD_FORMAT_CHANNEL =
+            DummyObjectProvider.createExtendedFor(EventContextKey.class, "SHOULD_FORMAT_CHANNEL");
+
+    public static class Identifiers {
+
+        private Identifiers() {}
+
+        /**
+         * ID for {@link EventContexts#SHOULD_FORMAT_CHANNEL}
+         */
+        public static final String SHOULD_FORMAT_CHANNEL = "nucleus:should_format_channel";
+
+    }
+
+}

--- a/nucleus-api/src/main/java/io/github/nucleuspowered/nucleus/api/events/NucleusChangeNicknameEvent.java
+++ b/nucleus-api/src/main/java/io/github/nucleuspowered/nucleus/api/events/NucleusChangeNicknameEvent.java
@@ -4,6 +4,7 @@
  */
 package io.github.nucleuspowered.nucleus.api.events;
 
+import io.github.nucleuspowered.nucleus.api.annotations.MightOccurAsync;
 import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.user.TargetUserEvent;
 import org.spongepowered.api.text.Text;
@@ -11,6 +12,7 @@ import org.spongepowered.api.text.Text;
 /**
  * Fired when a player requests a nickname.
  */
+@MightOccurAsync
 public interface NucleusChangeNicknameEvent extends Cancellable, TargetUserEvent {
 
     /**

--- a/nucleus-api/src/main/java/io/github/nucleuspowered/nucleus/api/events/NucleusNameBanEvent.java
+++ b/nucleus-api/src/main/java/io/github/nucleuspowered/nucleus/api/events/NucleusNameBanEvent.java
@@ -4,6 +4,7 @@
  */
 package io.github.nucleuspowered.nucleus.api.events;
 
+import io.github.nucleuspowered.nucleus.api.annotations.MightOccurAsync;
 import org.spongepowered.api.event.Event;
 
 /**
@@ -28,10 +29,12 @@ public interface NucleusNameBanEvent extends Event {
     /**
      * Fired when a regular expression is banned.
      */
+    @MightOccurAsync
     interface Banned extends NucleusNameBanEvent {}
 
     /**
      * Fired when a regular expression is unbanned.
      */
+    @MightOccurAsync
     interface Unbanned extends NucleusNameBanEvent {}
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/NucleusPlugin.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/NucleusPlugin.java
@@ -29,6 +29,7 @@ import io.github.nucleuspowered.nucleus.dataservices.dataproviders.DataProviders
 import io.github.nucleuspowered.nucleus.dataservices.loaders.UserDataManager;
 import io.github.nucleuspowered.nucleus.dataservices.loaders.WorldDataManager;
 import io.github.nucleuspowered.nucleus.dataservices.modular.ModularGeneralService;
+import io.github.nucleuspowered.nucleus.internal.CatalogTypeFinalStaticProcessor;
 import io.github.nucleuspowered.nucleus.internal.CommandPermissionHandler;
 import io.github.nucleuspowered.nucleus.internal.EconHelper;
 import io.github.nucleuspowered.nucleus.internal.InternalServiceManager;
@@ -70,6 +71,7 @@ import org.spongepowered.api.asset.Asset;
 import org.spongepowered.api.config.ConfigDir;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.Order;
+import org.spongepowered.api.event.game.state.GameInitializationEvent;
 import org.spongepowered.api.event.game.state.GamePostInitializationEvent;
 import org.spongepowered.api.event.game.state.GamePreInitializationEvent;
 import org.spongepowered.api.event.game.state.GameStartedServerEvent;
@@ -321,6 +323,23 @@ public class NucleusPlugin extends Nucleus {
                     .build();
 
             moduleContainer.startDiscover();
+        } catch (Exception e) {
+            isErrored = e;
+            disable();
+            e.printStackTrace();
+        }
+    }
+
+    @Listener(order = Order.FIRST)
+    public void onInit(GameInitializationEvent event) {
+        if (isErrored != null) {
+            return;
+        }
+
+        logger.info(messageProvider.getMessageWithFormat("startup.init", PluginInfo.NAME));
+
+        try {
+            CatalogTypeFinalStaticProcessor.setEventContexts();
         } catch (Exception e) {
             isErrored = e;
             disable();

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/CatalogTypeFinalStaticProcessor.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/CatalogTypeFinalStaticProcessor.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.internal;
+
+import io.github.nucleuspowered.nucleus.api.EventContexts;
+import org.spongepowered.api.event.cause.EventContextKey;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+public class CatalogTypeFinalStaticProcessor {
+
+    private CatalogTypeFinalStaticProcessor() {}
+
+    private static void setFinalStatic(Field field, Object entry) throws Exception {
+        field.setAccessible(true);
+
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        field.set(null, entry);
+    }
+
+    public static void setEventContexts() throws Exception {
+        EventContextKey<Boolean> shouldFormatChannel = EventContextKey.builder(Boolean.class)
+                .id(EventContexts.Identifiers.SHOULD_FORMAT_CHANNEL)
+                .name("Nucleus - Context to indicate whether a chat message should be formatted.")
+                .build();
+        setFinalStatic(EventContexts.class.getDeclaredField("SHOULD_FORMAT_CHANNEL"), shouldFormatChannel);
+    }
+
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/afk/listeners/AFKChatListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/afk/listeners/AFKChatListener.java
@@ -4,12 +4,11 @@
  */
 package io.github.nucleuspowered.nucleus.modules.afk.listeners;
 
+import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.internal.ListenerBase;
 import io.github.nucleuspowered.nucleus.modules.afk.config.AFKConfig;
 import io.github.nucleuspowered.nucleus.modules.afk.handlers.AFKHandler;
-import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
-import org.spongepowered.api.event.filter.cause.Root;
 import org.spongepowered.api.event.message.MessageChannelEvent;
 
 import javax.inject.Inject;
@@ -22,8 +21,8 @@ public class AFKChatListener extends AbstractAFKListener implements ListenerBase
     }
 
     @Listener
-    public void onPlayerChat(final MessageChannelEvent.Chat event, @Root Player player) {
-        update(player);
+    public void onPlayerChat(final MessageChannelEvent.Chat event) {
+        Util.onPlayerSimulatedOrPlayer(event, (e, p) -> update(p));
     }
 
     @Override

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/commands/MeCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/commands/MeCommand.java
@@ -5,6 +5,7 @@
 package io.github.nucleuspowered.nucleus.modules.chat.commands;
 
 import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.api.EventContexts;
 import io.github.nucleuspowered.nucleus.api.chat.NucleusChatChannel;
 import io.github.nucleuspowered.nucleus.argumentparsers.RemainingStringsArgument;
 import io.github.nucleuspowered.nucleus.internal.annotations.command.Permissions;
@@ -25,6 +26,7 @@ import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.args.CommandElement;
 import org.spongepowered.api.event.SpongeEventFactory;
+import org.spongepowered.api.event.cause.EventContext;
 import org.spongepowered.api.event.message.MessageChannelEvent;
 import org.spongepowered.api.event.message.MessageEvent;
 import org.spongepowered.api.text.Text;
@@ -74,9 +76,9 @@ public class MeCommand extends AbstractCommand<CommandSource> implements Reloada
 
         // We create an event so that other plugins can provide transforms, such as Boop, and that we
         // can catch it in ignore and mutes, and so can other plugins.
-        MessageChannelEvent.Chat event = CauseStackHelper.createFrameWithCausesWithReturn(c ->
+        MessageChannelEvent.Chat event = CauseStackHelper.createFrameWithCausesAndContextWithReturn(c ->
                 SpongeEventFactory.createMessageChannelEventChat(c, channel, Optional.of(channel), formatter, originalMessage, false),
-                src);
+                EventContext.builder().add(EventContexts.SHOULD_FORMAT_CHANNEL, false).build(), src);
 
         if (Sponge.getEventManager().post(event)) {
             throw new ReturnMessageException(plugin.getMessageProvider().getTextMessageWithFormat("command.me.cancel"));

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/listeners/BodyFixChatListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/listeners/BodyFixChatListener.java
@@ -5,6 +5,7 @@
 package io.github.nucleuspowered.nucleus.modules.chat.listeners;
 
 import io.github.nucleuspowered.nucleus.Nucleus;
+import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.internal.ListenerBase;
 import io.github.nucleuspowered.nucleus.modules.chat.ChatModule;
 import io.github.nucleuspowered.nucleus.modules.chat.config.ChatConfig;
@@ -12,7 +13,6 @@ import io.github.nucleuspowered.nucleus.modules.chat.config.ChatConfigAdapter;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.Order;
-import org.spongepowered.api.event.filter.cause.Root;
 import org.spongepowered.api.event.message.MessageChannelEvent;
 import org.spongepowered.api.text.serializer.TextSerializers;
 
@@ -25,7 +25,11 @@ public class BodyFixChatListener extends ListenerBase implements ListenerBase.Co
     private static final Pattern colorCodeAdjustment = Pattern.compile("^((&[0-9a-fklmno])+)\\s+");
 
     @Listener(order = Order.LATE)
-    public void onChat(MessageChannelEvent.Chat event, @Root Player player) {
+    public void onChat(MessageChannelEvent.Chat event) {
+        Util.onPlayerSimulatedOrPlayer(event, this::onChat);
+    }
+
+    private void onChat(MessageChannelEvent.Chat event, Player player) {
         if (bodyPattern.matcher(event.getFormatter().getBody().toText().toPlain()).find()) {
             String m = TextSerializers.FORMATTING_CODE.serialize(event.getFormatter().getBody().toText());
             m = m.replaceFirst("<" + player.getName() + ">", "").trim();

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/listeners/ChatListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/listeners/ChatListener.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Maps;
 import io.github.nucleuspowered.nucleus.NameUtil;
 import io.github.nucleuspowered.nucleus.Nucleus;
 import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.api.EventContexts;
 import io.github.nucleuspowered.nucleus.api.chat.NucleusNoFormatChannel;
 import io.github.nucleuspowered.nucleus.api.service.NucleusMessageTokenService;
 import io.github.nucleuspowered.nucleus.internal.ListenerBase;
@@ -25,7 +26,6 @@ import io.github.nucleuspowered.nucleus.modules.chat.util.TemplateUtil;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.Order;
-import org.spongepowered.api.event.filter.cause.Root;
 import org.spongepowered.api.event.message.MessageChannelEvent;
 import org.spongepowered.api.event.message.MessageEvent;
 import org.spongepowered.api.service.permission.Subject;
@@ -123,9 +123,14 @@ public class ChatListener extends ListenerBase implements Reloadable, ListenerBa
 
     // We do this first so that other plugins can alter it later if needs be.
     @Listener(order = Order.EARLY)
-    public void onPlayerChat(MessageChannelEvent.Chat event, @Root Player player) {
-        if (event.getChannel().isPresent() && event.getChannel().get() instanceof NucleusNoFormatChannel
-                && !((NucleusNoFormatChannel) event.getChannel().get()).formatMessages()) {
+    public void onPlayerChat(MessageChannelEvent.Chat event) {
+        Util.onPlayerSimulatedOrPlayer(event, this::onPlayerChatInternal);
+    }
+
+    private void onPlayerChatInternal(MessageChannelEvent.Chat event, Player player) {
+        if (!event.getContext().get(EventContexts.SHOULD_FORMAT_CHANNEL).orElse(true) ||
+                event.getChannel().isPresent() && event.getChannel().get() instanceof NucleusNoFormatChannel
+                    && !((NucleusNoFormatChannel) event.getChannel().get()).formatMessages()) {
             if (((NucleusNoFormatChannel) event.getChannel().get()).removePrefix()) {
                 event.getFormatter().setHeader(Text.EMPTY);
             }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/ignore/listeners/IgnoreListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/ignore/listeners/IgnoreListener.java
@@ -6,13 +6,13 @@ package io.github.nucleuspowered.nucleus.modules.ignore.listeners;
 
 import com.google.common.collect.Lists;
 import io.github.nucleuspowered.nucleus.Nucleus;
+import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.api.chat.NucleusNoIgnoreChannel;
 import io.github.nucleuspowered.nucleus.api.events.NucleusMailEvent;
 import io.github.nucleuspowered.nucleus.api.events.NucleusMessageEvent;
 import io.github.nucleuspowered.nucleus.dataservices.loaders.UserDataManager;
 import io.github.nucleuspowered.nucleus.internal.CommandPermissionHandler;
 import io.github.nucleuspowered.nucleus.internal.ListenerBase;
-import io.github.nucleuspowered.nucleus.modules.core.config.CoreConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.ignore.commands.IgnoreCommand;
 import io.github.nucleuspowered.nucleus.modules.ignore.datamodules.IgnoreUserDataModule;
 import org.spongepowered.api.entity.living.player.Player;
@@ -32,16 +32,24 @@ import javax.inject.Inject;
 
 public class IgnoreListener extends ListenerBase {
 
-    @Inject private UserDataManager loader;
-    @Inject private CoreConfigAdapter cca;
+    private final UserDataManager loader;
     private CommandPermissionHandler ignoreHandler = Nucleus.getNucleus().getPermissionRegistry().getPermissionsForNucleusCommand(IgnoreCommand.class);
 
+    @Inject
+    public IgnoreListener(UserDataManager loader) {
+        this.loader = loader;
+    }
+
     @Listener(order = Order.LATE)
-    public void onChat(MessageChannelEvent.Chat event, @Root Player player) {
+    public void onChat(MessageChannelEvent.Chat event) {
         if (event.getChannel().orElseGet(event::getOriginalChannel) instanceof NucleusNoIgnoreChannel) {
             return;
         }
 
+        Util.onPlayerSimulatedOrPlayer(event, this::onChat);
+    }
+
+    private void onChat(MessageChannelEvent.Chat event, Player player) {
         // Reset the channel - but only if we have to.
         checkCancels(event.getChannel().orElseGet(event::getOriginalChannel).getMembers(), player).ifPresent(x -> {
             MutableMessageChannel mmc = event.getChannel().orElseGet(event::getOriginalChannel).asMutable();

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/listeners/ChatJailListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/jail/listeners/ChatJailListener.java
@@ -5,6 +5,7 @@
 package io.github.nucleuspowered.nucleus.modules.jail.listeners;
 
 import io.github.nucleuspowered.nucleus.Nucleus;
+import io.github.nucleuspowered.nucleus.Util;
 import io.github.nucleuspowered.nucleus.internal.ListenerBase;
 import io.github.nucleuspowered.nucleus.modules.jail.JailModule;
 import io.github.nucleuspowered.nucleus.modules.jail.config.JailConfig;
@@ -13,7 +14,6 @@ import io.github.nucleuspowered.nucleus.modules.jail.handlers.JailHandler;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.Order;
-import org.spongepowered.api.event.filter.cause.Root;
 import org.spongepowered.api.event.message.MessageChannelEvent;
 
 import javax.inject.Inject;
@@ -28,7 +28,11 @@ public class ChatJailListener extends ListenerBase implements ListenerBase.Condi
     }
 
     @Listener(order = Order.FIRST)
-    public void onChat(MessageChannelEvent.Chat event, @Root Player player) {
+    public void onChat(MessageChannelEvent.Chat event) {
+        Util.onPlayerSimulatedOrPlayer(event, this::onChat);
+    }
+
+    private void onChat(MessageChannelEvent.Chat event, Player player) {
         if (handler.checkJail(player, false)) {
             player.sendMessage(Nucleus.getNucleus().getMessageProvider().getTextMessageWithFormat("jail.muteonchat"));
             event.setCancelled(true);

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/mute/listeners/MuteListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/mute/listeners/MuteListener.java
@@ -44,10 +44,17 @@ import javax.inject.Inject;
 
 public class MuteListener extends ListenerBase {
 
-    @Inject private MuteHandler handler;
-    @Inject private MuteConfigAdapter mca;
-    @Inject private PermissionRegistry permissionRegistry;
+    private final MuteHandler handler;
+    private final MuteConfigAdapter mca;
+    private final PermissionRegistry permissionRegistry;
     private CommandPermissionHandler cph;
+
+    @Inject
+    public MuteListener(MuteHandler handler, MuteConfigAdapter mca, PermissionRegistry permissionRegistry) {
+        this.handler = handler;
+        this.mca = mca;
+        this.permissionRegistry = permissionRegistry;
+    }
 
     /**
      * At the time the subject joins, check to see if the subject is muted.
@@ -108,7 +115,11 @@ public class MuteListener extends ListenerBase {
     }
 
     @Listener(order = Order.LATE)
-    public void onPlayerChat(MessageChannelEvent.Chat event, @Root Player player) {
+    public void onChat(MessageChannelEvent.Chat event) {
+        Util.onPlayerSimulatedOrPlayer(event, this::onChat);
+    }
+
+    private void onChat(MessageChannelEvent.Chat event, Player player) {
         boolean cancel = false;
         Optional<MuteData> omd = Util.testForEndTimestamp(handler.getPlayerMuteData(player), () -> handler.unmutePlayer(player));
         if (omd.isPresent()) {

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/StaffChatMessageChannel.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/staffchat/StaffChatMessageChannel.java
@@ -8,7 +8,6 @@ import com.google.common.base.Preconditions;
 import io.github.nucleuspowered.nucleus.NucleusPlugin;
 import io.github.nucleuspowered.nucleus.api.chat.NucleusChatChannel;
 import io.github.nucleuspowered.nucleus.internal.text.NucleusTextTemplateImpl;
-import io.github.nucleuspowered.nucleus.internal.text.TextParsingUtils;
 import io.github.nucleuspowered.nucleus.modules.staffchat.commands.StaffChatCommand;
 import io.github.nucleuspowered.nucleus.modules.staffchat.config.StaffChatConfigAdapter;
 import org.spongepowered.api.Sponge;
@@ -47,14 +46,12 @@ public class StaffChatMessageChannel implements NucleusChatChannel.StaffChat {
     }
 
     private final NucleusPlugin plugin;
-    private final TextParsingUtils textParsingUtils;
     private final String basePerm;
     private NucleusTextTemplateImpl template;
     private TextColor colour;
 
     StaffChatMessageChannel(NucleusPlugin plugin) {
         this.plugin = plugin;
-        textParsingUtils = plugin.getTextParsingUtils();
         plugin.registerReloadable(this::onReload);
         this.onReload();
         this.basePerm = plugin.getPermissionRegistry().getPermissionsForNucleusCommand(StaffChatCommand.class).getBase();
@@ -86,7 +83,8 @@ public class StaffChatMessageChannel implements NucleusChatChannel.StaffChat {
         return c;
     }
 
-    @Override public boolean formatMessages() {
+    @Override
+    public boolean formatMessages() {
         return this.formatting;
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/util/CauseStackHelper.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/util/CauseStackHelper.java
@@ -15,6 +15,13 @@ public class CauseStackHelper {
 
     private CauseStackHelper() {}
 
+    public static <T, X extends Throwable> T createFrameWithCausesAndContextWithReturn(ThrownFunction<Cause, T, X> function,
+            EventContext context, Object... causeStack) throws X {
+        try (CauseStackManager.StackFrame csf = createFrameWithCauses(context, causeStack)) {
+            return function.apply(Sponge.getCauseStackManager().getCurrentCause());
+        }
+    }
+
     public static <T, X extends Throwable> T createFrameWithCausesWithReturn(ThrownFunction<Cause, T, X> function, Object... causeStack) throws X {
         try (CauseStackManager.StackFrame csf = createFrameWithCauses(causeStack)) {
             return function.apply(Sponge.getCauseStackManager().getCurrentCause());

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -46,6 +46,7 @@ startup.welcome3=&fYou can also add a message to our Sponge Forum thread, or vis
 startup.welcome4=&fDiscover a bug? Report it at https://github.com/NucleusPowered/Nucleus/issues - adding a copy of the file from &e/nucleus info \
   &fto the report!
 startup.preinit={0} is now starting. Entering pre-init phase.
+startup.init={0} is now entering the init phase.
 startup.postinit={0} is now entering the post-init phase.
 startup.completeinit={0} has completed server initialisation tasks. Waiting for game server to start to complete the final tasks.
 startup.gamestart={0} is performing final tasks before server startup completes.


### PR DESCRIPTION
Plugins can check for this key to suggest whether they should format the
incoming message.

Also, as the cause of "player.simulateChat" would be the SENDING player,
not the SIMULATED player due to cause/context changes, we've updated our
listeners to check the PLAYER_SIMULATED context key first. That way, we
ensure that we're formatting for the correct player.

<!--
    When submitting a PR, please include the following:

    * Use case
    * A list of changes
    * Any related changes/issues

    If your PR is not finished but you're seeking a review on it, mark it with [WIP].
-->
