### PR TITLE
Add unloaded world compatibility to /back

### DIFF
--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/back/listeners/OfflineLocation.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/back/listeners/OfflineLocation.java
@@ -33,17 +33,8 @@ public class OfflineLocation {
         if (this.lastWorld == null || this.lastRotation == null || this.lastPosition == null) {
             return Optional.empty();
         }
-        
-        Optional<WorldProperties> optionalWorldProperties = Sponge.getServer()
-                .getUnloadedWorlds().stream().filter(worldProps -> worldProps.getUniqueId().equals(this.lastWorld))
-                .findFirst();
 
-        optionalWorldProperties.ifPresent(worldProperties -> {
-            Optional<World> worldOptional = Sponge.getServer().getWorld(worldProperties.getUniqueId());
-            if (!worldOptional.isPresent()) Sponge.getServer().loadWorld(worldProperties);
-        });
-
-        return Sponge.getServer().getWorld(this.lastWorld)
+        return Sponge.getServer().loadWorld(this.lastWorld)
                 .map(world -> new Transform<>(world, this.lastPosition, this.lastRotation));
     }
 

--- a/src/main/java/io/github/nucleuspowered/nucleus/modules/back/listeners/OfflineLocation.java
+++ b/src/main/java/io/github/nucleuspowered/nucleus/modules/back/listeners/OfflineLocation.java
@@ -8,6 +8,7 @@ import com.flowpowered.math.vector.Vector3d;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.Transform;
 import org.spongepowered.api.world.World;
+import org.spongepowered.api.world.storage.WorldProperties;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -32,6 +33,15 @@ public class OfflineLocation {
         if (this.lastWorld == null || this.lastRotation == null || this.lastPosition == null) {
             return Optional.empty();
         }
+        
+        Optional<WorldProperties> optionalWorldProperties = Sponge.getServer()
+                .getUnloadedWorlds().stream().filter(worldProps -> worldProps.getUniqueId().equals(this.lastWorld))
+                .findFirst();
+
+        optionalWorldProperties.ifPresent(worldProperties -> {
+            Optional<World> worldOptional = Sponge.getServer().getWorld(worldProperties.getUniqueId());
+            if (!worldOptional.isPresent()) Sponge.getServer().loadWorld(worldProperties);
+        });
 
         return Sponge.getServer().getWorld(this.lastWorld)
                 .map(world -> new Transform<>(world, this.lastPosition, this.lastRotation));


### PR DESCRIPTION
Sponge no longer returns unloaded worlds on Sponge.getServer().getWorld(world::World), causing /back to not teleport back when the previous world was unloaded (commonly present on servers with many worlds present)

To solve this we obtain the list of unloaded worlds from the server, and filter out the requested world. If it is present, we will attempt to load it and continue the default process.

This will not load disabled worlds, so server owners still have the ability to lock down worlds from players properly if needed.