### PR TITLE
Split a configurate getNode call chain to use Optional#map

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/dataservices/modular/DataModule.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/dataservices/modular/DataModule.java
@@ -72,7 +72,7 @@ public abstract class DataModule<S extends ModularDataService<S>> {
 
     protected <T> Optional<T> getValue(TypeToken<T> token, String path, ConfigurationNode node) {
         try {
-            return Optional.ofNullable(node.getNode(path).getValue(token));
+            return Optional.ofNullable(node.getNode(path)).map(innerNode -> innerNode.getValue(token));
         } catch (ObjectMappingException e) {
             e.printStackTrace();
             return Optional.empty();


### PR DESCRIPTION
Hello, I have been getting some reports about a NPE occurring on startup with Nucleus because of my plugin. 
I tracked the issue to this line of code, although it might require a different kind of change.

I do not know how Configurate works or how Nucleus handles configuration loading, so I am not sure if it resolves the underlying issue (There might be something wrong with the configuration file or I am calling Nucleus API too early after enable). 

There might be another way the line throws an NPE - it is not documented in Configurate API if one is thrown in their code.

### List of changes

- Changed one chain without null check to use Optional#map to prevent an NPE

### Related issues

https://github.com/plan-player-analytics/Plan/issues/1075

Issue includes
- gist of error stack trace
- gist of warps configuration file