### PR TITLE
Fix startup issue in singleplayer mode.

### DIFF
--- a/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/services/impl/messageprovider/MessageProviderService.java
+++ b/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/services/impl/messageprovider/MessageProviderService.java
@@ -67,7 +67,7 @@ public class MessageProviderService implements IMessageProviderService, IReloada
     private final INucleusServiceCollection serviceCollection;
     private final IUserPreferenceService userPreferenceService;
 
-    private Locale defaultLocale = Sponge.getServer().getConsole().getLocale();
+    private Locale defaultLocale = Locale.US;
     private boolean useMessagesFile;
     private boolean useClientLocalesWhenPossible;
 
@@ -91,6 +91,9 @@ public class MessageProviderService implements IMessageProviderService, IReloada
             INucleusServiceCollection serviceCollection, @ConfigDirectory Path configPath) {
         this.serviceCollection = serviceCollection;
         serviceCollection.reloadableService().registerReloadable(this);
+        if (Sponge.isServerAvailable()) {
+            defaultLocale = Sponge.getServer().getConsole().getLocale();
+        }
         this.defaultMessagesResource = new PropertiesMessageRepository(
                 serviceCollection.textStyleService(),
                 serviceCollection.playerDisplayNameService(),


### PR DESCRIPTION
Signed-off-by: Dockter <dockter@almuramc.com>

Fixed issue with starting nucleus in single player mode.  This change also work when running in the IDE along side another mod.  Added a fallback check if the server is available to do the lookup of the servers default locale if Sponge.isServerAvailable().