### PR TITLE
Add ultra-aggressive pre-gen option

### DIFF
--- a/changelogs/templates/2.1.4.md
+++ b/changelogs/templates/2.1.4.md
@@ -6,6 +6,19 @@ If you need help to decide which version of Nucleus to use, [please visit our gu
 
 For the things YOU need to do as a server owner, [please visit our instructions on how to upgrade](https://v2.nucleuspowered.org/docs/howto/migrate.html).
 
+# New Features
+
+## Added "ultra-aggressive" pre-generation mode
+
+`/world border gen` now has the `-u` flag in order to attempt to use as much time as possible pre-generating a world. 
+Server owners should only use this mode on an empty server. This mode:
+
+* Causes chunk generation to happen every tick.
+* Tries to use at least 95% of each tick time generating.
+* Saves world state every two minutes.
+
+Using this mode may cause crashes and severe server lag, but may be useful for new servers who are not yet open to the public. 
+
 # Bug Fixes
 
 * Fix `/home other` not checking the correct user for exemption permissions.

--- a/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/world/WorldKeys.java
+++ b/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/world/WorldKeys.java
@@ -34,9 +34,9 @@ public class WorldKeys {
             IWorldDataObject.class,
             "tick-freq");
 
-    public static DataKey<Boolean, IWorldDataObject> WORLD_PREGEN_AGGRESSIVE = DataKey.of(
-            false,
-            TypeToken.of(Boolean.class),
+    public static DataKey<Integer, IWorldDataObject> WORLD_PREGEN_AGGRESSIVE_LEVEL = DataKey.of(
+            0,
+            TypeToken.of(Integer.class),
             IWorldDataObject.class,
-            "aggressive");
+            "aggressive-level");
 }

--- a/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/border/GenerateChunksCommand.java
+++ b/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/border/GenerateChunksCommand.java
@@ -74,12 +74,22 @@ public class GenerateChunksCommand implements ICommandExecutor<CommandSource> {
                 .orElseThrow(() -> context.createException("command.world.gen.notloaded", wp.getWorldName()));
         worldHelper.startPregenningForWorld(w,
                 level,
-                context.getOne(GenerateChunksCommand.saveTimeKey, Long.class).orElse(20L) * 1000L,
+                context.getOne(GenerateChunksCommand.saveTimeKey, Long.class).orElseGet(() -> this.getDefaultSaveTime(level)) * 1000L,
                 context.getOne(ticksKey, Integer.class).orElse(null),
                 context.getOne(tickFrequency, Integer.class).orElse(null),
                 context.hasAny("r"));
 
         context.sendMessage("command.world.gen.started", wp.getWorldName());
         return context.successResult();
+    }
+
+    private long getDefaultSaveTime(final int aggressionLevel) {
+        if (aggressionLevel == 2) {
+            return 120L;
+        } else if (aggressionLevel == 1) {
+            return 30L;
+        } else {
+            return 20L;
+        }
     }
 }

