### PR TITLE
Refactor some group template logic to allow some servers to reduce overhead

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/config/ChatConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/config/ChatConfig.java
@@ -18,9 +18,6 @@ public class ChatConfig {
     @Setting(value = "modify-chat", comment = "config.chat.modify")
     private boolean modifychat = true;
 
-    @Setting(value = "use-group-templates", comment = "config.chat.useGroupTemplates")
-    private boolean useGroupTemplates = true;
-
     @Setting(value = "templates")
     private TemplateConfig templates = new TemplateConfig();
 
@@ -56,7 +53,11 @@ public class ChatConfig {
     }
 
     public boolean isUseGroupTemplates() {
-        return useGroupTemplates;
+        return this.templates.isUseGroupTemplates();
+    }
+
+    public boolean isCheckPermissionGroups() {
+        return this.templates.isCheckPermissionGroups();
     }
 
     public ChatTemplateConfig getDefaultTemplate() {

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/config/ChatConfigAdapter.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/config/ChatConfigAdapter.java
@@ -19,20 +19,6 @@ public class ChatConfigAdapter extends NucleusConfigAdapter.StandardWithSimpleDe
     @Override
     protected List<Transformation> getTransformations() {
         return Lists.newArrayList(
-            new Transformation(new Object[] {"template"}, ((inputPath, valueAtPath) -> new Object[] { "templates", "default" })),
-            new Transformation(new Object[] {"group-templates"}, ((inputPath, valueAtPath) -> new Object[] { "templates", "group-templates" })),
-            new Transformation(new Object[] {"modifychat"}, ((inputPath, valueAtPath) -> new Object[] { "modify-chat" })),
-            new Transformation(new Object[] {"templates", "group-templates"}, (((inputPath, valueAtPath) -> {
-                if (valueAtPath instanceof CommentedConfigurationNode) {
-                    CommentedConfigurationNode ccn = (CommentedConfigurationNode)valueAtPath;
-                    ccn.getComment().ifPresent(x -> {
-                        if (x.equals("Group templates override the default chat template based on the users group. Note that the group name is case sensitive.")) {
-                            ccn.setComment(null);
-                        }
-                    });
-                }
-
-                return null;
-            }))));
+                Transformation.moveFrom("use-group-templates").to("templates", "use-group-templates"));
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/config/TemplateConfig.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/config/TemplateConfig.java
@@ -14,6 +14,12 @@ import java.util.Map;
 @ConfigSerializable
 public class TemplateConfig {
 
+    @Setting(value = "use-group-templates", comment = "config.chat.useGroupTemplates")
+    private boolean useGroupTemplates = true;
+
+    @Setting(value = "check-permission-groups", comment = "config.chat.check-permission-groups")
+    private boolean checkPermissionGroups = true;
+
     @Setting(value = "default", comment = "config.chat.default-template")
     private ChatTemplateConfig defaultTemplate = new ChatTemplateConfig();
 
@@ -25,10 +31,18 @@ public class TemplateConfig {
     }};
 
     public ChatTemplateConfig getDefaultTemplate() {
-        return defaultTemplate;
+        return this.defaultTemplate;
     }
 
     public Map<String, WeightedChatTemplateConfig> getGroupTemplates() {
-        return groupTemplates;
+        return this.groupTemplates;
+    }
+
+    public boolean isUseGroupTemplates() {
+        return this.useGroupTemplates;
+    }
+
+    public boolean isCheckPermissionGroups() {
+        return this.checkPermissionGroups;
     }
 }

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/util/TemplateUtil.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/chat/util/TemplateUtil.java
@@ -11,11 +11,24 @@ import io.github.nucleuspowered.nucleus.modules.chat.config.ChatConfig;
 import io.github.nucleuspowered.nucleus.modules.chat.config.ChatConfigAdapter;
 import io.github.nucleuspowered.nucleus.modules.chat.config.ChatTemplateConfig;
 import io.github.nucleuspowered.nucleus.modules.chat.config.WeightedChatTemplateConfig;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.scheduler.Task;
+import org.spongepowered.api.service.context.Contextual;
 import org.spongepowered.api.service.permission.Subject;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 /**
@@ -23,57 +36,95 @@ import java.util.stream.Collectors;
  */
 public class TemplateUtil implements Reloadable {
 
-    private List<Map<String, WeightedChatTemplateConfig>> cachedTemplates = null;
-    private final ChatConfigAdapter chatConfigAdapter
-            = Nucleus.getNucleus().getInternalServiceManager().getServiceUnchecked(ChatConfigAdapter.class);
+    private final AtomicBoolean currentlyReloading = new AtomicBoolean(false);
+    private LinkedHashMap<String, WeightedChatTemplateConfig> cachedTemplates = null;
+    private ChatConfig config
+            = Nucleus.getNucleus().getInternalServiceManager().getServiceUnchecked(ChatConfigAdapter.class).getNodeOrDefault();
 
     public ChatTemplateConfig getTemplateNow(Subject subject) {
-        return getTemplate(subject).join();
-    }
+        if (!this.config.isUseGroupTemplates()) {
+            return this.config.getDefaultTemplate();
+        }
 
-    public CompletableFuture<ChatTemplateConfig> getTemplate(Subject subject) {
-        return CompletableFuture.supplyAsync(() -> {
-            ChatConfig cc = chatConfigAdapter.getNodeOrDefault();
-            List<Subject> groups;
+        Optional<String> groupString = subject.getOption("nucleus.chat.group");
+        List<String> groups = new ArrayList<>();
+        if (groupString.isPresent()) {
+            groups.add(groupString.get());
+        } else if (this.config.isCheckPermissionGroups()) {
+            // Expensive, should hide behind a switch.
             try {
-                groups = Util.getParentSubjects(subject).get();
+                groups = Util.getParentSubjects(subject)
+                    .get(100, TimeUnit.MILLISECONDS)
+                    .stream()
+                    .map(Contextual::getIdentifier)
+                    .collect(Collectors.toList());
             } catch (Exception e) {
-                return cc.getDefaultTemplate();
+                Nucleus.getNucleus().getLogger().error(
+                        Nucleus.getNucleus().getMessageProvider().getMessageWithFormat("chat.templates.timeout", subject.getIdentifier())
+                );
+                return this.config.getDefaultTemplate();
             }
 
             if (groups == null || groups.isEmpty()) {
-                return cc.getDefaultTemplate();
+                return this.config.getDefaultTemplate();
             }
+        } else {
+            // Nothin'. Return
+            return this.config.getDefaultTemplate();
+        }
 
-            if (this.cachedTemplates == null) {
-                this.cachedTemplates = cc.getGroupTemplates()
-                        .entrySet()
-                        .stream()
-                        .collect(Collectors.groupingBy(x -> x.getValue().getWeight(), Collectors.toSet()))
-                        .entrySet()
-                        .stream()
-                        // Reverse order.
-                        .sorted((first, second) -> second.getKey().compareTo(first.getKey()))
-                        .map(x -> x.getValue().stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
-                        .collect(Collectors.toList());
-            }
-
-            // For each weight...
-            for (Map<String, WeightedChatTemplateConfig> templates : cachedTemplates) {
-                // Iterate through all groups the subject is in.
-                for (Subject group : groups) {
-                    if (templates.containsKey(group.getIdentifier())) {
-                        return templates.get(group.getIdentifier());
-                    }
+        // For each weight...
+        for (Map.Entry<String, WeightedChatTemplateConfig> templates : this.cachedTemplates.entrySet()) {
+            // Iterate through all groups the subject is in.
+            for (String group : groups) {
+                if (templates.getKey().equalsIgnoreCase(group)) {
+                    return templates.getValue();
                 }
             }
+        }
 
-            // Return the default.
-            return cc.getDefaultTemplate();
-        });
+        // Return the default.
+        return this.config.getDefaultTemplate();
     }
 
-    @Override public void onReload() throws Exception {
-        this.cachedTemplates = null;
+    @Override
+    public void onReload() throws Exception {
+        try {
+            this.config = Nucleus.getNucleus().getInternalServiceManager().getServiceUnchecked(ChatConfigAdapter.class).getNodeOrDefault();
+            if (!this.currentlyReloading.get()) {
+                this.currentlyReloading.set(true);
+                // Do this off the main thread to not cause a lockup
+                Task.builder().async().execute(() -> {
+                    try {
+                        if (this.config.isUseGroupTemplates()) {
+                            LinkedHashMap<String, WeightedChatTemplateConfig> sw = new LinkedHashMap<>();
+                            SortedMap<Integer, Set<Map.Entry<String, WeightedChatTemplateConfig>>> firstStage =
+                                    new TreeMap<>(Comparator.reverseOrder());
+                            for (Map.Entry<String, WeightedChatTemplateConfig> me : this.config.getGroupTemplates().entrySet()) {
+                                // For each weight, get the set.
+                                Set<Map.Entry<String, WeightedChatTemplateConfig>> sme = firstStage
+                                        .computeIfAbsent(me.getValue().getWeight(), s -> new HashSet<>());
+
+                                sme.add(me);
+                            }
+
+                            // keySet is in order.
+                            for (int i : firstStage.keySet()) {
+                                firstStage.get(i).forEach(x -> sw.put(x.getKey(), x.getValue()));
+                            }
+
+                            this.cachedTemplates = sw;
+                        } else {
+                            this.cachedTemplates = new LinkedHashMap<>();
+                        }
+                    } finally {
+                        this.currentlyReloading.set(false);
+                    }
+                }).submit(Nucleus.getNucleus());
+
+            }
+        } catch (Exception e) {
+            this.currentlyReloading.set(false);
+        }
     }
 }

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -264,12 +264,17 @@ they are in the both groups.
 config.chat.useGroupTemplates=If "true", then Nucleus will select the most appropriate group template for a player when they send a chat message. If it''s false \n\
 the default template will always be used, but there will be a performance gain because a player''s groups not not have to be retrieved from the permission plugin. \n\
 Turn this off if you are getting severe performance problems when someone chats, it''s usually due to a misbehaving permissions plugin.
+config.chat.check-permission-groups=If true, Nucleus will select the most appropriate group template for a player when they send a chat message by \
+  checking all of the groups that a player has if the player does not have the "nucleus.chat.group" permission option set. If false, Nucleus will \
+  only look for the "nucleus.chat.group" option on players when they chat and will match that to the available group templates, if no match, \
+  Nucleus will apply the default template without checking actual permission groups. \n\n\
+  If your chat is lagging and you have group templates turned on, try setting this to false and giving your groups the appropriate \
+  "nucleus.chat.group" permission option.
 config.chat.main=If true, Nucleus will take the message and try to apply it''s own transforms to it. This may overwrite other plugins who do processing super early, so turn this off if you are having problems.
 config.chat.includeprefix=If false, Nucleus will prepend it''s prefixes/headers with those already set buy other plugins. If true, it will \
   overwrite them.
 config.chat.includesuffix=If false, Nucleus will prepend it''s suffixes/footers with those already set buy other plugins. If true, it will \
-  overwrite \
-  them.
+  overwrite them.
 config.chat.meprefix=The prefix to use when someone uses "/me".
 config.chat.checkbody=Some mods and plugins move the Minecraft player prefix to the main message body. If this is the case, turn this on, and Nucleus \n\
   will try to remove it.
@@ -1733,6 +1738,10 @@ command.crafting.error=&cCould not open the requested crafting window.
 
 command.trash.title=Trash
 command.trash.error=&cCould not open the trash inventory window.
+
+# Chat
+chat.templates.timeout=Could not retrieve parent groups for {0} in time. Consider turning group templates off, or using "nucleus.chat.group" \
+  permission options only.
 
 # Ban
 ban.defaultreason=The BanHammer has spoken!


### PR DESCRIPTION
There is now a new permission option, "nucleus.chat.group" that can be applied to groups or users to force the use of that group when selecting a group template. This bypasses potentially expensive checks during runtime by not having to calculate the parent groups for a player.

Servers are then encouraged to turn off the new chat config option "chat.templates.check-permission-groups" once they have added the required options to the groups. This should result in a performance gain by servers.

This will also stop rare watchdog errors killing the server when players chat - the time the system is allowed to take to perform these operations is 100ms, which is enough to slow a server down to a crawl but would be a more noticeable problem. Nucleus will spit the error into the console, allowing for servers to be shut down cleanly.

Works around #1073

<!--
    When submitting a PR, please include the following:

    * Use case
    * A list of changes
    * Any related changes/issues

    If your PR is not finished but you're seeking a review on it, mark it with [WIP].
-->
