### PR TITLE
Added further identification to /blockzap

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/BlockZapCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/BlockZapCommand.java
@@ -39,6 +39,7 @@ public class BlockZapCommand extends AbstractCommand<CommandSource> {
 
     @Override public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
         Location<World> location = args.<Location<World>>getOne(this.locationKey).get();
+        String getBlockZapped = location.getBlockType ().getName ();
         if (location.getBlockType() == BlockTypes.AIR) {
             throw new ReturnMessageException(Nucleus.getNucleus()
                     .getMessageProvider().getTextMessageWithFormat("command.blockzap.alreadyair", location.getPosition().toString(), location.getExtent().getName()));
@@ -46,7 +47,7 @@ public class BlockZapCommand extends AbstractCommand<CommandSource> {
 
         if (CauseStackHelper.createFrameWithCausesWithReturn(c -> location.setBlock(BlockTypes.AIR.getDefaultState(), BlockChangeFlags.ALL), src)) {
             src.sendMessage(Nucleus.getNucleus()
-                    .getMessageProvider().getTextMessageWithFormat("command.blockzap.success", location.getPosition().toString(), location.getExtent().getName()));
+                    .getMessageProvider().getTextMessageWithFormat("command.blockzap.success", location.getPosition().toString(), location.getExtent().getName(), getBlockZapped));
             return CommandResult.success();
         }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/BlockZapCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/BlockZapCommand.java
@@ -10,18 +10,32 @@ import io.github.nucleuspowered.nucleus.internal.annotations.command.RegisterCom
 import io.github.nucleuspowered.nucleus.internal.command.AbstractCommand;
 import io.github.nucleuspowered.nucleus.internal.command.ReturnMessageException;
 import io.github.nucleuspowered.nucleus.internal.docgen.annotations.EssentialsEquivalent;
+import io.github.nucleuspowered.nucleus.modules.item.commands.RepairCommand;
 import io.github.nucleuspowered.nucleus.util.CauseStackHelper;
+import jdk.nashorn.internal.ir.Block;
+import org.spongepowered.api.block.BlockType;
 import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.args.CommandElement;
 import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.item.ItemType;
+import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 import org.spongepowered.api.text.Text;
+import java.*;
+import org.spongepowered.api.text.action.TextActions;
+import org.spongepowered.api.text.format.TextStyle;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import org.spongepowered.api.world.BlockChangeFlags;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
+
+
+import java.util.EnumMap;
+import java.util.Optional;
 
 @NonnullByDefault
 @Permissions
@@ -40,14 +54,20 @@ public class BlockZapCommand extends AbstractCommand<CommandSource> {
     @Override public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
         Location<World> location = args.<Location<World>>getOne(this.locationKey).get();
         String getBlockZapped = location.getBlockType ().getName ();
+        ItemStack item = ItemStack.builder()
+                .fromBlockState(location.getBlock())
+                .build();
+        Text itemText = item.get(Keys.DISPLAY_NAME).orElse(Text.of(item.getTranslation().get())).toBuilder()
+                .onHover(TextActions.showItem(item.createSnapshot()))
+                .build();
         if (location.getBlockType() == BlockTypes.AIR) {
             throw new ReturnMessageException(Nucleus.getNucleus()
                     .getMessageProvider().getTextMessageWithFormat("command.blockzap.alreadyair", location.getPosition().toString(), location.getExtent().getName()));
         }
 
         if (CauseStackHelper.createFrameWithCausesWithReturn(c -> location.setBlock(BlockTypes.AIR.getDefaultState(), BlockChangeFlags.ALL), src)) {
-            src.sendMessage(Nucleus.getNucleus()
-                    .getMessageProvider().getTextMessageWithFormat("command.blockzap.success", location.getPosition().toString(), location.getExtent().getName(), getBlockZapped));
+
+            src.sendMessage(Nucleus.getNucleus().getMessageProvider().getTextMessageWithTextFormat("command.blockzap.success", Text.of(location.getPosition().toString()), Text.of(location.getExtent().getName()), itemText));
             return CommandResult.success();
         }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/BlockZapCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/BlockZapCommand.java
@@ -53,7 +53,6 @@ public class BlockZapCommand extends AbstractCommand<CommandSource> {
 
     @Override public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
         Location<World> location = args.<Location<World>>getOne(this.locationKey).get();
-        String getBlockZapped = location.getBlockType ().getName ();
         ItemStack item = ItemStack.builder()
                 .fromBlockState(location.getBlock())
                 .build();
@@ -67,7 +66,8 @@ public class BlockZapCommand extends AbstractCommand<CommandSource> {
 
         if (CauseStackHelper.createFrameWithCausesWithReturn(c -> location.setBlock(BlockTypes.AIR.getDefaultState(), BlockChangeFlags.ALL), src)) {
 
-            src.sendMessage(Nucleus.getNucleus().getMessageProvider().getTextMessageWithTextFormat("command.blockzap.success", Text.of(location.getPosition().toString()), Text.of(location.getExtent().getName()), itemText));
+            src.sendMessage(Nucleus.getNucleus()
+                            .getMessageProvider().getTextMessageWithTextFormat("command.blockzap.success", Text.of(location.getPosition().toString()), Text.of(location.getExtent().getName()), itemText));
             return CommandResult.success();
         }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/BlockZapCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/BlockZapCommand.java
@@ -53,17 +53,16 @@ public class BlockZapCommand extends AbstractCommand<CommandSource> {
 
     @Override public CommandResult executeCommand(CommandSource src, CommandContext args) throws Exception {
         Location<World> location = args.<Location<World>>getOne(this.locationKey).get();
+        if (location.getBlockType() == BlockTypes.AIR) {
+            throw new ReturnMessageException(Nucleus.getNucleus()
+                    .getMessageProvider().getTextMessageWithFormat("command.blockzap.alreadyair", location.getPosition().toString(), location.getExtent().getName()));
+        }
         ItemStack item = ItemStack.builder()
                 .fromBlockState(location.getBlock())
                 .build();
         Text itemText = item.get(Keys.DISPLAY_NAME).orElse(Text.of(item.getTranslation().get())).toBuilder()
                 .onHover(TextActions.showItem(item.createSnapshot()))
                 .build();
-        if (location.getBlockType() == BlockTypes.AIR) {
-            throw new ReturnMessageException(Nucleus.getNucleus()
-                    .getMessageProvider().getTextMessageWithFormat("command.blockzap.alreadyair", location.getPosition().toString(), location.getExtent().getName()));
-        }
-
         if (CauseStackHelper.createFrameWithCausesWithReturn(c -> location.setBlock(BlockTypes.AIR.getDefaultState(), BlockChangeFlags.ALL), src)) {
 
             src.sendMessage(Nucleus.getNucleus()

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -1706,7 +1706,7 @@ command.nameban.notvalid=&cThat is not a valid username. Usernames are between 3
 command.nameban.pardon.success=&aAny player with the name &e{0} &acan now join the server.
 command.nameban.pardon.failed=&cThe name &e{0} &cis already allowed to join the server.
 
-command.blockzap.success=&aSuccessfully zapped the block at &e{0}&a in the world &e{1}&a.
+command.blockzap.success=&aSuccessfully zapped the block &e{2} &aat &e{0}&a in the world &e{1}&a.
 command.blockzap.fail=&cCould not zap the block at &e{0}&c in the world &e{1}&c.
 command.blockzap.alreadyair=&cThe block at &e{0} &cin the world &e{1}&c is already air.
 


### PR DESCRIPTION
**First Pull Request on Nucleus**

The change in this request adds a block identifier when running the the /blockzap command, (Only if successful of course). It gives the ID of the block that was zapped in the output message. This is a fully working change and I have tested it on Modded and Vanilla.

I feel this will be helpful for server moderators/admins as it will mean they can make sure that the block they are trying to remove has been removed.

Thanks, 
TheFlash787 at ModRealms
