### PR TITLE
Set seed before creating world archetype

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/CreateWorldCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/CreateWorldCommand.java
@@ -167,8 +167,9 @@ public class CreateWorldCommand extends AbstractCommand<CommandSource> implement
         .commandsAllowed(allowCommands)
         .generateBonusChest(bonusChest);
 
-        WorldArchetype wa = worldSettingsBuilder.build(nameInput.toLowerCase(), nameInput);
         seedInput.ifPresent(worldSettingsBuilder::seed);
+
+        WorldArchetype wa = worldSettingsBuilder.build(nameInput.toLowerCase(), nameInput);
 
         src.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat("command.world.create.begin", nameInput));
         src.sendMessage(plugin.getMessageProvider().getTextMessageWithFormat("command.world.create.newparams",


### PR DESCRIPTION
Fixes #1072

Setting the seed won't have any effect if the `WorldArchetype` is built _before_ the seed is set.