### PR TITLE
Fix check and return instant kit can be redeemed

### DIFF
--- a/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/kit/services/KitService.java
+++ b/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/kit/services/KitService.java
@@ -159,7 +159,8 @@ public class KitService implements NucleusKitService, IReloadableService.Reloada
     @Override
     public CompletableFuture<Optional<Instant>> getCooldownExpiry(Kit kit, User user) {
         return redeemTime(kit.getName(), user).thenApply(x -> {
-            if (x.isPresent()) {
+            if (x.isPresent() && kit.getCooldown().isPresent()) {
+                x = Optional.of(x.get().plus(kit.getCooldown().get()));
                 if (x.get().isAfter(Instant.now())) {
                     return x;
                 }


### PR DESCRIPTION
Was trying to use getCooldownExpiry through the api and it wasn't working, found out that the check on the Instant
count never be true.

Made a simple change to return the actual Instant in which the kit can be redeemed. Not sure if you would have solved it this way but it works.

