### PR TITLE
[WIP] Enhanced Repair Command

### DIFF
--- a/sponge_intellij_style.xml
+++ b/sponge_intellij_style.xml
@@ -1,0 +1,134 @@
+<code_scheme name="Sponge">
+    <option name="LINE_SEPARATOR" value="&#10;"/>
+    <option name="USE_FQ_CLASS_NAMES_IN_JAVADOC" value="false"/>
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="2147483647"/>
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="2147483647"/>
+    <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+        <value/>
+    </option>
+    <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+            <package name="" withSubpackages="true" static="true"/>
+            <emptyLine/>
+            <package name="" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="java" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="javax" withSubpackages="true" static="false"/>
+        </value>
+    </option>
+    <option name="RIGHT_MARGIN" value="150"/>
+    <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="true"/>
+    <option name="ENABLE_JAVADOC_FORMATTING" value="false"/>
+    <option name="JD_ALIGN_PARAM_COMMENTS" value="false"/>
+    <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false"/>
+    <option name="JD_P_AT_EMPTY_LINES" value="false"/>
+    <option name="JD_PRESERVE_LINE_FEEDS" value="true"/>
+    <option name="FORMATTER_TAGS_ENABLED" value="true"/>
+    <option name="WRAP_COMMENTS" value="true"/>
+    <GroovyCodeStyleSettings>
+        <option name="USE_FQ_CLASS_NAMES_IN_JAVADOC" value="false"/>
+        <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="2147483647"/>
+        <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="2147483647"/>
+        <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+            <value/>
+        </option>
+        <option name="IMPORT_LAYOUT_TABLE">
+            <value>
+                <package name="" withSubpackages="true" static="true"/>
+                <emptyLine/>
+                <package name="" withSubpackages="true" static="false"/>
+                <emptyLine/>
+                <package name="java" withSubpackages="true" static="false"/>
+                <emptyLine/>
+                <package name="javax" withSubpackages="true" static="false"/>
+            </value>
+        </option>
+    </GroovyCodeStyleSettings>
+    <HoconCodeStyleSettings>
+        <option name="OBJECTS_WRAP" value="5"/>
+        <option name="LISTS_WRAP" value="1"/>
+        <option name="OBJECT_FIELDS_WITH_COLON_WRAP" value="1"/>
+        <option name="OBJECT_FIELDS_WITH_ASSIGNMENT_WRAP" value="1"/>
+        <option name="INCLUDED_RESOURCE_WRAP" value="1"/>
+    </HoconCodeStyleSettings>
+    <JavaCodeStyleSettings>
+        <option name="DO_NOT_WRAP_AFTER_SINGLE_ANNOTATION" value="true"/>
+        <option name="ANNOTATION_PARAMETER_WRAP" value="1"/>
+    </JavaCodeStyleSettings>
+    <editorconfig>
+        <option name="ENABLED" value="false"/>
+    </editorconfig>
+    <codeStyleSettings language="Groovy">
+        <option name="KEEP_FIRST_COLUMN_COMMENT" value="false"/>
+        <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false"/>
+        <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1"/>
+        <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+        <option name="SPACE_WITHIN_BRACES" value="false"/>
+        <option name="CALL_PARAMETERS_WRAP" value="1"/>
+        <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+        <option name="EXTENDS_LIST_WRAP" value="1"/>
+        <option name="THROWS_LIST_WRAP" value="1"/>
+        <option name="EXTENDS_KEYWORD_WRAP" value="1"/>
+        <option name="THROWS_KEYWORD_WRAP" value="1"/>
+        <option name="METHOD_CALL_CHAIN_WRAP" value="1"/>
+        <option name="BINARY_OPERATION_WRAP" value="1"/>
+        <option name="TERNARY_OPERATION_WRAP" value="1"/>
+        <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="false"/>
+        <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="false"/>
+        <option name="FOR_STATEMENT_WRAP" value="1"/>
+        <option name="ASSIGNMENT_WRAP" value="1"/>
+        <option name="ASSERT_STATEMENT_WRAP" value="1"/>
+        <option name="IF_BRACE_FORCE" value="3"/>
+        <option name="WHILE_BRACE_FORCE" value="3"/>
+        <option name="FOR_BRACE_FORCE" value="3"/>
+        <option name="WRAP_LONG_LINES" value="true"/>
+        <option name="PARAMETER_ANNOTATION_WRAP" value="1"/>
+        <option name="VARIABLE_ANNOTATION_WRAP" value="1"/>
+        <option name="ENUM_CONSTANTS_WRAP" value="1"/>
+    </codeStyleSettings>
+    <codeStyleSettings language="HOCON">
+        <indentOptions>
+            <option name="INDENT_SIZE" value="4"/>
+            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+        </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JAVA">
+        <option name="KEEP_FIRST_COLUMN_COMMENT" value="false"/>
+        <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false"/>
+        <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1"/>
+        <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+        <option name="ALIGN_MULTILINE_RESOURCES" value="false"/>
+        <option name="CALL_PARAMETERS_WRAP" value="1"/>
+        <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+        <option name="RESOURCE_LIST_WRAP" value="1"/>
+        <option name="EXTENDS_LIST_WRAP" value="1"/>
+        <option name="THROWS_LIST_WRAP" value="1"/>
+        <option name="EXTENDS_KEYWORD_WRAP" value="1"/>
+        <option name="THROWS_KEYWORD_WRAP" value="1"/>
+        <option name="METHOD_CALL_CHAIN_WRAP" value="1"/>
+        <option name="BINARY_OPERATION_WRAP" value="1"/>
+        <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+        <option name="TERNARY_OPERATION_WRAP" value="1"/>
+        <option name="FOR_STATEMENT_WRAP" value="1"/>
+        <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
+        <option name="ASSIGNMENT_WRAP" value="1"/>
+        <option name="ASSERT_STATEMENT_WRAP" value="1"/>
+        <option name="IF_BRACE_FORCE" value="3"/>
+        <option name="DOWHILE_BRACE_FORCE" value="3"/>
+        <option name="WHILE_BRACE_FORCE" value="3"/>
+        <option name="FOR_BRACE_FORCE" value="3"/>
+        <option name="WRAP_LONG_LINES" value="true"/>
+        <option name="PARAMETER_ANNOTATION_WRAP" value="1"/>
+        <option name="VARIABLE_ANNOTATION_WRAP" value="1"/>
+        <option name="ENUM_CONSTANTS_WRAP" value="1"/>
+        <option name="METHOD_ANNOTATION_WRAP" value="1" />
+        <option name="FIELD_ANNOTATION_WRAP" value="1" />
+    </codeStyleSettings>
+    <codeStyleSettings language="JSON">
+        <option name="WRAP_LONG_LINES" value="true"/>
+        <indentOptions>
+            <option name="INDENT_SIZE" value="4"/>
+        </indentOptions>
+    </codeStyleSettings>
+</code_scheme>

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/item/commands/RepairCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/item/commands/RepairCommand.java
@@ -9,41 +9,121 @@ import io.github.nucleuspowered.nucleus.internal.annotations.command.RegisterCom
 import io.github.nucleuspowered.nucleus.internal.command.AbstractCommand;
 import io.github.nucleuspowered.nucleus.internal.command.ReturnMessageException;
 import io.github.nucleuspowered.nucleus.internal.docgen.annotations.EssentialsEquivalent;
