### PR TITLE
Multiple fixes to the notes module, small change to message module

### DIFF
--- a/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/message/commands/MessageCommand.java
+++ b/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/message/commands/MessageCommand.java
@@ -65,7 +65,7 @@ public class MessageCommand implements ICommandExecutor<CommandSource>, IReloada
 
     @Override
     public ICommandResult execute(ICommandContext<? extends CommandSource> context) throws CommandException {
-        if (context.is(context.requireOne(TO, CommandSource.class))) {
+        if (context.is(context.requireOne(TO, CommandSource.class)) && !this.canMessageSelf) {
             return context.errorResult("command.message.self");
         }
         boolean b = context.getServiceCollection()

--- a/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/note/commands/NoteCommand.java
+++ b/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/note/commands/NoteCommand.java
@@ -30,7 +30,6 @@ import java.util.UUID;
         aliases = {"note", "addnote"},
         basePermission = NotePermissions.NOTE_NOTIFY,
         commandDescriptionKey = "note",
-        async = true,
         associatedPermissions = {
                 NotePermissions.NOTE_NOTIFY,
                 NotePermissions.NOTE_SHOWONLOGIN

--- a/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/note/data/NoteData.java
+++ b/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/note/data/NoteData.java
@@ -56,14 +56,18 @@ public class NoteData implements Note {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof NoteData))
+        if (!(o instanceof NoteData)) {
             return false;
-        if (o == this)
+        }
+        if (o == this) {
             return true;
-        if (!this.getNote().equals(((NoteData) o).getNote()))
+        }
+        if (!this.getNote().equals(((NoteData) o).getNote())) {
             return false;
-        if (!this.getDate().equals(((NoteData) o).getDate()))
+        }
+        if (!this.getDate().equals(((NoteData) o).getDate())) {
             return false;
+        }
         return this.getNoterInternal().equals(((NoteData) o).getNoter().orElse(Util.CONSOLE_FAKE_UUID));
     }
 

--- a/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/note/data/NoteData.java
+++ b/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/note/data/NoteData.java
@@ -10,6 +10,7 @@ import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
 import java.time.Instant;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -47,4 +48,23 @@ public class NoteData implements Note {
     @Override public Instant getDate() {
         return Instant.ofEpochMilli(this.date);
     }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getNoter(), getNote(), getDate());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof NoteData))
+            return false;
+        if (o == this)
+            return true;
+        if (!this.getNote().equals(((NoteData) o).getNote()))
+            return false;
+        if (!this.getDate().equals(((NoteData) o).getDate()))
+            return false;
+        return this.getNoterInternal().equals(((NoteData) o).getNoter().orElse(Util.CONSOLE_FAKE_UUID));
+    }
+
 }

--- a/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/note/services/NoteHandler.java
+++ b/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/note/services/NoteHandler.java
@@ -84,8 +84,7 @@ public class NoteHandler implements NucleusNoteService, ServiceBase {
             boolean res;
             try (IKeyedDataObject.Value<List<NoteData>> v = udo.get().getAndSet(NoteKeys.NOTE_DATA)) {
                 List<NoteData> data = v.getValue().orElseGet(Lists::newArrayList);
-                res = data.removeIf(x -> x.getNoterInternal().equals(note.getNoter().orElse(Util.CONSOLE_FAKE_UUID))
-                        && x.getNote().equals(note.getNote()));
+                res = data.removeIf(x -> x.equals(note));
                 v.setValue(data);
             }
 


### PR DESCRIPTION
This should fix:
* Can message self option in config
  boolean wasn't being checked

* No message when adding a note (Disabled async). 
  NoteHandler creates an event in addNote, sponge complains about CauseStackManager being called off-thread.

* Deleting notes through /notes. 
  Wrong index or id was being used, indexOf wasn't matching the supplied note properly. Ended up overriding equals method to 
  make sure it works.

* Multiple notes being deleted at once if Noter and Note where the same. 
   Used the new equals method so it checks if Date matches as well


