### PR TITLE
Fixed motd permission check

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/info/listeners/InfoListener.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/info/listeners/InfoListener.java
@@ -32,7 +32,6 @@ public class InfoListener extends ListenerBase implements Reloadable, ListenerBa
     private final String motdPerm = Nucleus.getNucleus().getPermissionRegistry()
             .getPermissionsForNucleusCommand(MotdCommand.class).getPermissionWithSuffix("login");
 
-    private String motdPermission = null;
     private boolean usePagination = true;
     private Text title = Text.EMPTY;
 
@@ -42,7 +41,7 @@ public class InfoListener extends ListenerBase implements Reloadable, ListenerBa
     public void playerJoin(ClientConnectionEvent.Join event, @Getter("getTargetEntity") Player player) {
         // Send message one second later on the Async thread.
         Sponge.getScheduler().createAsyncExecutor(plugin).schedule(() -> {
-                if (player.hasPermission(this.motdPermission)) {
+                if (player.hasPermission(this.motdPerm)) {
                     plugin.getTextFileController(InfoModule.MOTD_KEY).ifPresent(x -> {
                         if (this.usePagination) {
                             x.sendToPlayer(player, title);


### PR DESCRIPTION
Introduced in d26810597496303df8d72464029d067a6f0e9a4e , fixes the permission check by actually referencing the correct permission string instead of always null