+import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
-import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.args.GenericArguments;
 import org.spongepowered.api.data.DataTransactionResult;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.data.manipulator.mutable.item.DurabilityData;
 import org.spongepowered.api.data.type.HandTypes;
 import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.entity.Hotbar;
+import org.spongepowered.api.item.inventory.equipment.EquipmentType;
+import org.spongepowered.api.item.inventory.equipment.WornEquipmentType;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
+
+import java.util.Optional;
 
 @NonnullByDefault
 @Permissions(supportsOthers = true)
 @RegisterCommand({"repair", "mend"})
 @EssentialsEquivalent({"repair", "fix"})
-public class RepairCommand extends AbstractCommand.SimpleTargetOtherPlayer {
+public class RepairCommand extends AbstractCommand<Player> {
 
-    @Override protected CommandResult executeWithPlayer(CommandSource src, Player pl, CommandContext args, boolean isSelf) throws Exception {
-        if (pl.getItemInHand(HandTypes.MAIN_HAND).isPresent()) {
-            ItemStack stack = pl.getItemInHand(HandTypes.MAIN_HAND).get();
-            if (stack.get(DurabilityData.class).isPresent()) {
-                DurabilityData durabilityData = stack.get(DurabilityData.class).get();
-                DataTransactionResult transactionResult = stack.offer(Keys.ITEM_DURABILITY, durabilityData.durability().getMaxValue());
-                if (transactionResult.isSuccessful()) {
-                    pl.setItemInHand(HandTypes.MAIN_HAND, stack);
-                    src.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat("command.repair.success", pl.getName()));
-                    return CommandResult.success();
-                } else {
-                    throw ReturnMessageException.fromKey("command.repair.error");
+    private int successCount = 0;
+    private int errorCount = 0;
+    private int noRepairCount = 0;
+
+    @Override public CommandElement[] getArguments() {
+        return new CommandElement[]{
+            GenericArguments.flags()
+                .flag("m", "-mainhand")
+                .permissionFlag(permissions.getPermissionWithSuffix("all"), "a", "-all")
+                .permissionFlag(permissions.getPermissionWithSuffix("hotbar"), "h", "-hotbar")
+                .permissionFlag(permissions.getPermissionWithSuffix("equip"), "e", "-equip")
+                .permissionFlag(permissions.getPermissionWithSuffix("offhand"), "o", "-offhand")
+                .buildWith(GenericArguments.none())
+        };
+    }
+
+    @Override protected CommandResult executeCommand(Player pl, CommandContext args) throws Exception {
+        if (args.hasAny("a")) {
+            for (Inventory slot : pl.getInventory().slots()) {
+                if (slot.peek().isPresent() && !slot.peek().get().isEmpty()) {
+                    ItemStack stack = slot.peek().get();
+                    repairStack(stack).ifPresent(slot::set);
                 }
-            } else {
-                throw ReturnMessageException.fromKey("command.repair.error.notreparable");
             }
         } else {
+
+            boolean repairHotbar = args.hasAny("h");
+            boolean repairEquip = args.hasAny("e");
+            boolean repairOffhand = args.hasAny("o");
+            boolean repairMainhand = args.hasAny("m") || !repairHotbar && !repairEquip && !repairOffhand;
+
+            // Repair item in main hand
+            if (repairMainhand && pl.getItemInHand(HandTypes.MAIN_HAND).isPresent()) {
+                ItemStack stack = pl.getItemInHand(HandTypes.MAIN_HAND).get();
+                repairStack(stack).ifPresent(s -> pl.setItemInHand(HandTypes.MAIN_HAND, s));
+            }
+
+            // Repair item in off hand
+            if (repairOffhand && pl.getItemInHand(HandTypes.OFF_HAND).isPresent()) {
+                ItemStack stack = pl.getItemInHand(HandTypes.OFF_HAND).get();
+                repairStack(stack).ifPresent(s -> pl.setItemInHand(HandTypes.OFF_HAND, s));
+            }
+
+            // Repair worn equipment
+            if (repairEquip) {
+                for (EquipmentType type : Sponge.getRegistry().getAllOf(WornEquipmentType.class)) {
+                    if (pl.getEquipped(type).isPresent()) {
+                        ItemStack stack = pl.getEquipped(type).get();
+                        repairStack(stack).ifPresent(s -> pl.equip(type, s));
+                    }
+                }
+            }
+
+            // Repair Hotbar
+            if (repairHotbar) {
+                for (Inventory slot : pl.getInventory().query(Hotbar.class).slots()) {
+                    if (slot.peek().isPresent() && !slot.peek().get().isEmpty()) {
+                        ItemStack stack = slot.peek().get();
+                        repairStack(stack).ifPresent(slot::set);
+                    }
+                }
+            }
+        }
+
+        if (successCount == 0 && errorCount == 0 && noRepairCount == 0) {
             throw ReturnMessageException.fromKey("command.repair.error.handempty");
+        } else if (successCount > 0) {
+            pl.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat("command.repair.success", pl.getName()));
+            return CommandResult.successCount(successCount);
+        } else if (errorCount > 0) {
+            throw ReturnMessageException.fromKey("command.repair.error");
+        } else {
+            throw ReturnMessageException.fromKey("command.repair.error.notreparable");
+        }
+    }
+
+    private Optional<ItemStack> repairStack(ItemStack stack) {
+        if (stack.get(DurabilityData.class).isPresent()) {
+            DurabilityData durabilityData = stack.get(DurabilityData.class).get();
+            DataTransactionResult transactionResult = stack.offer(Keys.ITEM_DURABILITY, durabilityData.durability().getMaxValue());
+            if (transactionResult.isSuccessful()) {
+                successCount += 1;
+                return Optional.of(stack);
+            } else {
+                errorCount += 1;
+                return Optional.empty();
+            }
+        } else {
+            noRepairCount += 1;
+            return Optional.empty();
         }
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/item/commands/RepairCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/item/commands/RepairCommand.java
@@ -12,7 +12,6 @@ import io.github.nucleuspowered.nucleus.internal.command.ReturnMessageException;
 import io.github.nucleuspowered.nucleus.internal.docgen.annotations.EssentialsEquivalent;
 import io.github.nucleuspowered.nucleus.internal.interfaces.Reloadable;
 import io.github.nucleuspowered.nucleus.modules.item.config.ItemConfigAdapter;
-import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.args.CommandElement;
@@ -27,30 +26,20 @@ import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.inventory.entity.Hotbar;
-import org.spongepowered.api.item.inventory.equipment.EquipmentType;
-import org.spongepowered.api.item.inventory.equipment.WornEquipmentType;
+import org.spongepowered.api.item.inventory.equipment.EquipmentInventory;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.action.TextActions;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.List;
-import java.util.Optional;
 
 @NonnullByDefault
 @Permissions(supportsOthers = true)
 @RegisterCommand({"repair", "mend"})
 @EssentialsEquivalent({"repair", "fix"})
 public class RepairCommand extends AbstractCommand<Player> implements Reloadable {
-
-    private int successCount = 0;
-    private ItemStackSnapshot lastSuccess = ItemStackSnapshot.NONE;
-    private int restrictedCount = 0;
-    private ItemStackSnapshot lastRestricted = ItemStackSnapshot.NONE;
-    private int errorCount = 0;
-    private ItemStackSnapshot lastError = ItemStackSnapshot.NONE;
-    private int noDurabilityCount = 0;
-    private ItemStackSnapshot lastNoDurability = ItemStackSnapshot.NONE;
 
     private boolean whitelist = false;
     private List<ItemType> restrictions = new ArrayList<>();
@@ -75,12 +64,25 @@ public class RepairCommand extends AbstractCommand<Player> implements Reloadable
     }
 
     @Override protected CommandResult executeCommand(Player pl, CommandContext args) throws Exception {
+        EnumMap<ResultType, Integer> resultCount = new EnumMap(ResultType.class) {{
+            put(ResultType.SUCCESS, 0);
+            put(ResultType.ERROR, 0);
+            put(ResultType.NO_DURABILITY, 0);
+            put(ResultType.RESTRICTED, 0);
+        }};
+        EnumMap<ResultType, ItemStackSnapshot> lastItem = new EnumMap<>(ResultType.class);
+
         String location = "inventory";
         if (args.hasAny("a")) {
             for (Inventory slot : pl.getInventory().slots()) {
                 if (slot.peek().isPresent() && !slot.peek().get().isEmpty()) {
                     ItemStack stack = slot.peek().get();
-                    repairStack(stack).ifPresent(slot::set);
+                    RepairResult result = repairStack(stack);
+                    resultCount.compute(result.type, (t, i) -> i += 1);
+                    lastItem.put(result.type, result.stack.createSnapshot());
+                    if (result.isSuccessful()) {
+                        slot.set(result.stack);
+                    }
                 }
             }
         } else {
@@ -103,21 +105,36 @@ public class RepairCommand extends AbstractCommand<Player> implements Reloadable
             // Repair item in main hand
             if (repairMainhand && pl.getItemInHand(HandTypes.MAIN_HAND).isPresent()) {
                 ItemStack stack = pl.getItemInHand(HandTypes.MAIN_HAND).get();
-                repairStack(stack).ifPresent(s -> pl.setItemInHand(HandTypes.MAIN_HAND, s));
+                RepairResult result = repairStack(stack);
+                resultCount.compute(result.type, (t, i) -> i += 1);
+                lastItem.put(result.type, result.stack.createSnapshot());
+                if (result.isSuccessful()) {
+                    pl.setItemInHand(HandTypes.MAIN_HAND, result.stack);
+                }
             }
 
             // Repair item in off hand
             if (repairOffhand && pl.getItemInHand(HandTypes.OFF_HAND).isPresent()) {
                 ItemStack stack = pl.getItemInHand(HandTypes.OFF_HAND).get();
-                repairStack(stack).ifPresent(s -> pl.setItemInHand(HandTypes.OFF_HAND, s));
+                RepairResult result = repairStack(stack);
+                resultCount.compute(result.type, (t, i) -> i += 1);
+                lastItem.put(result.type, result.stack.createSnapshot());
+                if (result.isSuccessful()) {
+                    pl.setItemInHand(HandTypes.OFF_HAND, result.stack);
+                }
             }
 
             // Repair worn equipment
             if (repairEquip) {
-                for (EquipmentType type : Sponge.getRegistry().getAllOf(WornEquipmentType.class)) {
-                    if (pl.getEquipped(type).isPresent()) {
-                        ItemStack stack = pl.getEquipped(type).get();
-                        repairStack(stack).ifPresent(s -> pl.equip(type, s));
+                for (Inventory slot : pl.getInventory().query(EquipmentInventory.class).slots()) {
+                    if (slot.peek().isPresent() && !slot.peek().get().isEmpty()) {
+                        ItemStack stack = slot.peek().get();
+                        RepairResult result = repairStack(stack);
+                        resultCount.compute(result.type, (t, i) -> i += 1);
+                        lastItem.put(result.type, result.stack.createSnapshot());
+                        if (result.isSuccessful()) {
+                            slot.set(result.stack);
+                        }
                     }
                 }
             }
@@ -127,23 +144,32 @@ public class RepairCommand extends AbstractCommand<Player> implements Reloadable
                 for (Inventory slot : pl.getInventory().query(Hotbar.class).slots()) {
                     if (slot.peek().isPresent() && !slot.peek().get().isEmpty()) {
                         ItemStack stack = slot.peek().get();
-                        repairStack(stack).ifPresent(slot::set);
+                        RepairResult result = repairStack(stack);
+                        resultCount.compute(result.type, (t, i) -> i += 1);
+                        lastItem.put(result.type, result.stack.createSnapshot());
+                        if (result.isSuccessful()) {
+                            slot.set(result.stack);
+                        }
                     }
                 }
             }
         }
 
-        location = plugin.getMessageProvider().getMessageFromKey("repair.command.location." + location).get();
-        if (successCount == 0 && errorCount == 0 && noDurabilityCount == 0) {
+        location = plugin.getMessageProvider().getMessageFromKey("command.repair.location." + location).orElse("inventory");
+
+        if (resultCount.get(ResultType.SUCCESS) == 0 && resultCount.get(ResultType.ERROR) == 0
+                && resultCount.get(ResultType.NO_DURABILITY) == 0 && resultCount.get(ResultType.RESTRICTED) == 0) {
             throw ReturnMessageException.fromKey("command.repair.empty", pl.getName(), location);
         } else {
             // Non-repairable Message - Only used when all items processed had no durability
-            if (noDurabilityCount > 0 && successCount == 0 && errorCount == 0) {
-                if (noDurabilityCount == 1) {
+            if (resultCount.get(ResultType.NO_DURABILITY) > 0 && resultCount.get(ResultType.SUCCESS) == 0
+                    && resultCount.get(ResultType.ERROR) == 0 && resultCount.get(ResultType.RESTRICTED) == 0) {
+                if (resultCount.get(ResultType.NO_DURABILITY) == 1) {
+                    ItemStackSnapshot item = lastItem.get(ResultType.NO_DURABILITY);
                     pl.sendMessage(plugin.getMessageProvider().getTextMessageWithTextFormat(
                             "command.repair.nodurability.single",
-                            Text.builder(lastNoDurability.getTranslation().get())
-                                    .onHover(TextActions.showItem(lastNoDurability))
+                            item.get(Keys.DISPLAY_NAME).orElse(Text.of(item.getTranslation().get())).toBuilder()
+                                    .onHover(TextActions.showItem(item))
                                     .build(),
                             Text.of(pl.getName()),
                             Text.of(location)
@@ -151,87 +177,101 @@ public class RepairCommand extends AbstractCommand<Player> implements Reloadable
                 } else {
                     pl.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat(
                             "command.repair.nodurability.multiple",
-                            Integer.toString(noDurabilityCount), pl.getName(), location
+                            resultCount.get(ResultType.NO_DURABILITY).toString(), pl.getName(), location
                     ));
                 }
             }
 
             // Success Message
-            if (successCount == 1) {
+            if (resultCount.get(ResultType.SUCCESS) == 1) {
+                ItemStackSnapshot item = lastItem.get(ResultType.SUCCESS);
                 pl.sendMessage(plugin.getMessageProvider().getTextMessageWithTextFormat(
                         "command.repair.success.single",
-                        Text.builder(lastSuccess.getTranslation().get())
-                                .onHover(TextActions.showItem(lastSuccess))
+                        item.get(Keys.DISPLAY_NAME).orElse(Text.of(item.getTranslation().get())).toBuilder()
+                                .onHover(TextActions.showItem(item))
                                 .build(),
                         Text.of(pl.getName()),
                         Text.of(location)
                 ));
-            } else if (successCount > 1) {
+            } else if (resultCount.get(ResultType.SUCCESS) > 1) {
                 pl.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat(
                         "command.repair.success.multiple",
-                        Integer.toString(successCount), pl.getName(), location
+                        resultCount.get(ResultType.SUCCESS).toString(), pl.getName(), location
                 ));
             }
 
             // Error Message
-            if (errorCount == 1) {
+            if (resultCount.get(ResultType.ERROR) == 1) {
+                ItemStackSnapshot item = lastItem.get(ResultType.ERROR);
                 pl.sendMessage(plugin.getMessageProvider().getTextMessageWithTextFormat(
                         "command.repair.error.single",
-                        Text.builder(lastError.getTranslation().get())
-                                .onHover(TextActions.showItem(lastError))
+                        item.get(Keys.DISPLAY_NAME).orElse(Text.of(item.getTranslation().get())).toBuilder()
+                                .onHover(TextActions.showItem(item))
                                 .build(),
                         Text.of(pl.getName()),
                         Text.of(location)
                 ));
-            } else if (errorCount > 1) {
+            } else if (resultCount.get(ResultType.ERROR) > 1) {
                 pl.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat(
                         "command.repair.error.multiple",
-                        Integer.toString(errorCount), pl.getName(), location
+                        resultCount.get(ResultType.ERROR).toString(), pl.getName(), location
                 ));
             }
 
             // Restriction Message
-            if (restrictedCount == 1) {
+            if (resultCount.get(ResultType.RESTRICTED) == 1) {
+                ItemStackSnapshot item = lastItem.get(ResultType.RESTRICTED);
                 pl.sendMessage(plugin.getMessageProvider().getTextMessageWithTextFormat(
                         "command.repair.restricted.single",
-                        Text.builder(lastRestricted.getTranslation().get())
-                                .onHover(TextActions.showItem(lastRestricted))
+                        item.get(Keys.DISPLAY_NAME).orElse(Text.of(item.getTranslation().get())).toBuilder()
+                                .onHover(TextActions.showItem(item))
                                 .build(),
                         Text.of(pl.getName()),
                         Text.of(location)
                 ));
-            } else if (restrictedCount > 1) {
+            } else if (resultCount.get(ResultType.RESTRICTED) > 1) {
                 pl.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat(
                         "command.repair.restricted.multiple",
-                        Integer.toString(restrictedCount), pl.getName(), location
+                        resultCount.get(ResultType.RESTRICTED).toString(), pl.getName(), location
                 ));
             }
 
-            return CommandResult.successCount(successCount);
+            return CommandResult.successCount(resultCount.get(ResultType.SUCCESS));
         }
     }
 
-    private Optional<ItemStack> repairStack(ItemStack stack) {
+    private RepairResult repairStack(ItemStack stack) {
         if (whitelist && !restrictions.contains(stack.getType()) || restrictions.contains(stack.getType())) {
-            restrictedCount += 1;
-            lastRestricted = stack.createSnapshot();
-            return Optional.empty();
+            return new RepairResult(stack, ResultType.RESTRICTED);
         } else if (stack.get(DurabilityData.class).isPresent()) {
             DurabilityData durabilityData = stack.get(DurabilityData.class).get();
             DataTransactionResult transactionResult = stack.offer(Keys.ITEM_DURABILITY, durabilityData.durability().getMaxValue());
             if (transactionResult.isSuccessful()) {
-                successCount += 1;
-                lastSuccess = stack.createSnapshot();
-                return Optional.of(stack);
+                return new RepairResult(stack, ResultType.SUCCESS);
             } else {
-                errorCount += 1;
-                lastError = stack.createSnapshot();
-                return Optional.empty();
+                return new RepairResult(stack, ResultType.ERROR);
             }
         } else {
-            noDurabilityCount += 1;
-            lastNoDurability = stack.createSnapshot();
-            return Optional.empty();
+            return new RepairResult(stack, ResultType.NO_DURABILITY);
+        }
+    }
+
+    private enum ResultType {
+        SUCCESS, ERROR, RESTRICTED, NO_DURABILITY
+    }
+
+    private class RepairResult {
+
+        private ItemStack stack;
+        private ResultType type;
+
+        public RepairResult(ItemStack stack, ResultType type) {
+            this.stack = stack;
+            this.type = type;
+        }
+
+        public boolean isSuccessful() {
+            return type == ResultType.SUCCESS;
         }
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/item/commands/RepairCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/item/commands/RepairCommand.java
@@ -55,10 +55,10 @@ public class RepairCommand extends AbstractCommand<Player> implements Reloadable
         return new CommandElement[]{
                 GenericArguments.flags()
                         .flag("m", "-mainhand")
-                        .permissionFlag(permissions.getPermissionWithSuffix("all"), "a", "-all")
-                        .permissionFlag(permissions.getPermissionWithSuffix("hotbar"), "h", "-hotbar")
-                        .permissionFlag(permissions.getPermissionWithSuffix("equip"), "e", "-equip")
-                        .permissionFlag(permissions.getPermissionWithSuffix("offhand"), "o", "-offhand")
+                        .permissionFlag(permissions.getPermissionWithSuffix("flag.all"), "a", "-all")
+                        .permissionFlag(permissions.getPermissionWithSuffix("flag.hotbar"), "h", "-hotbar")
+                        .permissionFlag(permissions.getPermissionWithSuffix("flag.equip"), "e", "-equip")
+                        .permissionFlag(permissions.getPermissionWithSuffix("flag.offhand"), "o", "-offhand")
                         .buildWith(GenericArguments.none())
         };
     }
@@ -72,7 +72,7 @@ public class RepairCommand extends AbstractCommand<Player> implements Reloadable
         }};
         EnumMap<ResultType, ItemStackSnapshot> lastItem = new EnumMap<>(ResultType.class);
 
-        boolean checkRestrictions = !pl.hasPermission(permissions.getPermissionWithSuffix("exempt.restrictions"));
+        boolean checkRestrictions = !pl.hasPermission(permissions.getPermissionWithSuffix("exempt.restriction"));
 
         String location = "inventory";
         if (args.hasAny("a")) {

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/item/commands/RepairCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/item/commands/RepairCommand.java
@@ -25,9 +25,12 @@ import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.Inventory;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.item.inventory.entity.Hotbar;
 import org.spongepowered.api.item.inventory.equipment.EquipmentType;
 import org.spongepowered.api.item.inventory.equipment.WornEquipmentType;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.action.TextActions;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 
 import java.util.ArrayList;
@@ -41,32 +44,38 @@ import java.util.Optional;
 public class RepairCommand extends AbstractCommand<Player> implements Reloadable {
 
     private int successCount = 0;
+    private ItemStackSnapshot lastSuccess = ItemStackSnapshot.NONE;
+    private int restrictedCount = 0;
+    private ItemStackSnapshot lastRestricted = ItemStackSnapshot.NONE;
     private int errorCount = 0;
-    private int noRepairCount = 0;
+    private ItemStackSnapshot lastError = ItemStackSnapshot.NONE;
+    private int noDurabilityCount = 0;
+    private ItemStackSnapshot lastNoDurability = ItemStackSnapshot.NONE;
 
     private boolean whitelist = false;
     private List<ItemType> restrictions = new ArrayList<>();
 
     @Override public void onReload() throws Exception {
         this.whitelist = Nucleus.getNucleus().getInternalServiceManager().getServiceUnchecked(ItemConfigAdapter.class)
-            .getNodeOrDefault().getRepairConfig().isWhitelist();
+                .getNodeOrDefault().getRepairConfig().isWhitelist();
         this.restrictions = Nucleus.getNucleus().getInternalServiceManager().getServiceUnchecked(ItemConfigAdapter.class)
-            .getNodeOrDefault().getRepairConfig().getRestrictions();
+                .getNodeOrDefault().getRepairConfig().getRestrictions();
     }
 
     @Override public CommandElement[] getArguments() {
         return new CommandElement[]{
-            GenericArguments.flags()
-                .flag("m", "-mainhand")
-                .permissionFlag(permissions.getPermissionWithSuffix("all"), "a", "-all")
-                .permissionFlag(permissions.getPermissionWithSuffix("hotbar"), "h", "-hotbar")
-                .permissionFlag(permissions.getPermissionWithSuffix("equip"), "e", "-equip")
-                .permissionFlag(permissions.getPermissionWithSuffix("offhand"), "o", "-offhand")
-                .buildWith(GenericArguments.none())
+                GenericArguments.flags()
+                        .flag("m", "-mainhand")
+                        .permissionFlag(permissions.getPermissionWithSuffix("all"), "a", "-all")
+                        .permissionFlag(permissions.getPermissionWithSuffix("hotbar"), "h", "-hotbar")
+                        .permissionFlag(permissions.getPermissionWithSuffix("equip"), "e", "-equip")
+                        .permissionFlag(permissions.getPermissionWithSuffix("offhand"), "o", "-offhand")
+                        .buildWith(GenericArguments.none())
         };
     }
 
     @Override protected CommandResult executeCommand(Player pl, CommandContext args) throws Exception {
+        String location = "inventory";
         if (args.hasAny("a")) {
             for (Inventory slot : pl.getInventory().slots()) {
                 if (slot.peek().isPresent() && !slot.peek().get().isEmpty()) {
@@ -80,6 +89,16 @@ public class RepairCommand extends AbstractCommand<Player> implements Reloadable
             boolean repairEquip = args.hasAny("e");
             boolean repairOffhand = args.hasAny("o");
             boolean repairMainhand = args.hasAny("m") || !repairHotbar && !repairEquip && !repairOffhand;
+
+            if (repairHotbar && !repairEquip && !repairOffhand && !repairMainhand) {
+                location = "hotbar";
+            } else if (repairEquip && !repairHotbar && !repairOffhand && !repairMainhand) {
+                location = "equipment";
+            } else if (repairOffhand && !repairHotbar && !repairEquip && !repairMainhand) {
+                location = "offhand";
+            } else if (repairMainhand && !repairHotbar && !repairEquip && !repairOffhand) {
+                location = "mainhand";
+            }
 
             // Repair item in main hand
             if (repairMainhand && pl.getItemInHand(HandTypes.MAIN_HAND).isPresent()) {
@@ -114,34 +133,104 @@ public class RepairCommand extends AbstractCommand<Player> implements Reloadable
             }
         }
 
-        if (successCount == 0 && errorCount == 0 && noRepairCount == 0) {
-            throw ReturnMessageException.fromKey("command.repair.error.handempty");
-        } else if (successCount > 0) {
-            pl.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat("command.repair.success", pl.getName()));
-            return CommandResult.successCount(successCount);
-        } else if (errorCount > 0) {
-            throw ReturnMessageException.fromKey("command.repair.error");
+        location = plugin.getMessageProvider().getMessageFromKey("repair.command.location." + location).get();
+        if (successCount == 0 && errorCount == 0 && noDurabilityCount == 0) {
+            throw ReturnMessageException.fromKey("command.repair.empty", pl.getName(), location);
         } else {
-            throw ReturnMessageException.fromKey("command.repair.error.notreparable");
+            // Non-repairable Message - Only used when all items processed had no durability
+            if (noDurabilityCount > 0 && successCount == 0 && errorCount == 0) {
+                if (noDurabilityCount == 1) {
+                    pl.sendMessage(plugin.getMessageProvider().getTextMessageWithTextFormat(
+                            "command.repair.nodurability.single",
+                            Text.builder(lastNoDurability.getTranslation().get())
+                                    .onHover(TextActions.showItem(lastNoDurability))
+                                    .build(),
+                            Text.of(pl.getName()),
+                            Text.of(location)
+                    ));
+                } else {
+                    pl.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat(
+                            "command.repair.nodurability.multiple",
+                            Integer.toString(noDurabilityCount), pl.getName(), location
+                    ));
+                }
+            }
+
+            // Success Message
+            if (successCount == 1) {
+                pl.sendMessage(plugin.getMessageProvider().getTextMessageWithTextFormat(
+                        "command.repair.success.single",
+                        Text.builder(lastSuccess.getTranslation().get())
+                                .onHover(TextActions.showItem(lastSuccess))
+                                .build(),
+                        Text.of(pl.getName()),
+                        Text.of(location)
+                ));
+            } else if (successCount > 1) {
+                pl.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat(
+                        "command.repair.success.multiple",
+                        Integer.toString(successCount), pl.getName(), location
+                ));
+            }
+
+            // Error Message
+            if (errorCount == 1) {
+                pl.sendMessage(plugin.getMessageProvider().getTextMessageWithTextFormat(
+                        "command.repair.error.single",
+                        Text.builder(lastError.getTranslation().get())
+                                .onHover(TextActions.showItem(lastError))
+                                .build(),
+                        Text.of(pl.getName()),
+                        Text.of(location)
+                ));
+            } else if (errorCount > 1) {
+                pl.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat(
+                        "command.repair.error.multiple",
+                        Integer.toString(errorCount), pl.getName(), location
+                ));
+            }
+
+            // Restriction Message
+            if (restrictedCount == 1) {
+                pl.sendMessage(plugin.getMessageProvider().getTextMessageWithTextFormat(
+                        "command.repair.restricted.single",
+                        Text.builder(lastRestricted.getTranslation().get())
+                                .onHover(TextActions.showItem(lastRestricted))
+                                .build(),
+                        Text.of(pl.getName()),
+                        Text.of(location)
+                ));
+            } else if (restrictedCount > 1) {
+                pl.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat(
+                        "command.repair.restricted.multiple",
+                        Integer.toString(restrictedCount), pl.getName(), location
+                ));
+            }
+
+            return CommandResult.successCount(successCount);
         }
     }
 
     private Optional<ItemStack> repairStack(ItemStack stack) {
         if (whitelist && !restrictions.contains(stack.getType()) || restrictions.contains(stack.getType())) {
+            restrictedCount += 1;
+            lastRestricted = stack.createSnapshot();
             return Optional.empty();
-        }
-        if (stack.get(DurabilityData.class).isPresent()) {
+        } else if (stack.get(DurabilityData.class).isPresent()) {
             DurabilityData durabilityData = stack.get(DurabilityData.class).get();
             DataTransactionResult transactionResult = stack.offer(Keys.ITEM_DURABILITY, durabilityData.durability().getMaxValue());
             if (transactionResult.isSuccessful()) {
                 successCount += 1;
+                lastSuccess = stack.createSnapshot();
                 return Optional.of(stack);
             } else {
                 errorCount += 1;
+                lastError = stack.createSnapshot();
                 return Optional.empty();
             }
         } else {
-            noRepairCount += 1;
+            noDurabilityCount += 1;
+            lastNoDurability = stack.createSnapshot();
             return Optional.empty();
         }
     }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/item/config/ItemConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/item/config/ItemConfig.java
@@ -10,8 +10,15 @@ import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 @ConfigSerializable
 public class ItemConfig {
 
+    @Setting("repair")
+    private RepairConfig repairConfig = new RepairConfig();
+
     @Setting("skull")
     private SkullConfig skullConfig = new SkullConfig();
+
+    public RepairConfig getRepairConfig() {
+        return repairConfig;
+    }
 
     public SkullConfig getSkullConfig() {
         return skullConfig;

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/item/config/RepairConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/item/config/RepairConfig.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.modules.item.config;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+import org.spongepowered.api.item.ItemType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ConfigSerializable
+public class RepairConfig {
+
+    @Setting(value = "use-whitelist", comment = "config.item.repair.whitelist")
+    private boolean useWhitelist = false;
+
+    @Setting(value = "restrictions", comment = "config.item.repair.restrictions")
+    private List<ItemType> restrictions = new ArrayList<>();
+
+    public boolean isWhitelist() {
+        return useWhitelist;
+    }
+
+    public List<ItemType> getRestrictions() {
+        return restrictions;
+    }
+}

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -512,6 +512,8 @@ config.servershop.maxpurchasable=The maximum amount a player can buy in one tran
 config.itemdatanode.aliases=A set of aliases that Nucleus recognises for this item. They all must be lowercase, and contain only letters, numbers, hyphens or underscores.
 
 config.item.skullcompat=If true, Nucleus will simply treat /skull as an alias to '"/give [player] skull [number] 3 {SkullOwner:[skullplayer]}"'
+config.item.repair.whitelist=If true, the restriction list will be used as a whitelist vs a blacklist.
+config.item.repair.restrictions=The list of item types to prevent (or allow if whitelist is true) repairing using /repair
 
 config.geoip.onlogin=If true, Nucleus will tell players with the "nucleus.geoip.login" permission the country the player is connecting via. Please be considerate with this permission, do not give it to everyone.
 

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -1108,9 +1108,25 @@ command.fly.on=&aYou are now able to fly.
 command.fly.off=&aYou are no longer able to fly.
 command.fly.error=&cCould not set fly status.
 
+# Deprecated
 command.repair.success=&aRepaired the item in {0}''s hand.
 command.repair.error.notreparable=&cThe item in your hand is not reparable.
 command.repair.error.handempty=&cYou must be holding an item to use this command.
+
+command.repair.success.single=&aSuccessfully repaired {0} in {1}'s {2}.
+command.repair.success.multiple=&aSuccessfully repaired &e{0} &aitems in {1}'s {2}.
+command.repair.restricted.single={0} &cis blacklisted and could not be repaired.
+command.repair.restricted.multiple=&e{0} &citems are blacklisted and could not be repaired.
+command.repair.nodurability.single={0} &cin {1}'s {2} are not repairable.
+command.repair.nodurability.multiple=&e{0} &citems in {1}'s {2} are not repairable.
+command.repair.error.single=&cAn error occurred repairing {0} &cin {1}'s {2}.
+command.repair.error.multiple=&cAn error occurred repairing &e{0} &citems in {1}'s {2}.
+command.repair.empty=&cThere are no items in {0}'s {1}.
+command.repair.location.mainhand=hand
+command.repair.location.offhand=offhand
+command.repair.location.hotbar=hotbar
+command.repair.location.equipment=equipment
+command.repair.location.inventory=inventory
 
 command.mail.send.successful=&aYour mail was sent to &e{0}.
 command.mail.send.error=&e{0} &cis unable to receive mail. Your mail was not sent.

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -1108,20 +1108,16 @@ command.fly.on=&aYou are now able to fly.
 command.fly.off=&aYou are no longer able to fly.
 command.fly.error=&cCould not set fly status.
 
-# Deprecated
-command.repair.success=&aRepaired the item in {0}''s hand.
-command.repair.error.notreparable=&cThe item in your hand is not reparable.
-command.repair.error.handempty=&cYou must be holding an item to use this command.
-
-command.repair.success.single=&aSuccessfully repaired {0} in {1}'s {2}.
-command.repair.success.multiple=&aSuccessfully repaired &e{0} &aitems in {1}'s {2}.
-command.repair.restricted.single={0} &cis blacklisted and could not be repaired.
+# Repair
+command.repair.success.single=&aSuccessfully repaired &e{0} &ain {1}''s {2}.
+command.repair.success.multiple=&aSuccessfully repaired &e{0} &aitems in {1}''s {2}.
+command.repair.restricted.single=&e{0} &cis blacklisted and could not be repaired.
 command.repair.restricted.multiple=&e{0} &citems are blacklisted and could not be repaired.
-command.repair.nodurability.single={0} &cin {1}'s {2} are not repairable.
-command.repair.nodurability.multiple=&e{0} &citems in {1}'s {2} are not repairable.
-command.repair.error.single=&cAn error occurred repairing {0} &cin {1}'s {2}.
-command.repair.error.multiple=&cAn error occurred repairing &e{0} &citems in {1}'s {2}.
-command.repair.empty=&cThere are no items in {0}'s {1}.
+command.repair.nodurability.single=&e{0} &cin {1}''s {2} is not repairable.
+command.repair.nodurability.multiple=&e{0} &citems in {1}''s {2} are not repairable.
+command.repair.error.single=&cAn error occurred repairing &e{0} &cin {1}''s {2}.
+command.repair.error.multiple=&cAn error occurred repairing &e{0} &citems in {1}''s {2}.
+command.repair.empty=&cThere are no items in {0}''s {1}.
 command.repair.location.mainhand=hand
 command.repair.location.offhand=offhand
 command.repair.location.hotbar=hotbar


### PR DESCRIPTION
Aims to complete #891. 

### Features
- [X] `/repair` or `/repair -m` - `nucleus.repair.base` - repairs the player's mainhand **(original behavior)**
- [X] `/repair -a` - `nucleus.repair.flag.all` - repairs the player's entire inventory
- [X] `/repair -h` - `nucleus.repair.flag.hotbar` - repairs the player's hotbar
- [X] `/repair -o` - `nucleus.repair.flag.offhand` - repairs the player's offhand
- [X] `/repair -e` - `nucleus.repair.flag.equip` - repairs the player's worn equipment (armor)
- [X] Adds the repair black/whitelist that was requested in Discord (#927)
- [X] Adds `nucleus.repair.exempt.restriction` to bypass the repair black/whitelist
- [X] When a single item returns the same repair result, the item is linked in the message to the player.
- [X] Up to 3 messages (success, failure, & restricted) may be sent to the player when using repair on multiple items

### Other Issues
Should I leave the use of flag args or should traditional command args be used for this command?

~~The command's messages are really going to need an overhaul to provide proper feedback. I'm already tracking how many items a processed by status for this purpose.~~ _The command messages have been completely overhauled._