### PR TITLE
Fix duplicate command registering when `reload`

### DIFF
--- a/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/core/services/impl/commandmetadata/CommandMetadataService.java
+++ b/nucleus-core/src/main/java/io/github/nucleuspowered/nucleus/core/services/impl/commandmetadata/CommandMetadataService.java
@@ -96,6 +96,7 @@ public class CommandMetadataService implements ICommandMetadataService, IReloada
 
     @Override
     public void reset() {
+        this.controlToAliases.clear();
         this.registeredAliases.clear();
         this.registeredCommands.clear();
         this.registrationComplete = false;


### PR DESCRIPTION
`The command alias xxx:xxx has already been registered for this plugin`