### PR TITLE
Add gamerules alias & suggest command click actions

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/GameruleCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/GameruleCommand.java
@@ -16,6 +16,7 @@ import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.args.CommandElement;
 import org.spongepowered.api.command.args.GenericArguments;
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.action.TextActions;
 import org.spongepowered.api.text.serializer.TextSerializers;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.api.world.storage.WorldProperties;
@@ -29,7 +30,7 @@ import java.util.stream.Collectors;
 @NoModifiers
 @NonnullByDefault
 @Permissions(prefix = "world", suggestedLevel = SuggestedLevel.ADMIN)
-@RegisterCommand(value = { "gamerule" }, subcommandOf = WorldCommand.class)
+@RegisterCommand(value = { "gamerule" }, subcommandOf = WorldCommand.class, rootAliasRegister = "gamerules")
 public class GameruleCommand extends AbstractCommand<CommandSource> {
 
     private static final String worldKey = "world";
@@ -46,7 +47,10 @@ public class GameruleCommand extends AbstractCommand<CommandSource> {
 
         String message = plugin.getMessageProvider().getMessageWithFormat("command.world.gamerule.key");
         List<Text> text = gameRules.entrySet().stream().sorted(Comparator.comparing(Map.Entry::getKey))
-            .map(x -> TextSerializers.FORMATTING_CODE.deserialize(MessageFormat.format(message, x.getKey(), x.getValue())))
+            .map(x -> Text.of(
+                TextActions.suggestCommand(String.format("/world gamerule set %s %s ", worldProperties.getWorldName(), x.getKey())),
+                TextSerializers.FORMATTING_CODE.deserialize(MessageFormat.format(message, x.getKey(), x.getValue()))
+            ))
             .collect(Collectors.toList());
 
         Util.getPaginationBuilder(src)


### PR DESCRIPTION
Adds `/gamerules` as an alias for `/world gamerule`
Makes the gamerule text in `/world gamerule`'s output clickable to allow quick modification of gamerules.