### PR TITLE
Added subcommands to add and remove time from a world

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/environment/commands/AddTimeCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/environment/commands/AddTimeCommand.java
@@ -1,3 +1,7 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
 package io.github.nucleuspowered.nucleus.modules.environment.commands;
 
 import io.github.nucleuspowered.nucleus.Nucleus;
@@ -20,7 +24,6 @@ import java.util.function.LongFunction;
 
 @Permissions(prefix = "time")
 @RegisterCommand(value = "add", subcommandOf = TimeCommand.class, rootAliasRegister = { "addtime", "timeadd" })
-@EssentialsEquivalent(value = {"time", "day", "night"}, isExact = false, notes = "A time MUST be specified.")
 @NonnullByDefault
 public class AddTimeCommand extends AbstractCommand<CommandSource> {
     private final String time = "time";
@@ -41,7 +44,7 @@ public class AddTimeCommand extends AbstractCommand<CommandSource> {
         long tick = args.<Long>getOne(this.time).get();
         long time = pr.getWorldTime() + tick;
         pr.setWorldTime(time);
-        src.sendMessage(Nucleus.getNucleus().getMessageProvider().getTextMessageWithFormat("command.addtime.done2",
+        src.sendMessage(Nucleus.getNucleus().getMessageProvider().getTextMessageWithFormat("command.addtime.done",
                 pr.getWorldName(),
                 tick,
                 Util.getTimeFromTicks(time)));

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/environment/commands/AddTimeCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/environment/commands/AddTimeCommand.java
@@ -1,0 +1,50 @@
+package io.github.nucleuspowered.nucleus.modules.environment.commands;
+
+import io.github.nucleuspowered.nucleus.Nucleus;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.argumentparsers.WorldTimeArgument;
+import io.github.nucleuspowered.nucleus.internal.annotations.command.Permissions;
+import io.github.nucleuspowered.nucleus.internal.annotations.command.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.AbstractCommand;
+import io.github.nucleuspowered.nucleus.internal.docgen.annotations.EssentialsEquivalent;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.api.world.storage.WorldProperties;
+import java.util.function.LongFunction;
+
+@Permissions(prefix = "time")
+@RegisterCommand(value = "add", subcommandOf = TimeCommand.class, rootAliasRegister = { "addtime", "timeadd" })
+@EssentialsEquivalent(value = {"time", "day", "night"}, isExact = false, notes = "A time MUST be specified.")
+@NonnullByDefault
+public class AddTimeCommand extends AbstractCommand<CommandSource> {
+    private final String time = "time";
+    private final String world = "world";
+
+    @Override
+    public CommandElement[] getArguments() {
+        return new CommandElement[] {
+                GenericArguments.optionalWeak(GenericArguments.onlyOne(GenericArguments.world(Text.of(this.world)))),
+                GenericArguments.onlyOne(GenericArguments.longNum(Text.of(this.time)))
+        };
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args, Cause cause) {
+        WorldProperties pr = getWorldPropertiesOrDefault(src, this.world, args);
+
+        long tick = args.<Long>getOne(this.time).get();
+        long time = pr.getWorldTime() + tick;
+        pr.setWorldTime(time);
+        src.sendMessage(Nucleus.getNucleus().getMessageProvider().getTextMessageWithFormat("command.addtime.done2",
+                pr.getWorldName(),
+                tick,
+                Util.getTimeFromTicks(time)));
+        return CommandResult.success();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/environment/commands/RemoveTimeCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/environment/commands/RemoveTimeCommand.java
@@ -1,0 +1,48 @@
+package io.github.nucleuspowered.nucleus.modules.environment.commands;
+
+import io.github.nucleuspowered.nucleus.Nucleus;
+import io.github.nucleuspowered.nucleus.Util;
+import io.github.nucleuspowered.nucleus.internal.annotations.command.Permissions;
+import io.github.nucleuspowered.nucleus.internal.annotations.command.RegisterCommand;
+import io.github.nucleuspowered.nucleus.internal.command.AbstractCommand;
+import io.github.nucleuspowered.nucleus.internal.docgen.annotations.EssentialsEquivalent;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.args.GenericArguments;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.util.annotation.NonnullByDefault;
+import org.spongepowered.api.world.storage.WorldProperties;
+
+@Permissions(prefix = "time")
+@RegisterCommand(value = "remove", subcommandOf = TimeCommand.class, rootAliasRegister = { "removetime", "timeremove"})
+@EssentialsEquivalent(value = {"time", "day", "night"}, isExact = false, notes = "A time MUST be specified.")
+@NonnullByDefault
+public class RemoveTimeCommand extends AbstractCommand<CommandSource> {
+    private final String time = "time";
+    private final String world = "world";
+
+    @Override
+    public CommandElement[] getArguments() {
+        return new CommandElement[] {
+                GenericArguments.optionalWeak(GenericArguments.onlyOne(GenericArguments.world(Text.of(this.world)))),
+                GenericArguments.onlyOne(GenericArguments.longNum(Text.of(this.time)))
+        };
+    }
+
+    @Override
+    public CommandResult executeCommand(CommandSource src, CommandContext args, Cause cause) {
+        WorldProperties pr = getWorldPropertiesOrDefault(src, this.world, args);
+
+        long tick = args.<Long>getOne(this.time).get();
+        long time = pr.getWorldTime() - tick;
+        pr.setWorldTime(time);
+        src.sendMessage(Nucleus.getNucleus().getMessageProvider().getTextMessageWithFormat("command.removetime.done2",
+                pr.getWorldName(),
+                tick,
+                Util.getTimeFromTicks(time)));
+        return CommandResult.success();
+    }
+}

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/environment/commands/RemoveTimeCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/environment/commands/RemoveTimeCommand.java
@@ -1,3 +1,7 @@
+/*
+ * This file is part of Nucleus, licensed under the MIT License (MIT). See the LICENSE.txt file
+ * at the root of this project for more details.
+ */
 package io.github.nucleuspowered.nucleus.modules.environment.commands;
 
 import io.github.nucleuspowered.nucleus.Nucleus;
@@ -18,7 +22,6 @@ import org.spongepowered.api.world.storage.WorldProperties;
 
 @Permissions(prefix = "time")
 @RegisterCommand(value = "remove", subcommandOf = TimeCommand.class, rootAliasRegister = { "removetime", "timeremove"})
-@EssentialsEquivalent(value = {"time", "day", "night"}, isExact = false, notes = "A time MUST be specified.")
 @NonnullByDefault
 public class RemoveTimeCommand extends AbstractCommand<CommandSource> {
     private final String time = "time";
@@ -39,7 +42,7 @@ public class RemoveTimeCommand extends AbstractCommand<CommandSource> {
         long tick = args.<Long>getOne(this.time).get();
         long time = pr.getWorldTime() - tick;
         pr.setWorldTime(time);
-        src.sendMessage(Nucleus.getNucleus().getMessageProvider().getTextMessageWithFormat("command.removetime.done2",
+        src.sendMessage(Nucleus.getNucleus().getMessageProvider().getTextMessageWithFormat("command.removetime.done",
                 pr.getWorldName(),
                 tick,
                 Util.getTimeFromTicks(time)));

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/environment/commands/SetTimeCommand.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/environment/commands/SetTimeCommand.java
@@ -46,7 +46,7 @@ public class SetTimeCommand extends AbstractCommand<CommandSource> {
         LongFunction<Long> tick = args.<LongFunction<Long>>getOne(this.time).get();
         long time = tick.apply(pr.getWorldTime());
         pr.setWorldTime(time);
-        src.sendMessage(Nucleus.getNucleus().getMessageProvider().getTextMessageWithFormat("command.settime.done2",
+        src.sendMessage(Nucleus.getNucleus().getMessageProvider().getTextMessageWithFormat("command.settime.done",
                 pr.getWorldName(),
                 String.valueOf(Util.getTimeFromTicks(time))));
         return CommandResult.success();

--- a/src/main/resources/assets/nucleus/commands.properties
+++ b/src/main/resources/assets/nucleus/commands.properties
@@ -1,5 +1,7 @@
 time.desc=Gets the time for the specified world.
 time.set.desc=Sets the time for the specified world.
+time.add.desc=Adds time for the specified world.
+time.remove.desc=Removes time from the specified world.
 exp.give.desc=Gives experience to the specified player.
 exp.give.extended=If you want to add raw experience, just add the number as an argument. If you want to add a specific number of levels, the argument can be of \
 the form "L30" or "30L" (assuming you want to give 30 levels).

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -1216,6 +1216,8 @@ command.weather.locked=&cThe weather is locked for the world &e{0}&c. It must be
 
 command.settime.done=&aThe time on the world has been set to &e{0}&a.
 command.settime.done2=&aThe time on the world "&e{0}&a" has been set to &e{1}&a.
+command.addtime.done=&aThe time on the world has been increased by &e{0} ticks &aand is now &e{1}&a.
+command.addtime.done2=&aThe time on the world "&e{0}&a" has been increased by &e{1} ticks &aand is now &e{2}&a.
 command.time=&aThe time on world &e{0} &ais currently &e{1}&a.
 
 command.servertime.time=&aCurrent server wall clock time: &e{0}&a.

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -1218,6 +1218,8 @@ command.settime.done=&aThe time on the world has been set to &e{0}&a.
 command.settime.done2=&aThe time on the world "&e{0}&a" has been set to &e{1}&a.
 command.addtime.done=&aThe time on the world has been increased by &e{0} ticks &aand is now &e{1}&a.
 command.addtime.done2=&aThe time on the world "&e{0}&a" has been increased by &e{1} ticks &aand is now &e{2}&a.
+command.removetime.done=&aThe time on the world has been decreased by &e{0} ticks &aand is now &e{1}&a.
+command.removetime.done2=&aThe time on the world "&e{0}&a" has been decreased by &e{1} ticks &aand is now &e{2}&a.
 command.time=&aThe time on world &e{0} &ais currently &e{1}&a.
 
 command.servertime.time=&aCurrent server wall clock time: &e{0}&a.

--- a/src/main/resources/assets/nucleus/messages.properties
+++ b/src/main/resources/assets/nucleus/messages.properties
@@ -1214,12 +1214,9 @@ command.weather.time=&aYou set the weather to &e{0} &ain the world &e{1} &afor &
 command.weather.toolong=&cThe maximum amount of time the weather can be set to last for is &4{0}.
 command.weather.locked=&cThe weather is locked for the world &e{0}&c. It must be unlocked to change the weather.
 
-command.settime.done=&aThe time on the world has been set to &e{0}&a.
-command.settime.done2=&aThe time on the world "&e{0}&a" has been set to &e{1}&a.
-command.addtime.done=&aThe time on the world has been increased by &e{0} ticks &aand is now &e{1}&a.
-command.addtime.done2=&aThe time on the world "&e{0}&a" has been increased by &e{1} ticks &aand is now &e{2}&a.
-command.removetime.done=&aThe time on the world has been decreased by &e{0} ticks &aand is now &e{1}&a.
-command.removetime.done2=&aThe time on the world "&e{0}&a" has been decreased by &e{1} ticks &aand is now &e{2}&a.
+command.settime.done=&aThe time on the world "&e{0}&a" has been set to &e{1}&a.
+command.addtime.done=&aThe time on the world "&e{0}&a" has been increased by &e{1} ticks &aand is now &e{2}&a.
+command.removetime.done=&aThe time on the world "&e{0}&a" has been decreased by &e{1} ticks &aand is now &e{2}&a.
 command.time=&aThe time on world &e{0} &ais currently &e{1}&a.
 
 command.servertime.time=&aCurrent server wall clock time: &e{0}&a.


### PR DESCRIPTION
Hey! So I was looking through the issues page to see if anyone had created an issue requesting something I personally wanted to see (some vanish improvements) but noticed that somebody wanted to see a **/time add** and **/time remove** commands (which are available in Essentials afaik). This PR provides exactly that, with the appropriate lang messages. They also come with the appropriate aliases too (/addtime, /removetime, /timeadd, /timeremove), using the /time set as a prime example. 

The issue requesting this can be seen here https://github.com/NucleusPowered/Nucleus/issues/1413

**/time add [world] <ticks>**
**/time remove [world] <ticks>**
![image](https://user-images.githubusercontent.com/25883284/64036593-7ce6d880-cb4b-11e9-95e6-7acc62b2f312.png)

If there's anything that you feel should be changed before it can be merged, please do let me know!
Thank you.