### PR TITLE
Remove confusing line of code that does nothing

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/item/commands/SkullCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/item/commands/SkullCommand.java
@@ -99,8 +99,6 @@ public class SkullCommand extends AbstractCommand<Player> implements Reloadable 
         // Set it to subject skull type and set the owner to the specified subject
         if (skullStack.offer(Keys.SKULL_TYPE, SkullTypes.PLAYER).isSuccessful()
                 && skullStack.offer(Keys.REPRESENTED_PLAYER, user.getProfile()).isSuccessful()) {
-            skullStack.toContainer().set(DataQuery.of("SkullOwner"), user.getName());
-
             List<ItemStack> itemStackList = Lists.newArrayList();
 
             // If there were stacks, create as many as needed.


### PR DESCRIPTION
There's a line in `SkullCommand.java` that apparently does nothing.
I asked about this line in the SpongePowered Discord, and I was told by @Aaron1011 that it "will modify a fresh DataContainer which isn't connected to the skull".  He mentioned that the proper way is to use RepresentedPlayerData -- but the REPRESENTED_PLAYER key is already set to `user.getProfile()`, so even if the line did anything it would be redundant.