### PR TITLE
Fix Nickname Issues: Nucleus V2 - RC1

### DIFF
--- a/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/nickname/listeners/NicknameListener.java
+++ b/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/nickname/listeners/NicknameListener.java
@@ -31,6 +31,7 @@ public class NicknameListener implements ListenerBase {
     @Listener(order = Order.FIRST)
     public void onPlayerJoin(ClientConnectionEvent.Join event, @Root Player player) {
         Optional<Text> nickname = this.nicknameService.getNickname(player);
+        this.nicknameService.markRead(player.getUniqueId());
         nickname.ifPresent(text -> {
             this.nicknameService.updateCache(player.getUniqueId(), text);
         });

--- a/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/nickname/services/NicknameService.java
+++ b/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/nickname/services/NicknameService.java
@@ -88,8 +88,11 @@ public class NicknameService implements NucleusNicknameService, IReloadableServi
         );
     }
 
-    public void updateCache(UUID player, Text text) {
+    public void markRead(UUID player) {
         this.cached.add(player);
+    }
+
+    public void updateCache(UUID player, Text text) {
         this.cache.put(player, text.toPlain());
         this.textCache.put(player, text);
     }

--- a/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/nickname/services/NicknameService.java
+++ b/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/nickname/services/NicknameService.java
@@ -9,8 +9,6 @@ import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import io.github.nucleuspowered.nucleus.NucleusBootstrap;
-import io.github.nucleuspowered.nucleus.api.NucleusAPI;
 import io.github.nucleuspowered.nucleus.api.module.nickname.NucleusNicknameService;
 import io.github.nucleuspowered.nucleus.api.module.nickname.exception.NicknameException;
 import io.github.nucleuspowered.nucleus.modules.nickname.NicknameKeys;

--- a/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/services/impl/placeholder/PlaceholderService.java
+++ b/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/services/impl/placeholder/PlaceholderService.java
@@ -94,7 +94,7 @@ public class PlaceholderService implements IPlaceholderService, IInitService {
 
         NamePlaceholder displayName = new NamePlaceholder(
                 serviceCollection.playerDisplayNameService(),
-                IPlayerDisplayNameService::addCommandToName,
+                IPlayerDisplayNameService::getDisplayName,
                 "nucleus:displayname",
                 "Nucleus subject (including console) placeholder");
         registerToken("player", displayName);


### PR DESCRIPTION
In relation to this discord message: [https://discordapp.com/channels/271356139365597185/645299231044665357/739620634564362291](url), I found what appeared to be an accidental copy/paste operation that went unnoticed. For user display names, Nucleus was accidentally defaulting to their actual name, unstyled. I fixed this with a simple replacement of a call to getDisplayName rather than addCommandToName. We may want to also fix the name of that, which also seems cloned from the default version of the placeholder parser, but I'll let you make that call before I process that change.

Additionally, there was a secondary issue regarding nicknames. With the way Nucleus was attempting to read them from the storage, it seems there may be a Sponge bug in that a player is already marked online by Sponge even prior to `ClientConnectionEvent.Login`. This was causing Nucleus to always use its nickname cache, without ever attempting to make a call to the user data.

To work around that, I added a fallback cache which Nucleus uses instead to manage its use of the cache. It's simply a list of UUIDs, and is synced up with `updateCache(UUID, Text)` and `removeFromCache(UUID)`. So far, testing has shown this system works as intended, but there may be some changes you desire as I will say, it's not an optimal solution.