--- a/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/border/GenerateChunksCommand.java
+++ b/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/world/commands/border/GenerateChunksCommand.java
@@ -42,8 +42,9 @@ public class GenerateChunksCommand implements ICommandExecutor<CommandSource> {
     public CommandElement[] parameters(INucleusServiceCollection serviceCollection) {
         return new CommandElement[] {
                 GenericArguments.flags()
-                    .flag("a")
-                    .flag("r")
+                    .flag("a", "-aggressive")
+                    .flag("u", "-ultra-aggressive")
+                    .flag("r", "-restart")
                     .valueFlag(new TimespanArgument(Text.of(saveTimeKey), serviceCollection), "-save")
                     .valueFlag(new BoundedIntegerArgument(Text.of(ticksKey), 0, 100, serviceCollection), "t", "-tickpercent")
                     .valueFlag(new BoundedIntegerArgument(Text.of(tickFrequency), 1, 100, serviceCollection), "f", "-frequency")
@@ -60,10 +61,19 @@ public class GenerateChunksCommand implements ICommandExecutor<CommandSource> {
             return context.errorResult("command.world.gen.alreadyrunning", wp.getWorldName());
         }
 
+        final int level;
+        if (context.hasAny("u")) {
+            level = 2;
+        } else if (context.hasAny("a")) {
+            level = 1;
+        } else {
+            level = 0;
+        }
+
         World w = Sponge.getServer().getWorld(wp.getUniqueId())
                 .orElseThrow(() -> context.createException("command.world.gen.notloaded", wp.getWorldName()));
         worldHelper.startPregenningForWorld(w,
-                context.hasAny("a"),
+                level,
                 context.getOne(GenerateChunksCommand.saveTimeKey, Long.class).orElse(20L) * 1000L,
                 context.getOne(ticksKey, Integer.class).orElse(null),
                 context.getOne(tickFrequency, Integer.class).orElse(null),

--- a/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/world/listeners/WorldGenListener.java
+++ b/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/world/listeners/WorldGenListener.java
@@ -65,7 +65,7 @@ public class WorldGenListener implements ListenerBase {
                                     boolean act = worldDataObject.get(WorldKeys.WORLD_PREGEN_START).orElse(false);
                                     if (act && worldHelper.startPregenningForWorld(
                                             world,
-                                            worldDataObject.getOrDefault(WorldKeys.WORLD_PREGEN_AGGRESSIVE),
+                                            worldDataObject.getOrDefault(WorldKeys.WORLD_PREGEN_AGGRESSIVE_LEVEL),
                                             worldDataObject.getOrDefault(WorldKeys.WORLD_PREGEN_SAVE_FREQUENCY),
                                             worldDataObject.getOrDefault(WorldKeys.WORLD_PREGEN_TICK_PERCENT),
                                             worldDataObject.getOrDefault(WorldKeys.WORLD_PREGEN_TICK_FREQUENCY),

--- a/nucleus-core/src/main/resources/assets/nucleus/messages.properties
+++ b/nucleus-core/src/main/resources/assets/nucleus/messages.properties
@@ -2775,12 +2775,14 @@ world.border.gen.desc=Generates chunks up to the world border.
 world.border.gen.extended=When invoked, Nucleus will start generating chunks up to the world border. During this time, \
   the server will be susceptible to reduced performance.\n\n\
 There are a few flags you can use:\n\n\
-* -a - aggressive mode, turns off memory checks\n\
-* -r - restart pregeneration if the server is restarted (use with caution, does not disable if the pregen causes the crash)\n\
-* -t [1-100] - the percentage of a tick to use when generating, defaults to 80% (90% with aggressive mode)\n\
-* -f [1-100] - the number of ticks to wait after a generation to perform the next generation - defaults to Sponge default (3 in aggressive mode)\n\
-* --save [timespan] - frequency to peform a save at, defaults to 20 seconds (30 seconds with aggressive mode)\n\n\
-If you want to maximise generation, run "/world border gen -a -t 100 -f 1", but be prepared for lag!
+* -a - aggressive mode, turns off memory checks, saves less often, uses every three ticks (instead of four) to generate\n\
+* -u - ultra-aggressive mode, turns off memory checks, saves every 2 minutes, uses every tick to generate\n\
+* -r - restart pre-generation if the server is restarted (use with caution, does not disable if the pre-gen causes the crash)\n\
+* -t [1-100] - the percentage of a tick to use when generating, defaults to 80% (90% with aggressive mode, 95% with ultra aggressive mode)\n\
+* -f [1-100] - the number of ticks to wait after a generation to perform the next generation - defaults to Sponge default (3 in aggressive mode, 1 \
+  in ultra aggressive mode)\n\
+* --save [timespan] - frequency to peform a save at, defaults to 20 seconds (30 seconds with aggressive mode, 120 for ultra aggressive)\n\n\
+If you want to maximise generation, run "/world border gen -u -t 100 -f 1", but be prepared for lag!
 
 world.border.cancelgen.desc=Cancels any current world border generation.
 


### PR DESCRIPTION
It's often the case that server owners want to have a faster pre-gen while no-one is on the server. Aggressive mode default aren't always aggressive enough - this adds a `-u` flag to make it more aggressive.

* 95% tick time generation per tick
* Generate during all ticks
* Save every 2 minutes

If it crashes, it's not my fault!