### PR TITLE
Update FlyCommand.java - Fix Fly MSG issue 1580

### DIFF
--- a/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/commands/FlyCommand.java
+++ b/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/commands/FlyCommand.java
@@ -58,7 +58,7 @@ public class FlyCommand implements ICommandExecutor<CommandSource> { // extends 
             context.sendMessage(fly ? "command.fly.player.on" : "command.fly.player.off", player.getName());
         }
 
-        context.sendMessage(fly ? "command.fly.on" : "command.fly.off");
+        player.sendMessage(context.getMessage(fly ? "command.fly.on" : "command.fly.off"));
         return context.successResult();
     }
 

--- a/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/commands/FlyCommand.java
+++ b/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/commands/FlyCommand.java
@@ -58,7 +58,7 @@ public class FlyCommand implements ICommandExecutor<CommandSource> { // extends 
             context.sendMessage(fly ? "command.fly.player.on" : "command.fly.player.off", player.getName());
         }
 
-        context.sendMessageTo(player, fly ? "command.fly.on" : "command.fly.off"));
+        context.sendMessageTo(player, (fly ? "command.fly.on" : "command.fly.off"));
         return context.successResult();
     }
 

--- a/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/commands/FlyCommand.java
+++ b/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/modules/fly/commands/FlyCommand.java
@@ -58,7 +58,7 @@ public class FlyCommand implements ICommandExecutor<CommandSource> { // extends 
             context.sendMessage(fly ? "command.fly.player.on" : "command.fly.player.off", player.getName());
         }
 
-        player.sendMessage(context.getMessage(fly ? "command.fly.on" : "command.fly.off"));
+        context.sendMessageTo(player, fly ? "command.fly.on" : "command.fly.off"));
         return context.successResult();
     }
 


### PR DESCRIPTION
When executing fly <player> from the console it prints "You are now able to fly" to the console

Replaced context.sendMessage with player.sendMessage in FlyCommand.java

Related issues: https://github.com/NucleusPowered/Nucleus/issues/1580

Please verify this PR since it is my first one.

<!--
    When submitting a PR, please include the following:

    * Use case
    * A list of changes
    * Any related changes/issues

    If your PR is not finished but you're seeking a review on it, mark it as a draft when creating it.
-->
