### PR TITLE
fix(admin): gamemode default namespace to sponge

### DIFF
--- a/nucleus-modules/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/gamemode/GamemodeCommand.java
+++ b/nucleus-modules/src/main/java/io/github/nucleuspowered/nucleus/modules/admin/commands/gamemode/GamemodeCommand.java
@@ -44,7 +44,7 @@ public class GamemodeCommand extends GamemodeBase {
     private final Parameter.Value<GameMode> gameModeParameter =
             Parameter.builder(GameMode.class)
                     .key("Game Mode")
-                    .addParser(VariableValueParameters.registryEntryBuilder(RegistryTypes.GAME_MODE).defaultNamespace("minecraft").build())
+                    .addParser(VariableValueParameters.registryEntryBuilder(RegistryTypes.GAME_MODE).defaultNamespace("sponge").build())
                     .build();
 
     final Parameter.Value<ServerPlayer> playerValue;


### PR DESCRIPTION
Before: `/gamemode sponge:creative`
After: `/gamemode creative`

Context:
https://discord.com/channels/142425412096491520/142425521391665153/934074869950341130
> @Zidane: Unless Mojang already provides a registry construct in the base game, all ones that Sponge make into a registry are under us. It is Mojang's wish for only what they make registry to be under their namespace