### PR TITLE
[WIP] Private Messaging Service Enhancements

### DIFF
--- a/nucleus-api/src/main/java/io/github/nucleuspowered/nucleus/api/service/NucleusPrivateMessagingService.java
+++ b/nucleus-api/src/main/java/io/github/nucleuspowered/nucleus/api/service/NucleusPrivateMessagingService.java
@@ -228,4 +228,12 @@ public interface NucleusPrivateMessagingService {
      */
     <T extends CommandSource & Identifiable> void registerMessageTarget(UUID uniqueId, String targetName, @Nullable Text displayName, Supplier<T> target)
         throws NullPointerException, IllegalArgumentException, IllegalStateException;
+
+    /**
+     * Removes a previously registered message target.
+     *
+     * @param uniqueId The {@link UUID} of the target.
+     * @throws IllegalStateException thrown if the {@link UUID} is not registered.
+     */
+    void removeMessageTarget(UUID uniqueId) throws IllegalStateException;
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/message/handlers/MessageHandler.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/message/handlers/MessageHandler.java
@@ -354,6 +354,14 @@ public class MessageHandler implements NucleusPrivateMessagingService {
         targetNames.put(targetName.toLowerCase(), uniqueId);
     }
 
+    @Override
+    public void removeMessageTarget(UUID uniqueId) throws IllegalStateException {
+        Preconditions.checkState(targets.containsKey(uniqueId), "UUID not registered");
+
+        targetNames.remove(targets.get(uniqueId).targetName.toLowerCase());
+        targets.remove(uniqueId);
+    }
+
     public Optional<CommandSource> getLastMessageFrom(UUID from) {
         Preconditions.checkNotNull(from);
         UUID to = messagesReceived.get(from);


### PR DESCRIPTION
The NucleusPrivateMessagingService is in need of enhancements to make it truly viable for cross-server and/or cross-platform private messaging.

Requirements:
- [X] Ability to remove Message Targets
- [ ] Add an alternative to `MessageReciever#sendMessage(Text text)` where the sender is also passed
- [ ] Remove the requirement to construct a `CommandSource`. Most of the methods are unnecessary for a message target
