### PR TITLE
Add way to track potential world UUID changes.

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/Nucleus.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/Nucleus.java
@@ -34,6 +34,7 @@ import uk.co.drnaylor.quickstart.modulecontainers.DiscoveryModuleContainer;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -51,6 +52,8 @@ public abstract class Nucleus {
     public static Nucleus getNucleus() {
         return nucleus;
     }
+
+    public abstract void addX(List<Text> messages, int spacing);
 
     public abstract void saveData();
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/internal/WorldCorrector.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/internal/WorldCorrector.java
@@ -1,0 +1,147 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
+package io.github.nucleuspowered.nucleus.internal;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.reflect.TypeToken;
+import io.github.nucleuspowered.nucleus.Nucleus;
+import io.github.nucleuspowered.nucleus.internal.messages.MessageProvider;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.gson.GsonConfigurationLoader;
+import ninja.leaping.configurate.loader.ConfigurationLoader;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.source.ConsoleSource;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.event.game.state.GameStoppedServerEvent;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
+import org.spongepowered.api.world.storage.WorldProperties;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.annotation.Nullable;
+
+public class WorldCorrector {
+
+    public static void worldCheck() throws IOException, ObjectMappingException {
+        final Map<String, UUID> m = get();
+
+        // Now get the file out.
+        Path path = Nucleus.getNucleus().getDataPath().resolve("worlduuids.json");
+        ConfigurationLoader<ConfigurationNode> cl = GsonConfigurationLoader.builder().setPath(path).build();
+        Map<String, UUID> ms = cl.load().getValue(new TypeToken<Map<String, UUID>>() {}, Maps.newHashMap());
+
+        final Map<UUID, UUID> fromToConverter = Maps.newHashMap();
+        for (String r : ms.keySet()) {
+            UUID oldUuid = ms.get(r);
+            @Nullable UUID newUuid = m.get(r);
+            if (newUuid != null && !oldUuid.equals(newUuid)) {
+                fromToConverter.put(newUuid, oldUuid);
+            }
+        }
+
+        cl.save(cl.createEmptyNode().setValue(new TypeToken<Map<String, UUID>>() {}, m));
+
+        if (fromToConverter.isEmpty()) {
+            return;
+        }
+
+        MessageProvider mp = Nucleus.getNucleus().getMessageProvider();
+        ConsoleSource cs = Sponge.getServer().getConsole();
+        List<Text> msg = Lists.newArrayList();
+        Nucleus.getNucleus().addX(msg, 0);
+        msg.forEach(cs::sendMessage);
+        cs.sendMessage(Text.of(TextColors.RED, "--------------------"));
+        cs.sendMessage(mp.getTextMessageWithFormat("worldrepair.detected"));
+        for (Map.Entry<UUID, UUID> u : fromToConverter.entrySet()) {
+            cs.sendMessage(mp.getTextMessageWithFormat("worldrepair.worldlist",
+                    Sponge.getServer().getWorldProperties(u.getKey()).get().getWorldName(),
+                    u.getValue().toString(),
+                    u.getKey().toString()));
+        }
+
+        Method method;
+        try {
+            method = Sponge.getServer().getDefaultWorld().get().getClass().getDeclaredMethod("setUniqueId", UUID.class);
+            method.setAccessible(true);
+        } catch (NoSuchMethodException e) {
+            cs.sendMessage(mp.getTextMessageWithFormat("worldrepair.whitelist.nocmd"));
+            return;
+        }
+
+        cs.sendMessage(mp.getTextMessageWithFormat("worldrepair.whitelist.cmd"));
+        cs.sendMessage(Text.of(TextColors.RED, "--------------------"));
+        cs.sendMessage(mp.getTextMessageWithFormat("worldrepair.whitelist.cmd2"));
+
+        Sponge.getServer().setHasWhitelist(true);
+
+        Sponge.getCommandManager().register(Nucleus.getNucleus(), CommandSpec.builder().executor((s, a) -> {
+            MessageProvider mpr = Nucleus.getNucleus().getMessageProvider();
+            if (s instanceof ConsoleSource) {
+                cs.sendMessage(mpr.getTextMessageWithFormat("worldrepair.repair.start"));
+                Sponge.getEventManager().registerListener(Nucleus.getNucleus(), GameStoppedServerEvent.class, event -> {
+                    for (Map.Entry<UUID, UUID> meuu : fromToConverter.entrySet()) {
+                        // Magic!
+                        WorldProperties wp = Sponge.getServer().getWorldProperties(meuu.getKey()).get();
+                        String name = wp.getWorldName();
+                        try {
+                            cs.sendMessage(mpr.getTextMessageWithFormat("worldrepair.repair.try", name));
+                            method.invoke(wp, meuu.getValue());
+                            Sponge.getServer().saveWorldProperties(wp);
+                            cs.sendMessage(mpr.getTextMessageWithFormat("worldrepair.repair.success", name));
+                        } catch (Exception e) {
+                            cs.sendMessage(mpr.getTextMessageWithFormat("worldrepair.repair.fail", name));
+                            e.printStackTrace();
+                        }
+                    }
+
+                    try {
+                        cl.save(cl.createEmptyNode().setValue(new TypeToken<Map<String, UUID>>() {}, get()));
+                    } catch (IOException | ObjectMappingException e) {
+                        e.printStackTrace();
+                    }
+                });
+
+                Sponge.getServer().shutdown();
+                return CommandResult.success();
+            } else {
+                s.sendMessage(mpr.getTextMessageWithFormat("command.consoleonly"));
+                return CommandResult.empty();
+            }
+        }).build(), "repairuuids");
+
+    }
+
+    public static void delete() throws IOException {
+        Files.deleteIfExists(Nucleus.getNucleus().getDataPath().resolve("worlduuids.json"));
+    }
+
+    public static Map<String, UUID> save() throws IOException, ObjectMappingException {
+        Path path = Nucleus.getNucleus().getDataPath().resolve("worlduuids.json");
+        ConfigurationLoader<ConfigurationNode> cl = GsonConfigurationLoader.builder().setPath(path).build();
+        Map<String, UUID> g = get();
+        cl.save(cl.createEmptyNode().setValue(new TypeToken<Map<String, UUID>>() {}, g));
+        return g;
+    }
+
+    private static Map<String, UUID> get() {
+        Map<String, UUID> m = Maps.newHashMap();
+        Collection<WorldProperties> lwp = Sponge.getServer().getAllWorldProperties();
+        for (WorldProperties wp : lwp) {
+            m.put(wp.getWorldName(), wp.getUniqueId());
+        }
+        return m;
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/core/config/CoreConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/core/config/CoreConfig.java
@@ -52,6 +52,9 @@ public class CoreConfig {
     @Setting(value = "print-file-save-load")
     private boolean printSaveLoad = false;
 
+    @Setting(value = "track-world-uuids", comment = "config.core.track")
+    private boolean trackWorldUUIDs = true;
+
     public boolean isDebugmode() {
         return debugmode;
     }
@@ -106,5 +109,9 @@ public class CoreConfig {
 
     public boolean isPrintSaveLoad() {
         return this.printSaveLoad;
+    }
+
+    public boolean isTrackWorldUUIDs() {
+        return trackWorldUUIDs;
     }
 }

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -501,6 +501,8 @@ config.core.kickonstop.message=The message to display to players when restarting
 config.core.safeteleport=These parameters define how far out to check from a specific point when performing a warp. Larger numbers mean that a wider area is checked, \
 but large numbers will cause server lag. The defaults are sufficient in most cases.
 config.core.consoleoverrides=If true, commands executed by the console can affect players that normally have an exempt permission against the command.
+config.core.track=If true, if the server detects that a world UUID might have changed, Nucleus will whitelist the server and offer the chance to \
+  revert the UUID change, if it detects methods that allow it to do so. You may to turn this off if you are deleting and recreating worlds.
 
 config.misc.speed.max=Sets the maximum speed that a player can set via the /speed command.
 
@@ -1817,6 +1819,18 @@ vanish.login=&aYou are currently vanished.
 
 # World
 world.access.denied=&cYou do not have permission to access the world &e{0}&c.
+
+worldrepair.detected=&cWORLD UUID CHANGE DETECTED. The following worlds have changed UUID:
+worldrepair.worldlist=&e{0} &c({1} -> {2})
+worldrepair.whitelist.nocmd=&cThe whitelist has been enabled. You will need to make any reversions manually.
+
+worldrepair.whitelist.cmd=&cThe whitelist has been enabled. If the server is restarted, the change will be permanent.
+worldrepair.whitelist.cmd2=&cIf you want to fix the UUIDs, run &e/repairuuids &cfrom the console
+
+worldrepair.repair.start=&cStarting repair. The server will shut down to complete this process.
+worldrepair.repair.try=&cTrying to repair &e{0}
+worldrepair.repair.success=&aSuccesfully repaired &e{0}
+worldrepair.repair.fail=&cUnable to repair &e{0}
 
 # Permission Descriptions
 permission.base=Allows the user to run the command /{0}

--- a/src/test/java/io/github/nucleuspowered/nucleus/tests/TestBase.java
+++ b/src/test/java/io/github/nucleuspowered/nucleus/tests/TestBase.java
@@ -45,6 +45,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -95,6 +96,11 @@ public abstract class TestBase {
 
         private final MessageProvider mp = new ResourceMessageProvider(ResourceMessageProvider.messagesBundle);
         private final PermissionRegistry permissionRegistry = new PermissionRegistry();
+
+        @Override
+        public void addX(List<Text> messages, int spacing) {
+            // NOOP
+        }
 
         @Override
         public void saveData() {


### PR DESCRIPTION
On each startup, Nucleus determines the mapping of world name -> UUID. If a world doesn't match the UUID on subsequent startups, Nucleus whitelists the server and offers the `/repairuuid` command, which will correct it and shutdown the server if it can find the right methods.

Fixes #834