### PR TITLE
Fix compile issues for ban-related commands

### DIFF
--- a/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/core/core/commands/nucleus/ResetUserCommand.java
+++ b/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/core/core/commands/nucleus/ResetUserCommand.java
@@ -191,7 +191,7 @@ public class ResetUserCommand implements ICommandExecutor {
             // Ban temporarily.
             final BanService bss = Sponge.server().serviceProvider().banService();
             final CompletableFuture<Optional<? extends Ban>> future =
-                    bss.addBan(Ban.builder().type(BanTypes.PROFILE)
+                    bss.add(Ban.builder().type(BanTypes.PROFILE)
                             .expirationDate(Instant.now().plus(30, ChronoUnit.SECONDS)).profile(user.profile())
                             .build());
 
@@ -221,7 +221,7 @@ public class ResetUserCommand implements ICommandExecutor {
                 } catch (final Exception e) {
                     source.sendMessage(messageProvider.getMessageFor(source, "command.nucleus.reset.failed", user.name()));
                 } finally {
-                    ban.ifPresent(bss::removeBan);
+                    ban.ifPresent(bss::remove);
                 }
             } , 1, TimeUnit.SECONDS);
         }

--- a/nucleus-modules/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/BanCommand.java
+++ b/nucleus-modules/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/BanCommand.java
@@ -121,7 +121,7 @@ public class BanCommand implements ICommandExecutor, IReloadableService.Reloadab
         }
 
         // TODO: Fix joins to be async
-        if (service.banFor(user.profile()).join().isPresent()) {
+        if (service.find(user.profile()).join().isPresent()) {
             return context.errorResult("command.ban.alreadyset",
                     context.getServiceCollection().playerDisplayNameService().getName(user));
         }
@@ -140,7 +140,7 @@ public class BanCommand implements ICommandExecutor, IReloadableService.Reloadab
         final Ban bp = Ban.builder().type(BanTypes.PROFILE).profile(user.profile())
                 .source(context.getDisplayName())
                 .reason(LegacyComponentSerializer.legacyAmpersand().deserialize(r)).build();
-        service.addBan(bp);
+        service.add(bp);
 
         // Get the permission, "quickstart.ban.notify"
         final Audience audience = Audience.audience(

--- a/nucleus-modules/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/CheckBanCommand.java
+++ b/nucleus-modules/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/CheckBanCommand.java
@@ -39,7 +39,7 @@ public class CheckBanCommand implements ICommandExecutor {
         final BanService service = Sponge.server().serviceProvider().banService();
 
         // TODO: Async
-        final Optional<Ban.Profile> obp = service.banFor(profile).join();
+        final Optional<Ban.Profile> obp = service.find(profile).join();
         if (!obp.isPresent()) {
             return context.errorResult("command.checkban.notset", Util.getNameOrUnkown(context, profile));
         }

--- a/nucleus-modules/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/TempBanCommand.java
+++ b/nucleus-modules/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/TempBanCommand.java
@@ -82,7 +82,7 @@ public class TempBanCommand implements ICommandExecutor, IReloadableService.Relo
         final BanService service = Sponge.server().serviceProvider().banService();
 
         // TODO: Fix joins to be async
-        if (service.banFor(u.profile()).join().isPresent()) {
+        if (service.find(u.profile()).join().isPresent()) {
             return context.errorResult("command.ban.alreadyset", u.name());
         }
 
@@ -102,7 +102,7 @@ public class TempBanCommand implements ICommandExecutor, IReloadableService.Relo
         final Component src = context.getDisplayName();
         final Component r = LegacyComponentSerializer.legacyAmpersand().deserialize(reason);
         final Ban bp = Ban.builder().type(BanTypes.PROFILE).profile(u.profile()).source(src).expirationDate(date).reason(r).build();
-        service.addBan(bp);
+        service.add(bp);
 
         final Audience send = Audience.audience(
                 context.audience(),

--- a/nucleus-modules/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/UnbanCommand.java
+++ b/nucleus-modules/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/commands/UnbanCommand.java
@@ -51,7 +51,7 @@ public class UnbanCommand implements ICommandExecutor, IReloadableService.Reload
         final BanService service = Sponge.server().serviceProvider().banService();
 
         // TODO: Async
-        final Optional<Ban.Profile> obp = service.banFor(profile).join();
+        final Optional<Ban.Profile> obp = service.find(profile).join();
         if (!obp.isPresent()) {
             return context.errorResult(
                     "command.checkban.notset", Util.getNameOrUnkown(context, profile));
@@ -67,7 +67,7 @@ public class UnbanCommand implements ICommandExecutor, IReloadableService.Reload
             return context.errorResult("command.modifiers.level.insufficient", user.name());
         }
 
-        service.removeBan(obp.get());
+        service.remove(obp.get());
 
         final Audience send = Audience.audience(
                 context.audience(),

--- a/nucleus-modules/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/infoprovider/BanInfoProvider.java
+++ b/nucleus-modules/src/main/java/io/github/nucleuspowered/nucleus/modules/ban/infoprovider/BanInfoProvider.java
@@ -38,7 +38,7 @@ public class BanInfoProvider implements NucleusProvider {
             final IMessageProviderService messageProviderService = serviceCollection.messageProvider();
 
             // TODO: Async
-            final Optional<Ban.Profile> bs = obs.banFor(user.profile()).join();
+            final Optional<Ban.Profile> bs = obs.find(user.profile()).join();
             final Audience audience = source.audience();
             if (bs.isPresent()) {
 

--- a/nucleus-modules/src/main/java/io/github/nucleuspowered/nucleus/modules/connection/listeners/ConnectionListener.java
+++ b/nucleus-modules/src/main/java/io/github/nucleuspowered/nucleus/modules/connection/listeners/ConnectionListener.java
@@ -51,12 +51,12 @@ public class ConnectionListener implements IReloadableService.Reloadable, Listen
         // Have to join - we need to handle this event
         // TODO: Maybe look into getting Sponge to report a ban in this event if there is one.
         final BanService banService = Sponge.server().serviceProvider().banService();
-        final Optional<Ban.Profile> profileBan = banService.banFor(user.profile()).join();
+        final Optional<Ban.Profile> profileBan = banService.find(user.profile()).join();
         if (profileBan.isPresent()) {
             return;
         }
 
-        final Optional<Ban.IP> ipBan = banService.banFor(event.connection().address().getAddress()).join();
+        final Optional<Ban.IP> ipBan = banService.find(event.connection().address().getAddress()).join();
         if (ipBan.isPresent()) {
             return;
         }


### PR DESCRIPTION
These changes fix the compile issues in all ban-related commands. These were only caused by minor out-of-date API usages for Sponge's `BanService`.  
I haven't run into further compile issues, and have tested this build with SpongeVanilla 8.0.0 RC705 succesfully
